### PR TITLE
feat: use namespace instead of package name for reusable ui5 modules

### DIFF
--- a/packages/ui5-app-module/Chart.js
+++ b/packages/ui5-app-module/Chart.js
@@ -1,6 +1,6 @@
 sap.ui.define(["sap/ui/core/Control", "chart.js/auto"], function(Control, Chart) {
 
-    return Control.extend("ui5-app-module.Chart", {
+    return Control.extend("ui5.cc.chart.Chart", {
         metadata: {
             properties: {
                 "title": "string",
@@ -8,7 +8,7 @@ sap.ui.define(["sap/ui/core/Control", "chart.js/auto"], function(Control, Chart)
             },
             aggregations: {
                 "records": {
-                    type: "ui5-app-module.ChartRecord"
+                    type: "ui5.cc.chart.ChartRecord"
                 }
             },
             defaultAggregation: "records"

--- a/packages/ui5-app-module/ChartRecord.js
+++ b/packages/ui5-app-module/ChartRecord.js
@@ -1,6 +1,6 @@
 sap.ui.define(["sap/ui/core/Element"], function(Element) {
 
-    return Element.extend("ui5-app-module.ChartRecord", {
+    return Element.extend("ui5.cc.chart.ChartRecord", {
         metadata: {
             properties: {
                 label: "string",

--- a/packages/ui5-app-module/ui5.yaml
+++ b/packages/ui5-app-module/ui5.yaml
@@ -1,0 +1,9 @@
+specVersion: "2.2"
+type: module
+metadata:
+  name: ui5-app-module
+
+resources:
+  configuration:
+    paths:
+      "/resources/ui5/cc/chart/": "./"

--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -97,7 +97,8 @@
       "ui5-task-stringreplacer",
       "ui5-task-transpile",
       "ui5-task-zipper",
-      "ui5-tooling-modules"
+      "ui5-tooling-modules",
+      "ui5-app-module"
     ]
   }
 }

--- a/packages/ui5-app/webapp/controller/Main.controller.js
+++ b/packages/ui5-app/webapp/controller/Main.controller.js
@@ -1,7 +1,7 @@
 sap.ui.define([
     "test/Sample/controller/BaseController",
     "sap/m/MessageToast"
-], (Controller, MessageToast, Chart) => {
+], (Controller, MessageToast) => {
     "use strict";
 
     return Controller.extend("test.Sample.controller.Main", {

--- a/packages/ui5-app/webapp/view/Main.view.xml
+++ b/packages/ui5-app/webapp/view/Main.view.xml
@@ -1,7 +1,7 @@
 <mvc:View controllerName="test.Sample.controller.Main"
 	xmlns:core="sap.ui.core"
 	xmlns:mvc="sap.ui.core.mvc"
-	xmlns:am="ui5-app-module"
+	xmlns:am="ui5.cc.chart"
 	displayBlock="true"
 	xmlns="sap.m">
 


### PR DESCRIPTION
Hi @petermuessig,

really cool work regarding the ui5-tooling-modules 👍. Sry for anwsering a bit late, but I was very busy the last two days.  
Here is the other solution with namespaces, which is the one I prefer because it's more natural for a UI5 dev. Let's discuss pro's and con's with @marianfoo and @mauriciolauffer. 

Have a nice weekend :)
Marcel