### PR TITLE
feat: include ui5-cc-md published on npm via it's namespace

### DIFF
--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -76,7 +76,8 @@
     "ui5-tooling-modules": "^0.2.5",
     "wait-on": "^6.0.1",
     "wdio-chromedriver-service": "^7.2.8",
-    "wdio-ui5-service": "^0.8.2"
+    "wdio-ui5-service": "^0.8.2",
+    "ui5-cc-md": "^0.0.4"
   },
   "ui5": {
     "dependencies": [
@@ -97,7 +98,8 @@
       "ui5-task-stringreplacer",
       "ui5-task-transpile",
       "ui5-task-zipper",
-      "ui5-tooling-modules"
+      "ui5-tooling-modules",
+      "ui5-cc-md"
     ]
   }
 }

--- a/packages/ui5-app/webapp/view/Main.view.xml
+++ b/packages/ui5-app/webapp/view/Main.view.xml
@@ -2,6 +2,7 @@
 	xmlns:core="sap.ui.core"
 	xmlns:mvc="sap.ui.core.mvc"
 	xmlns:am="ui5-app-module"
+    xmlns:md="cc.md"
 	displayBlock="true"
 	xmlns="sap.m">
 
@@ -62,6 +63,7 @@
 					<am:ChartRecord label="Day 4" value="150"></am:ChartRecord>
 					<am:ChartRecord label="Day 5" value="125"></am:ChartRecord>
 				</am:Chart>
+                <md:Markdown content="I'm the custom control [ui5-cc-mdç](https://www.npmjs.com/package/ui5-cc-md) published on **npm** and included via my `namespace`" />
 			</VBox>
 		</content>
 	</Page>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8855,6 +8855,11 @@ markdown-it@^12.3.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+marked@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+
 marked@^4.0.10:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
@@ -12677,6 +12682,13 @@ uglify-js@^3.1.4:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.1.tgz#9403dc6fa5695a6172a91bc983ea39f0f7c9086d"
   integrity sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==
+
+ui5-cc-md@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/ui5-cc-md/-/ui5-cc-md-0.0.4.tgz#53da46a52e475c836c87c3155a16df35bac3c86f"
+  integrity sha512-gZ6EU8n2smq1WYg1iNIywtX80ug5M6M63bjehX00GnL8SlyEU4JHTTeqQ9vHXgh1coGmhxsKeOxWSF5ST6tubQ==
+  dependencies:
+    marked "^2.0.0"
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Hi @petermuessig,
like discussed in #586. I just used the custom control ui5-cc-md from @vobu to showcase how custom controls / modules can be included via it's namespace instead of package name + ui5-tooling-modules. 