### PR TITLE
feat(ui5-tooling-modules): ignore UI5 modules for transpiling

### DIFF
--- a/packages/ui5-app-module/Chart.js
+++ b/packages/ui5-app-module/Chart.js
@@ -1,0 +1,63 @@
+sap.ui.define(["sap/ui/core/Control", "chart.js/auto"], function(Control, Chart) {
+
+    return Control.extend("ui5-app-module.Chart", {
+        metadata: {
+            properties: {
+                "title": "string",
+                "color": "sap.ui.core.CSSColor"
+            },
+            aggregations: {
+                "records": {
+                    type: "ui5-app-module.ChartRecord"
+                }
+            },
+            defaultAggregation: "records"
+        },
+        renderer: {
+            apiVersion: 2,
+            render: function(rm, chart) {
+                rm.openStart("div", chart);
+                rm.style("color", chart.getColor());
+                rm.style("padding", "2em");
+                rm.openEnd();
+
+                rm.openStart("canvas", chart.getId() + "-canvas");
+                rm.openEnd();
+                rm.close("canvas");
+
+                rm.close("div");
+            }
+        },
+        _getChartData: function() {
+            const aRecords = this.getRecords();
+            return {
+                labels: aRecords.map(record => {
+                    return record.getLabel();
+                }),
+                datasets: [{
+                    label: this.getTitle(),
+                    backgroundColor: this.getColor(),
+                    borderColor: this.getColor(),
+                    data: aRecords.map(record => {
+                        return record.getValue();
+                    })
+                }]
+            };
+        },
+        onAfterRendering: function() {
+            if (!this._chart) {
+                this._chart = new Chart(this.getDomRef("canvas"), {
+                    type: 'line',
+                    data: this._getChartData(),
+                    options: {
+                        responsive: true
+                    }
+                });
+            } else {
+                this._chart.data = this._getChartData();
+                this._chart.update();
+            }
+        }
+    });
+
+});

--- a/packages/ui5-app-module/ChartRecord.js
+++ b/packages/ui5-app-module/ChartRecord.js
@@ -1,0 +1,12 @@
+sap.ui.define(["sap/ui/core/Element"], function(Element) {
+
+    return Element.extend("ui5-app-module.ChartRecord", {
+        metadata: {
+            properties: {
+                label: "string",
+                value: "float"
+            }
+        }
+    });
+
+});

--- a/packages/ui5-app-module/package.json
+++ b/packages/ui5-app-module/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ui5-app-module",
+  "version": "0.0.0",
+  "description": "UI5 module",
+  "private": true,
+  "author": "Peter Muessig",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",
+    "directory": "packages/ui5-app-module"
+  },
+  "dependencies": {
+    "chart.js": "^3.7.1"
+  }
+}

--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -35,6 +35,9 @@
       "quiet": false
     }
   },
+  "dependencies": {
+    "ui5-app-module": "^0.0.0"
+  },
   "devDependencies": {
     "@openui5/ts-types": "^1.99.0",
     "@ui5/cli": "^2.14.6",
@@ -70,6 +73,7 @@
     "ui5-task-stringreplacer": "^0.6.1",
     "ui5-task-transpile": "^0.3.6",
     "ui5-task-zipper": "^0.4.9",
+    "ui5-tooling-modules": "^0.1.3",
     "wait-on": "^6.0.1",
     "wdio-chromedriver-service": "^7.2.8",
     "wdio-ui5-service": "^0.8.2"
@@ -92,7 +96,8 @@
       "ui5-task-pwa-enabler",
       "ui5-task-stringreplacer",
       "ui5-task-transpile",
-      "ui5-task-zipper"
+      "ui5-task-zipper",
+      "ui5-tooling-modules"
     ]
   }
 }

--- a/packages/ui5-app/ui5-min.yaml
+++ b/packages/ui5-app/ui5-min.yaml
@@ -54,3 +54,5 @@ server:
         url: "https://services.odata.org/V2/Northwind/Northwind.svc/"
       - name: "todos"
         url: "https://jsonplaceholder.typicode.com/todos/"
+  - name: ui5-tooling-modules-middleware
+    afterMiddleware: compression

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -19,6 +19,7 @@ builder:
       removeConsoleStatements: true
       transpileAsync: true
       excludePatterns:
+        - "resources/"
         - "lib/"
         - "test/"
   - name: ui5-task-stringreplacer
@@ -47,6 +48,8 @@ builder:
       - "another/dir/in/webapp"
       - "yet/another/dir"
   - name: ui5-task-i18ncheck
+    afterTask: replaceVersion
+  - name: ui5-tooling-modules-task
     afterTask: replaceVersion
   - name: ui5-task-zipper
     afterTask: uglify
@@ -152,6 +155,10 @@ server:
     configuration:
       debug: true
       jarRootPath: "META-INF/"
+  - name: ui5-tooling-modules-middleware
+    afterMiddleware: compression
+    configuration:
+      skipCache: true
   - name: ui5-middleware-livecompileless
     beforeMiddleware: serveResources
     configuration:

--- a/packages/ui5-app/webapp/controller/Main.controller.js
+++ b/packages/ui5-app/webapp/controller/Main.controller.js
@@ -1,7 +1,9 @@
 sap.ui.define([
     "test/Sample/controller/BaseController",
-    "sap/m/MessageToast"
-], (Controller, MessageToast) => {
+    "sap/m/MessageToast",
+    "ui5-app-module/Chart",
+    "ui5-app-module/ChartRecord"
+], (Controller, MessageToast, Chart) => {
     "use strict";
 
     return Controller.extend("test.Sample.controller.Main", {

--- a/packages/ui5-app/webapp/view/Main.view.xml
+++ b/packages/ui5-app/webapp/view/Main.view.xml
@@ -1,6 +1,7 @@
 <mvc:View controllerName="test.Sample.controller.Main"
 	xmlns:core="sap.ui.core"
 	xmlns:mvc="sap.ui.core.mvc"
+	xmlns:am="ui5-app-module"
 	displayBlock="true"
 	xmlns="sap.m">
 
@@ -53,7 +54,14 @@
 					placeholder="Enter Date ..." />
 				<Button text="Don't press me!"
 					press="onBoo" />
-                <Text text="Styled with less" class="styledWithLess"/>
+				<Text text="Styled with less" class="styledWithLess"/>
+				<am:Chart title="Some Chart" color="green">
+					<am:ChartRecord label="Day 1" value="100"></am:ChartRecord>
+					<am:ChartRecord label="Day 2" value="50"></am:ChartRecord>
+					<am:ChartRecord label="Day 3" value="200"></am:ChartRecord>
+					<am:ChartRecord label="Day 4" value="150"></am:ChartRecord>
+					<am:ChartRecord label="Day 5" value="125"></am:ChartRecord>
+				</am:Chart>
 			</VBox>
 		</content>
 	</Page>

--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -16,7 +16,8 @@ const { generateBundle } = require("./util");
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {boolean} [parameters.options.configuration.skipCache] Flag whether the module cache for the bundles should be skipped
  * @returns {function} Middleware function to use
  */
 module.exports = function ({
@@ -32,7 +33,7 @@ module.exports = function ({
         const match = /^\/resources\/(.*)\.js$/.exec(req.path);
         if (match) {
 
-            const bundle = await generateBundle(match[1]);
+            const bundle = await generateBundle(match[1], config.skipCache);
             if (bundle) {
                 try {
 
@@ -42,17 +43,17 @@ module.exports = function ({
                         charset
                     } = middlewareUtil.getMimeInfo(req.path);
                     res.setHeader("Content-Type", contentType);
-    
+
                     res.send(bundle);
-    
+
                     res.end();
-    
+
                     log.verbose(`Created bundle for ${req.path}`);
-    
+
                     log.info(`Bundling took ${(Date.now() - time)} millis`);
-    
+
                     return;
-    
+
                 } catch (err) {
                     log.error(`Couldn't write bundle ${match[1]}: ${err}`);
                 }

--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -25,15 +25,19 @@ module.exports = function ({
 }) {
 
     const config = options.configuration || {}
+    log.verbose(`Starting ui5-tooling-modules-middleware`);
 
     return async (req, res, next) => {
 
+        const reqPath = middlewareUtil.getPathname(req);
+
         const time = Date.now();
 
-        const match = /^\/resources\/(.*)\.js$/.exec(req.path);
+        const match = /^\/resources\/(.*)\.js$/.exec(reqPath);
         if (match) {
 
-            const bundle = await generateBundle(match[1], config.skipCache);
+            const bundleName = match[1];
+            const bundle = await generateBundle(bundleName, config.skipCache);
             if (bundle) {
                 try {
 
@@ -41,21 +45,19 @@ module.exports = function ({
                     let {
                         contentType,
                         charset
-                    } = middlewareUtil.getMimeInfo(req.path);
+                    } = middlewareUtil.getMimeInfo(reqPath);
                     res.setHeader("Content-Type", contentType);
 
-                    res.send(bundle);
+                    res.end(bundle);
 
-                    res.end();
+                    log.verbose(`Process resource ${bundleName}`);
 
-                    log.verbose(`Created bundle for ${req.path}`);
-
-                    log.info(`Bundling took ${(Date.now() - time)} millis`);
+                    log.info(`Processing took ${(Date.now() - time)} millis`);
 
                     return;
 
                 } catch (err) {
-                    log.error(`Couldn't write bundle ${match[1]}: ${err}`);
+                    log.error(`Couldn't process resource ${bundleName}: ${err}`);
                 }
             }
 

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -3,6 +3,7 @@ const resourceFactory = require("@ui5/fs").resourceFactory;
 
 const { generateBundle } = require("./util");
 
+const { readFileSync } = require("fs");
 const espree = require('espree');
 const estraverse = require('estraverse');
 
@@ -28,23 +29,22 @@ module.exports = async function ({
     options
 }) {
 
+    // do not run the task for root projects!
     if (!taskUtil.isRootProject()) {
         log.info(`Skipping execution. Current project '${options.projectName}' is not the root project.`);
         return;
     }
 
+    // find all JS resources to determine their dependencies
     const allWorkspaceResources = await workspace.byGlob("/**/*.js");
     const allDependenciesResources = await dependencies.byGlob("/**/*.js");
     const allResources = [...allWorkspaceResources, ...allDependenciesResources];
 
+    // utility to lookup unique dependencies
     const uniqueDeps = new Set();
-
-    await Promise.all(allResources.map(async (resource) => {
-        log.verbose(`Processing: ${resource.getPath()}`);
-
-        const content = await resource.getString();
+    function findUniqueDeps(content) {
+        // use espree to parse the UI5 modules and extract the UI5 module dependencies
         const program = espree.parse(content, { range: true, comment: true, tokens: true, ecmaVersion: "latest" });
-
         estraverse.traverse(program, {
             enter(node, parent) {
                 if (node?.type === "CallExpression" &&
@@ -54,17 +54,34 @@ module.exports = async function ({
                     const depsArray = node.arguments.filter(arg => arg.type === "ArrayExpression");
                     if (depsArray.length > 0) {
                         const deps = depsArray[0].elements.filter(el => el.type === "Literal").map(el => el.value);
-                        deps.forEach(dep => uniqueDeps.add(dep));
-                    } 
+                        deps.forEach(dep => {
+                            uniqueDeps.add(dep);
+                            // each dependency which can be resolved via the NPM package name
+                            // should also be checked for its dependencies to finally handle them
+                            // here if they also require to be transpiled by the task
+                            try {
+                                const depPath = require.resolve(dep);
+                                const depConent = readFileSync(depPath, {encoding: "utf8"});
+                                findUniqueDeps(depConent);
+                            } catch (err) {}
+                        });
+                    }
                 }
             }
         });
+    }
+
+    // lookup all resources for their dependencies via the above utility
+    await Promise.all(allResources.map(async (resource) => {
+        log.verbose(`Processing: ${resource.getPath()}`);
+
+        const content = await resource.getString();
+        findUniqueDeps(content);
 
         return resource;
-
     }));
 
-    const bundleCache = {};
+    // every unique dependency will be tried to be transpiled
     await Promise.all(Array.from(uniqueDeps).map(async (dep) => {
 
         log.verbose(`Trying to bundle dependency: ${dep}`);

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -4,6 +4,11 @@ const commonjs = require('@rollup/plugin-commonjs');
 const json = require('@rollup/plugin-json');
 const nodePolyfills = require('rollup-plugin-polyfill-node');
 
+const { readFile } = require("fs").promises;
+const espree = require('espree');
+const estraverse = require('estraverse');
+
+
 // local bundle cache
 const bundleCache = {};
 
@@ -13,9 +18,10 @@ module.exports = {
      * Generates a UI5 AMD-like bundle for a module out of the node_modules
      *
      * @param {string} moduleName the module name
+     * @param {boolean} skipCache skip the module cache
      * @returns the content of the bundle or undefined
      */
-    generateBundle: async function generateBundle(moduleName) {
+    generateBundle: async function generateBundle(moduleName, skipCache) {
 
         let bundling = false;
 
@@ -33,40 +39,62 @@ module.exports = {
             */
 
             let cachedBundle = bundleCache[moduleName];
-            if (!cachedBundle) {
+            if (skipCache || !cachedBundle) {
 
                 bundling = true;
 
-                // create a bundle (maybe in future we should again load the )
-                const bundle = await rollup.rollup({
-                    input: modulePath,
-                    plugins: [
-                        //typescript(),
-                        nodePolyfills(),
-                        nodeResolve({
-                            browser: true,
-                            mainFields: ["module", "main"]
-                        }),
-                        json(),
-                        commonjs()
-                    ]
-                });
-
-                // generate output specific code in-memory
-                // you can call this function multiple times on the same bundle object
-                const { output } = await bundle.generate({
-                    output: {
-                        format: 'amd',
-                        amd: {
-                            define: "sap.ui.define"
+                // is the bundle a UI5 module?
+                const moduleContent = await readFile(modulePath, { encoding: "utf8" });
+                const program = espree.parse(moduleContent, { range: true, comment: true, tokens: true, ecmaVersion: "latest" });
+                let isUI5Module = false;
+                estraverse.traverse(program, {
+                    enter(node, parent) {
+                        if (node?.type === "CallExpression" &&
+                            /require|define/.test(node?.callee?.property?.name) &&
+                            node?.callee?.object?.property?.name == "ui" &&
+                            node?.callee?.object?.object?.name == "sap") {
+                                isUI5Module = true;
                         }
                     }
                 });
 
-                // Right now we only support one chunk as build result
-                // should be also given by the rollup configuration!
-                if (output.length === 1 && output[0].type === "chunk") {
-                    cachedBundle = bundleCache[moduleName] = output[0].code;
+                // only transform non-UI5 modules
+                if (!isUI5Module) {
+
+                    // create a bundle (maybe in future we should again load the )
+                    const bundle = await rollup.rollup({
+                        input: moduleName,
+                        plugins: [
+                            //typescript(),
+                            nodePolyfills(),
+                            nodeResolve({
+                                browser: true,
+                                mainFields: ["module", "main"]
+                            }),
+                            json(),
+                            commonjs()
+                        ]
+                    });
+
+                    // generate output specific code in-memory
+                    // you can call this function multiple times on the same bundle object
+                    const { output } = await bundle.generate({
+                        output: {
+                            format: 'amd',
+                            amd: {
+                                define: "sap.ui.define"
+                            }
+                        }
+                    });
+
+                    // Right now we only support one chunk as build result
+                    // should be also given by the rollup configuration!
+                    if (output.length === 1 && output[0].type === "chunk") {
+                        cachedBundle = bundleCache[moduleName] = output[0].code;
+                    }
+
+                } else {
+                    cachedBundle = bundleCache[moduleName] = moduleContent;
                 }
 
             }

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -17,6 +17,7 @@
     "@ui5/logger": "^2.0.1",
     "espree": "^9.3.1",
     "estraverse": "^5.3.0",
+    "fast-xml-parser": "^4.0.3",
     "rollup": "^2.68.0",
     "rollup-plugin-polyfill-node": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,6 +6217,13 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-xml-parser@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.3.tgz#ad1ebfa53a447369634454073f7952f171ed4aba"
+  integrity sha512-xhQbg3a/EYNHwK0cxIG1nZmVkHX/0tWihamn5pU4Mhd9KEVE2ga8ZJiqEUgB2sApElvAATOdMTLjgqIpvYDUkQ==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -12185,6 +12192,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4099,6 +4099,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.1.tgz#0516f690c6a8680c6c707e31a4c1807a6f400ada"
+  integrity sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==
+
 cheerio-select@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"


### PR DESCRIPTION
Enhanced the transpiling script to also follow the dependencies
chain, e.g. if a module is resolve from another NPM package (not
via the UI5 tooling) then the dependencies of this UI5 module needs
to be also covered by the task. For the middleware the client will
follow the dependencies and request them from the server.