### PR TITLE
Fixed error in ui5-tooling-modules

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -63,7 +63,7 @@ module.exports = {
 
         } catch (err) {
             if (bundling) {
-                console.error(`Couldn't bundle ${match[1]}: ${err}`);
+                console.error(`Couldn't bundle ${moduleName}: ${err}`);
             }
         }
 


### PR DESCRIPTION
Fixed error in ui5-tooling-modules\lib\util.js which made the build task fail completly when using ui5-tooling-modules