### PR TITLE
fix(ui5-tooling-modules): add node polyfills later

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -87,7 +87,6 @@ module.exports = {
                     const bundle = await rollup.rollup({
                         input: moduleName,
                         plugins: [
-                            nodePolyfills(),
                             nodeResolve({
                                 browser: true,
                                 mainFields: ["module", "main"]
@@ -97,6 +96,7 @@ module.exports = {
                             commonjs({
                                 defaultIsModuleExports: true
                             }),
+                            nodePolyfills(),
                             injectProcessEnv({
                                 NODE_ENV: "production"
                             })


### PR DESCRIPTION
When using `nodePolyfills` before `nodeResolve` and `commonJS` it may happen that dependencies matching the name of built-in node modules are not going to be resolved and included anymore.