### PR TITLE
fix(flatten-library): Ignore resources tagged as 'omit from build result'

### DIFF
--- a/packages/ui5-task-flatten-library/lib/flatten-library.js
+++ b/packages/ui5-task-flatten-library/lib/flatten-library.js
@@ -30,6 +30,11 @@ module.exports = async function ({ workspace, taskUtil, options }) {
 
   await Promise.all(allWorkspaceResources.map(async (resource) => {
 
+    if (taskUtil.getTag(resource, taskUtil.STANDARD_TAGS.OmitFromBuildResult)) {
+      // Resource should not be part of the build result
+      // Therefore no need to flatten it
+      return;
+    }
     // Tag all resources to be omitted from the build result (based on current resource path)
     taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.OmitFromBuildResult);
 


### PR DESCRIPTION
The current task implementation basically re-includes such resources in
the build result.