### PR TITLE
feat(SimpleProxy):  added a feature to skip the server cache 

### DIFF
--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -30,6 +30,8 @@ npm install ui5-middleware-simpleproxy --save-dev
   Query parameters set for the proxied request. Will overwrite the parameters from the request. 
 - excludePatterns: `string[]`
   Array of exclude patterns using glob syntax
+- skipCache: `boolean`
+  Remove the cache guid when serving from the FLP launchpad if it matches an excludePattern
 
 In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
 

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -145,10 +145,17 @@ module.exports = function ({ resources, options }) {
     https: protocol === "https",
     limit: limit,
     filter: excludePatterns && Array.isArray(excludePatterns) && function(req, res) {
-      return excludePatterns.some(glob => {
+      const pattern = !excludePatterns.some(glob => {
         isDebug && log.info(`Proxy request ${req.url} is matched to glob "${glob}": ${minimatch(req.url, glob)} ${providedBaseUri}`);
-        return !minimatch(req.url, glob);
+
+        return minimatch(req.url, glob);
       });
+      if (!pattern && req.url.includes("~") && (options.configuration && options.configuration.skipCache)) {
+        const newUrl = req.url.replaceAll(/\/~.*~.\//g, "/");
+        isDebug && log.info(`Removing cache from ${req.url}, resolving to ${newUrl}`);
+        req.url = newUrl;
+      }
+      return pattern
     },
     preserveHostHdr: false,
     proxyReqOptDecorator: function (proxyReqOpts) {


### PR DESCRIPTION
The skipcache flag is introduced to remove the ~<GUID>~ cache when serving the embedded FLP
launchpad and it matches an exclude pattern. Also fixed a bug on the excludepattern when using an
array with more than one entry as it was always returning true.