### PR TITLE
missing encoding of uri parameters

### DIFF
--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -178,7 +178,7 @@ module.exports = function ({ resources, options }) {
             reqPath = `${(path ? path : "")}${req.path}?${key}=${value}`;
           }
         }
-        return reqPath;
+        return encodeURI(reqPath);
       }
       return (path ? path : "") + req.url;
     },


### PR DESCRIPTION
When adding uri parameters to the proxy request the "req.query" parameter object contains the parameters unescaped and the finaly build uri of them will also be unescaped