### PR TITLE
fix(livereload): support HTTP/2 --h2 option

### DIFF
--- a/packages/ui5-middleware-livereload/README.md
+++ b/packages/ui5-middleware-livereload/README.md
@@ -124,6 +124,10 @@ The middleware launches a `livereload`-server on the specified `port`, listening
 
 When changes are detected, a reload is triggered to **all connected clients** - so all browsers having `$yourapp` will reload the application. The reload is `#`-aware, meaning the current displayed route in your single-page UI5 app is kept steady.
 
+## HTTP/2 support
+
+The middleware supports HTTP/2 automatically, when the UI5 server is started with the --h2 option. It uses the same SSL key and certificate, either set using the --key and --cert options, or using the default ~/.ui5/server/server.key and ~/.ui5/server/server.crt.
+
 ## Misc/FAQ
 
 yep, cross-browser, cross-platform.

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -67,13 +67,31 @@ module.exports = async ({ resources, options }) => {
     if (options.configuration && options.configuration.debug) {
         debug = options.configuration.debug;
     }
+        
+    let serverOptions = {
+        debug: debug,
+        extraExts: extraExts ? extraExts.split(",") : undefined,
+        port: port,
+        exclusions: exclusions
+    };
+    
+    const cli = require("yargs");
+    if (cli.argv.h2) {
+        const path = require("path");
+        const os = require("os");
+        const fs = require("fs");
+        
+        sslKeyPath = cli.argv.key ? cli.argv.key : path.join(os.homedir(), ".ui5", "server", "server.key");
+        sslCertPath = cli.argv.cert ? cli.argv.cert : path.join(os.homedir(), ".ui5", "server", "server.crt");
+        
+        serverOptions.https = {
+            key: fs.readFileSync(sslKeyPath),
+            cert: fs.readFileSync(sslCertPath)
+        };
+    }
+    
     const livereloadServer = livereload.createServer(
-        {
-            debug: debug,
-            extraExts: extraExts ? extraExts.split(",") : undefined,
-            port: port,
-            exclusions: exclusions
-        },
+        serverOptions,
         () => {
             log.info("Livereload server started!");
         }

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -77,13 +77,14 @@ module.exports = async ({ resources, options }) => {
     
     const cli = require("yargs");
     if (cli.argv.h2) {
-        const path = require("path");
         const os = require("os");
         const fs = require("fs");
         
         sslKeyPath = cli.argv.key ? cli.argv.key : path.join(os.homedir(), ".ui5", "server", "server.key");
         sslCertPath = cli.argv.cert ? cli.argv.cert : path.join(os.homedir(), ".ui5", "server", "server.crt");
-        
+		debug ? log.info(`Livereload using SSL key ${sslKeyPath}`) : null;
+		debug ? log.info(`Livereload using SSL certificate ${sslCertPath}`) : null;
+		
         serverOptions.https = {
             key: fs.readFileSync(sslKeyPath),
             cert: fs.readFileSync(sslCertPath)

--- a/packages/ui5-middleware-livereload/package.json
+++ b/packages/ui5-middleware-livereload/package.json
@@ -12,7 +12,8 @@
     "@ui5/logger": "^2.0.0",
     "connect-livereload": "^0.6.1",
     "livereload": "^0.9.1",
-    "portfinder": "^1.0.26"
+    "portfinder": "^1.0.26",
+    "yargs": "^16.2.0"
   },
   "ui5": {
     "dependencies": []


### PR DESCRIPTION
Fix for #510 