### PR TITLE
[FIX] Auth Routes Config

### DIFF
--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -34,7 +34,7 @@ module.exports = function ({ resources, options }) {
 
     xsappConfig.routes.forEach(route => {
         /* Authentication type should come from route if authenticationMethod is set to "route", otherwise set to "none" */
-        route.authenticationType = (xsappConfig.authenticationMethod == "route") ? route.authenticationType : "none";
+        route.authenticationType = (xsappConfig.authenticationMethod.toLowerCase() === "route") ? route.authenticationType : "none";
 
         // ignore /-redirects (e.g. "^/(.*)"
         // a source declaration such as "^/backend/(.*)$" is needed

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -33,8 +33,9 @@ module.exports = function ({ resources, options }) {
         .filter((route) => !route.localDir && (options.configuration.allowServices || !route.service)); //ignore routes that point to web apps as they are already hosted by the ui5 tooling
 
     xsappConfig.routes.forEach(route => {
-        /* Authentication type should come from route or be set to none as default */
-        route.authenticationType = route.authenticationType || "none";
+        /* Authentication type should come from route if authenticationMethod is set to "route", otherwise set to "none" */
+        route.authenticationType = (xsappConfig.authenticationMethod == "route") ? route.authenticationType : "none";
+
         // ignore /-redirects (e.g. "^/(.*)"
         // a source declaration such as "^/backend/(.*)$" is needed
         if (route.source.match(/.*\/.*\/.*/)) {

--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-cfdestination",
-  "version": "0.4.1",
+  "version": "0.4.0",
   "description": "UI5 middleware for CF destinations",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-cfdestination",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "UI5 middleware for CF destinations",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",
@@ -9,7 +9,7 @@
     "url": "https://github.com/petermuessig/ui5-ecosystem-showcase.git"
   },
   "dependencies": {
-    "@sap/approuter": "^9.0.1",
+    "@sap/approuter": "^9.3.0",
     "@ui5/logger": "^2.0.0",
     "request": "^2.88.2"
   },


### PR DESCRIPTION
Fixing reported issue #503 and update app router to latest version (`9.3.0`). Based on the global `authenticationType` setting, either the route's `authenticationMethod` is being used or set to `none`.