### PR TITLE
fix(ui5-middleware/task-stringreplacer): handle missing strings

### DIFF
--- a/packages/ui5-middleware-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-middleware-stringreplacer/lib/stringreplacer.js
@@ -46,6 +46,12 @@ if (typeof envVariables === "object") {
 	}
 }
 
+// check if we found any strings to replace
+let hasStringsToReplace = Object.keys(placeholderStrings).length > 0
+if(!hasStringsToReplace){
+    log.warn(`No strings to replace provided either through the process environment or middleware config`);
+}
+
 // create the helper function to pipe the stream and replace the placeholders
 function createReplacePlaceholdersDestination({ resource, isDebug }) {
 	const replaceStreamRegExp = `(${Object.keys(placeholderStrings)
@@ -107,6 +113,12 @@ module.exports = function createMiddleware({ resources, options, middlewareUtil 
 
 	// returns the middleware function
 	return async function stringreplacer(req, res, next) {
+		if(!hasStringsToReplace){
+            // Nothing to do
+			next();
+			return;
+        }
+
 		const pathname = middlewareUtil.getPathname(req);
 		const resource = await resources.all.byPath(pathname);
 		if (!resource) {

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -32,6 +32,13 @@ if (typeof envVariables === "object") {
 	}
 }
 
+// check if we found any strings to replace and stop the build if no strings are found (we don't want to finish build for production while missing strings intended to be included in the build)
+let hasStringsToReplace = Object.keys(placeholderStrings).length > 0
+if(!hasStringsToReplace){
+    log.error(`No strings to replace provided either through the process environment or middleware config`);
+    process.exit(-1)
+}
+
 // create the helper function to pipe the stream and replace the placeholders
 function createReplacePlaceholdersDestination({ resource, isDebug }) {
 	const replaceStreamRegExp = `(${Object.keys(placeholderStrings)


### PR DESCRIPTION
If there were no strings provided, the build would fail after a while and the middelware would get in an endless loop and you'd have to kill the node ùi5 serve` process (and the live reload would keep running). 

With this PR a check is done and the user is warned in case of the middleware and there is no attempt to replace any strings. In the case of the build taks we raise an error and stop the build to avoid that builds are completed while missing strings intended for production.