### PR TITLE
feat(ui5-tooling-modules): support name-spacing of modules

### DIFF
--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -53,6 +53,7 @@ builder:
       afterTask: replaceVersion
       configuration:
         prependPathMappings: true
+        addToNamespace: true
     - name: ui5-task-zipper
       afterTask: uglify
       configuration:

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -9,7 +9,8 @@ const { getResource, resolveModule } = require("./util");
 const { readFileSync } = require("fs");
 const espree = require("espree");
 const estraverse = require("estraverse");
-const { XMLParser } = require("fast-xml-parser");
+const { XMLParser, XMLBuilder, XMLValidator } = require("fast-xml-parser");
+const escodegen = require("escodegen");
 
 /**
  * Custom task to create the UI5 AMD-like bundles for used ES imports from node_modules.
@@ -89,6 +90,47 @@ module.exports = async function ({ workspace, dependencies, taskUtil, options })
 		}
 	}
 
+	// utility to rewrite JS dependencies
+	function rewriteJSDeps(content, bundledResources) {
+		let changed = false;
+		const program = espree.parse(content, { range: true, comment: true, tokens: true, ecmaVersion: "latest" });
+		estraverse.traverse(program, {
+			enter(node, parent) {
+				if (
+					/* sap.ui.require.toUrl */
+					node?.type === "CallExpression" &&
+					node?.callee?.property?.name == "toUrl" &&
+					node?.callee?.object?.property?.name == "require" &&
+					node?.callee?.object?.object?.property?.name == "ui" &&
+					node?.callee?.object?.object?.object?.name == "sap"
+				) {
+					const elDep = node.arguments[0];
+					if (elDep?.type === "Literal" && bundledResources.includes(elDep.value)) {
+						elDep.value = `${options.projectNamespace}/thirdparty/${elDep.value}`;
+						changed = true;
+					}
+				} else if (
+					/* sap.ui.(require|define) */
+					node?.type === "CallExpression" &&
+					/require|define/.test(node?.callee?.property?.name) &&
+					node?.callee?.object?.property?.name == "ui" &&
+					node?.callee?.object?.object?.name == "sap"
+				) {
+					const depsArray = node.arguments.filter((arg) => arg.type === "ArrayExpression");
+					if (depsArray.length > 0) {
+						depsArray[0].elements
+							.filter((el) => el.type === "Literal" && bundledResources.includes(el.value))
+							.map((el) => {
+								el.value = `${options.projectNamespace}/thirdparty/${el.value}`;
+								changed = true;
+							});
+					}
+				}
+			},
+		});
+		return changed ? escodegen.generate(program) : content;
+	}
+
 	// utility to lookup unique XML dependencies
 	// eslint-disable-next-line jsdoc/require-jsdoc
 	function findUniqueXMLDeps(node, ns = {}) {
@@ -137,6 +179,48 @@ module.exports = async function ({ workspace, dependencies, taskUtil, options })
 						});
 				});
 		}
+	}
+
+	// utility to lookup unique XML dependencies
+	function rewriteXMLDeps(node, bundledResources) {
+		let changed = false;
+		if (node) {
+			// attributes
+			Object.keys(node)
+				.filter((key) => key.startsWith("@_"))
+				.forEach((key) => {
+					const nsParts = /@_xmlns(?::(.*))?/.exec(key);
+					if (nsParts) {
+						// namespace (default namespace => "")
+						const namespace = node[key].replace(/\./g, "/");
+						if (
+							bundledResources.some((res) => {
+								return res.startsWith(namespace);
+							})
+						) {
+							node[key] = `${options.projectNamespace.replace(/\//g, ".")}.thirdparty.${node[key]}`;
+							changed = true;
+						}
+					}
+				});
+			// nodes
+			Object.keys(node)
+				.filter((key) => !key.startsWith("@_"))
+				.forEach((key) => {
+					const children = Array.isArray(node[key]) ? node[key] : [node[key]];
+					children.forEach((child) => {
+						const nodeParts = /(?:([^:]*):)?(.*)/.exec(key);
+						if (nodeParts) {
+							// skip #text nodes
+							let module = nodeParts[2];
+							if (module !== "#text") {
+								changed = rewriteXMLDeps(child, bundledResources) || changed;
+							}
+						}
+					});
+				});
+		}
+		return changed;
 	}
 
 	// find all XML resources to determine their dependencies
@@ -191,7 +275,7 @@ module.exports = async function ({ workspace, dependencies, taskUtil, options })
 			if (bundle) {
 				log.info(`Processing dependency: ${dep}`);
 				const bundleResource = resourceFactory.createResource({
-					path: `/resources/${dep}.js`,
+					path: `/resources/${config?.addToNamespace ? options.projectNamespace + "/thirdparty/" : ""}${dep}.js`,
 					string: bundle,
 				});
 				bundledResources.push(dep);
@@ -208,7 +292,7 @@ module.exports = async function ({ workspace, dependencies, taskUtil, options })
 			if (content) {
 				log.info(`Processing resource: ${resource}`);
 				const newResource = resourceFactory.createResource({
-					path: `/resources/${resource}`,
+					path: `/resources/${config?.addToNamespace ? options.projectNamespace + "/thirdparty/" : ""}${resource}`,
 					string: content,
 				});
 				bundledResources.push(resource);
@@ -217,8 +301,59 @@ module.exports = async function ({ workspace, dependencies, taskUtil, options })
 		})
 	);
 
+	// process all XML and JS files in workspace and rewrite the module names
+	if (config?.addToNamespace) {
+		const parser = new XMLParser({
+			attributeNamePrefix: "@_",
+			ignoreAttributes: false,
+			ignoreNameSpace: false,
+			processEntities: false,
+			allowBooleanAttributes: false,
+			suppressBooleanAttributes: true,
+			preserveOrder: true,
+		});
+		const builder = new XMLBuilder({
+			attributeNamePrefix: "@_",
+			ignoreAttributes: false,
+			ignoreNameSpace: false,
+			processEntities: false,
+			allowBooleanAttributes: false,
+			suppressBooleanAttributes: true,
+			preserveOrder: true,
+			format: true,
+		});
+
+		const allResources = await workspace.byGlob("/**/*.{js,xml}");
+		await Promise.all(
+			allResources.map(async (res) => {
+				if (res.getPath().endsWith(".js")) {
+					try {
+						const content = await res.getString();
+						const newContent = rewriteJSDeps(content, bundledResources);
+						if (newContent != content) {
+							log.info(`Rewriting JS resource: ${res.getPath()}`);
+							res.setString(newContent);
+							await workspace.write(res);
+						}
+					} catch (err) {
+						log.info(`Failed to rewrite "${res.getPath()}" with espree!`, err);
+					}
+				} else if (res.getPath().endsWith(".xml")) {
+					const content = await res.getString();
+					const xmldom = parser.parse(content);
+					if (rewriteXMLDeps(xmldom, bundledResources)) {
+						log.info(`Rewriting XML resource: ${res.getPath()}`);
+						const newContent = builder.build(xmldom);
+						res.setString(newContent);
+						await workspace.write(res);
+					}
+				}
+			})
+		);
+	}
+
 	// create path mappings for bundled resources in Component.js
-	if (config?.prependPathMappings) {
+	if (!config?.addToNamespace && config?.prependPathMappings) {
 		const resComponent = await workspace.byPath(`/resources/${options.projectNamespace}/Component.js`);
 		if (resComponent) {
 			let pathMappings = "";

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -20,6 +20,7 @@
     "@rollup/pluginutils": "^4.2.1",
     "@ui5/fs": "^2.0.6",
     "@ui5/logger": "^2.0.1",
+    "escodegen": "^2.0.0",
     "espree": "^9.3.2",
     "estraverse": "^5.3.0",
     "fast-xml-parser": "^4.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,7 @@ importers:
       '@rollup/pluginutils': ^4.2.1
       '@ui5/fs': ^2.0.6
       '@ui5/logger': ^2.0.1
+      escodegen: ^2.0.0
       espree: ^9.3.2
       estraverse: ^5.3.0
       fast-xml-parser: ^4.0.7
@@ -409,6 +410,7 @@ importers:
       '@rollup/pluginutils': 4.2.1
       '@ui5/fs': 2.0.6
       '@ui5/logger': 2.0.1
+      escodegen: 2.0.0
       espree: 9.3.2
       estraverse: 5.3.0
       fast-xml-parser: 4.0.8
@@ -5136,7 +5138,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -5161,7 +5163,7 @@ packages:
   /axios/0.27.2_debug@4.3.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -6775,6 +6777,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: false
 
   /debug/4.3.3:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
@@ -8220,6 +8223,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
+    dev: false
 
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}


### PR DESCRIPTION
When using the configuration option addToNamespace 3rd party modules
will now be moved into the project namespace in the thirdparty folders
and the used module names in JS and XML files will be prefixed with
the projectNamespace+thirdparty. This ensures that 3rd party modules
are packaged locally within the application and do not conflict globally
with other modules.