### PR TITLE
fix: encoding of full url

### DIFF
--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -99,24 +99,6 @@ function getQueryParameters(environmentValue, configuration) {
 }
 
 /**
- * Checks if the URI already contains encoded URI parts
- * @param {string} Uri the Uri to check
- * @returns {boolean}
- */
-function isUriEncoded(Uri) {
-    return Uri === decodeURI(Uri);
-}
-
-/**
- * Checks if the Uri already contains encoded Uri Component parts
- * @param {string} Uri the Uri to check
- * @returns {boolean}
- */
-function isUriComponentEncoded(Uri) {
-    return Uri === decodeURIComponent(Uri);
-}
-
-/**
  * Custom UI5 Server middleware example
  *
  * @param {Object} parameters Parameters

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -99,6 +99,24 @@ function getQueryParameters(environmentValue, configuration) {
 }
 
 /**
+ * Checks if the URI already contains encoded URI parts
+ * @param {string} Uri the Uri to check
+ * @returns {boolean}
+ */
+function isUriEncoded(Uri) {
+    return Uri === decodeURI(Uri);
+}
+
+/**
+ * Checks if the Uri already contains encoded Uri Component parts
+ * @param {string} Uri the Uri to check
+ * @returns {boolean}
+ */
+function isUriComponentEncoded(Uri) {
+    return Uri === decodeURIComponent(Uri);
+}
+
+/**
  * Custom UI5 Server middleware example
  *
  * @param {Object} parameters Parameters
@@ -172,13 +190,13 @@ module.exports = function ({ resources, options }) {
         Object.assign(queryParameters, req.query, providedQueryParameters);
         for (const [key, value] of Object.entries(queryParameters)) {
           if(reqPath) {
-            reqPath = reqPath.concat(`&${key}=${value}`);
+            reqPath = reqPath.concat(`&${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
           } else {
             // first query parameter
-            reqPath = `${(path ? path : "")}${req.path}?${key}=${value}`;
+            reqPath = `${(path ? path : "")}${req.path}?${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
           }
         }
-        return encodeURI(reqPath);
+        return reqPath;
       }
       return (path ? path : "") + req.url;
     },
@@ -225,3 +243,4 @@ module.exports = function ({ resources, options }) {
     },
   });
 };
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,11 +2002,6 @@
   resolved "https://registry.yarnpkg.com/@types/easy-table/-/easy-table-0.0.32.tgz#961034bf7bba3d5a4344585b960d7a0d11a249b5"
   integrity sha512-zKh0f/ixYFnr3Ldf5ZJTi1ZpnRqAynTTtVyGvWDf/TT12asE8ac98t3/WGWfFdRPp/qsccxg82C/Kl3NPNhqEw==
 
-"@types/easy-table@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/easy-table/-/easy-table-0.0.32.tgz#961034bf7bba3d5a4344585b960d7a0d11a249b5"
-  integrity sha512-zKh0f/ixYFnr3Ldf5ZJTi1ZpnRqAynTTtVyGvWDf/TT12asE8ac98t3/WGWfFdRPp/qsccxg82C/Kl3NPNhqEw==
-
 "@types/ejs@^3.0.5":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.0.6.tgz#aca442289df623bfa8e47c23961f0357847b83fe"
@@ -5015,6 +5010,11 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz#aec24b091c82acbfabbdcce08076a703941d17ca"
   integrity sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==
 
+emittery@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
+  integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -7355,7 +7355,7 @@ js-yaml@4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.1, js-yaml@^3.14.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -8477,15 +8477,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~0.0.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"


### PR DESCRIPTION
req.path and req.url are already fully encoded so we only need to encode the url parameters to prevent double encoding

closes : https://github.com/ui5-community/ui5-ecosystem-showcase/issues/529