### PR TITLE
feature(simpleproxy): adding excludePatterns for proxy requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "url": "https://github.com/petermuessig/ui5-ecosystem-showcase.git"
   },
   "scripts": {
-    "build": "cd packages/ui5-app && yarn build",
-    "build:pwa": "cd packages/ui5-app && yarn build:pwa",
-    "clean": "cd packages/ui5-app && yarn clean",
-    "dev": "cd packages/ui5-app && yarn dev",
-    "start": "cd packages/ui5-app && yarn start",
+    "build": "yarn workspace ui5-app build",
+    "build:pwa": "yarn workspace ui5-app build:pwa",
+    "clean": "yarn workspace ui5-app clean",
+    "dev": "yarn workspace ui5-app dev",
+    "start": "yarn workspace ui5-app start",
     "start:ci": "cd packages/ui5-app && npm run start:ci &",
     "//*test:ci": "1. start ui5 serve and bg it - 2. run the e2e tests in parallel - 3. kill the bg'ed ui5 serve",
     "pretest:ci": "npm run start:ci",
@@ -24,7 +24,7 @@
     "test:opa5-ci": "cd packages/ui5-app && karma start karma-ci.conf.js",
     "test:uiveri5": "cd packages/ui5-app/webapp/test/e2e && uiveri5 --debug conf.js",
     "test:wdi5": "cd packages/ui5-app && wdio",
-    "watch": "cd packages/ui5-app && yarn watch"
+    "watch": "yarn workspace ui5-app watch"
   },
   "devDependencies": {
     "lerna": "^3.22.1"

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -34,7 +34,7 @@ builder:
   - name: ui5-task-i18ncheck
     afterTask: replaceVersion
   - name: ui5-task-zipper
-    afterTask: uglify 
+    afterTask: uglify
     configuration:
       archiveName: webapp
       includeDependencies: true
@@ -68,6 +68,8 @@ server:
         Any-Header: AnyHeader
       query:
         type: sdk #other types: runtime, runtimeMobile
+      excludePatterns:
+      - "/local/**"
     # PoC: reuse the same middleware at a different "mountPath"
   - name: ui5-middleware-simpleproxy
     mountPath: /proxy2

--- a/packages/ui5-app/webapp/proxy/local/hello.txt
+++ b/packages/ui5-app/webapp/proxy/local/hello.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -28,6 +28,8 @@ npm install ui5-middleware-simpleproxy --save-dev
   Http headers set for the proxied request. Will overwrite the http headers from the request. 
 - query: `map`
   Query parameters set for the proxied request. Will overwrite the parameters from the request. 
+- excludePatterns: `string[]`
+  Array of exclude patterns using glob syntax
 
 In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
 
@@ -68,6 +70,8 @@ server:
         Any-Header: AnyHeader
       query:
         sap-client: 206
+      excludePatterns:
+      - "/local/**"
 ```
 
 ## How it works

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@ui5/logger": "^2.0.0",
     "dotenv": "^8.2.0",
-    "express-http-proxy": "^1.6.0"
+    "express-http-proxy": "^1.6.0",
+    "minimatch": "^3.0.4"
   },
   "ui5": {
     "dependencies": []


### PR DESCRIPTION
With this change I enable the simpleproxy to use exclude patterns in glob syntax to define which paths should not be proxied. This is quite helpful when mixing proxy and local resources.