### PR TITLE
chore: add metadata to `package.json` for all packages for ui5-community website

### DIFF
--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -35,5 +35,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "btp"
+    ]
   }
 }

--- a/packages/ui5-middleware-iasync/package.json
+++ b/packages/ui5-middleware-iasync/package.json
@@ -16,5 +16,13 @@
     },
     "ui5": {
         "dependencies": []
+    },
+    "ui5-community": {
+      "types": [
+        "middleware"
+      ],
+      "tags": [
+        "browser"
+      ]
     }
 }

--- a/packages/ui5-middleware-index/package.json
+++ b/packages/ui5-middleware-index/package.json
@@ -14,5 +14,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "browser"
+    ]
   }
 }

--- a/packages/ui5-middleware-livecompileless/package.json
+++ b/packages/ui5-middleware-livecompileless/package.json
@@ -15,5 +15,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "css"
+    ]
   }
 }

--- a/packages/ui5-middleware-livereload/package.json
+++ b/packages/ui5-middleware-livereload/package.json
@@ -18,5 +18,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "livereload"
+    ]
   }
 }

--- a/packages/ui5-middleware-livetranspile/package.json
+++ b/packages/ui5-middleware-livetranspile/package.json
@@ -18,5 +18,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "transpile"
+    ]
   }
 }

--- a/packages/ui5-middleware-onelogin/package.json
+++ b/packages/ui5-middleware-onelogin/package.json
@@ -38,5 +38,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "auth"
+    ]
   }
 }

--- a/packages/ui5-middleware-servestatic/package.json
+++ b/packages/ui5-middleware-servestatic/package.json
@@ -16,5 +16,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "proxy"
+    ]
   }
 }

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -17,5 +17,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "proxy"
+    ]
   }
 }

--- a/packages/ui5-middleware-stringreplacer/package.json
+++ b/packages/ui5-middleware-stringreplacer/package.json
@@ -20,5 +20,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "replace"
+    ]
   }
 }

--- a/packages/ui5-middleware-webjars/package.json
+++ b/packages/ui5-middleware-webjars/package.json
@@ -16,5 +16,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware"
+    ],
+    "tags": [
+      "webjars"
+    ]
   }
 }

--- a/packages/ui5-task-compileless/package.json
+++ b/packages/ui5-task-compileless/package.json
@@ -16,5 +16,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "css"
+    ]
   }
 }

--- a/packages/ui5-task-flatten-library/package.json
+++ b/packages/ui5-task-flatten-library/package.json
@@ -14,5 +14,13 @@
     },
     "ui5": {
         "dependencies": []
+    },
+    "ui5-community": {
+      "types": [
+        "task"
+      ],
+      "tags": [
+        "netweaver"
+      ]
     }
 }

--- a/packages/ui5-task-i18ncheck/package.json
+++ b/packages/ui5-task-i18ncheck/package.json
@@ -15,5 +15,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "i18n"
+    ]
   }
 }

--- a/packages/ui5-task-minify-xml/package.json
+++ b/packages/ui5-task-minify-xml/package.json
@@ -15,5 +15,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "minify"
+    ]
   }
 }

--- a/packages/ui5-task-pwa-enabler/package.json
+++ b/packages/ui5-task-pwa-enabler/package.json
@@ -18,5 +18,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "pwa"
+    ]
   }
 }

--- a/packages/ui5-task-stringreplacer/package.json
+++ b/packages/ui5-task-stringreplacer/package.json
@@ -17,5 +17,13 @@
     },
     "ui5": {
         "dependencies": []
+    },
+    "ui5-community": {
+      "types": [
+        "task"
+      ],
+      "tags": [
+        "replace"
+      ]
     }
 }

--- a/packages/ui5-task-transpile/package.json
+++ b/packages/ui5-task-transpile/package.json
@@ -19,5 +19,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "transpile"
+    ]
   }
 }

--- a/packages/ui5-task-zipper/package.json
+++ b/packages/ui5-task-zipper/package.json
@@ -32,5 +32,13 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "task"
+    ],
+    "tags": [
+      "zip"
+    ]
   }
 }

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -24,5 +24,14 @@
   },
   "ui5": {
     "dependencies": []
+  },
+  "ui5-community": {
+    "types": [
+      "middleware",
+      "task"
+    ],
+    "tags": [
+      "tooling"
+    ]
   }
 }


### PR DESCRIPTION
To get a comprehensive metadata database as well as to display data in the UI5 community website, metadata is necessary in the respective packages.

For this purpose, a subitem is created in `package.json` with the name `ui5-community` similar to the already existing item `ui5`.

In this subitem two arrays are added with the name `types` and `tags`.
In `types` the types will be contained, which can be multiple for each package. For example: "task" or "middleware".
In `tags` several free descriptive names of the package can be entered.

The explicit specification of these parameters makes the extraction much easier, instead of pulling them out of yaml or json files.