### PR TITLE
sap-client shall be configured with quotes

### DIFF
--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -69,7 +69,7 @@ server:
       httpHeaders:
         Any-Header: AnyHeader
       query:
-        sap-client: 206
+        sap-client: '206'
       excludePatterns:
       - "/local/**"
 ```


### PR DESCRIPTION
If the sap-client number starts with zero (e.g. 001) and it got configured here without quotes, then the proxy will try to connect to sap-client 1 instead of 001.
Furthermore, the proxy log will not point the developer to this wrong sap-client 1. It is quite hard to figure out the wrong configuration.
Hence, we shall give a hint in this documentation, that the client shall be entered always with quotes.