### PR TITLE
feat(ui5-tooling-modules): respect cjs file extensions and try bundling them as well

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -79,7 +79,7 @@ module.exports = {
                 const moduleContent = await readFile(modulePath, { encoding: "utf8" });
 
                 // only transform non-UI5 modules
-                if (moduleExt === ".js" && !isUI5Module(moduleContent)) {
+                if (( moduleExt === ".js" || moduleExt === ".cjs" ) && !isUI5Module(moduleContent)) {
 
                     bundling = true;
 


### PR DESCRIPTION
Hey there 👋

this is my first PR in the ecosystem showcase so I hope things aren't too out of hand. Even though the actual change is quite small. 😅

I've had the issue (also described in a bit more detail further below) that one of my third party libraries ([marked.js](https://github.com/markedjs/marked) to be precise) swapped their build between versions [4.0.1](https://github.com/markedjs/marked/tree/v4.0.1/lib) and [4.0.2](https://github.com/markedjs/marked/tree/v4.0.2/lib) (this [PR](https://github.com/markedjs/marked/pull/2281)).

As far as I understand the `require.resolve` is able to successfully determine the dependency path, however in this particular case it is the `.cjs` build of marked. Looking through the code a bit more I realized that maybe using rollup within `util.js` could also solve my issues here. Sure enough by already using the rollup [node resolve plugin](https://www.npmjs.com/package/@rollup/plugin-node-resolve), the proper esm build can be "pulled" or rather bundled up and be used accordingly. This fixes my issues during dev but also build time.

Here is some more information (including a few twitter threads that I created when looking into this ^^). Maybe this help to determine if this is even a valid approach or something else could've been done ...
- https://github.com/wridgeu/github_pages/pull/50

I haven't done a lot when it comes to this but I've been debugging the whole AST, Espree, Acorn stuff the past few days and was able to learn a bit at least. If there is _anything_ I might have missed in my thoughts or if this is a bad idea or should be resolved differently then I'd love to know! Maybe then I should create an Issue rather than a PR. (: 

I made sure that running `yarn dev` will result in a still functioning demo app and that it still successfully loads chart.js. ^^

Thanks for reading all this! 

BR,
Marco
