### PR TITLE
feat(ui5-tooling-modules): support app-local bundle defs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,4 +10,5 @@
 /**/*.png
 
 # Additionally ignore folders for lint-staged
+/packages/ui5-app/lib/**
 /packages/ui5-middleware-cfdestination/test/**

--- a/packages/ui5-app/lib/firebase.js
+++ b/packages/ui5-app/lib/firebase.js
@@ -1,0 +1,4 @@
+import { initializeApp } from "firebase/app";
+import { getFirestore, doc, getDoc } from "firebase/firestore/lite";
+
+export { initializeApp, getFirestore, doc, getDoc };

--- a/packages/ui5-app/webapp/controller/Thirdparty.controller.js
+++ b/packages/ui5-app/webapp/controller/Thirdparty.controller.js
@@ -1,11 +1,10 @@
-sap.ui.define(["test/Sample/controller/BaseController", "xlsx", "firebase/app", "firebase/auth", "@supabase/supabase-js"], (Controller, xlsx, app, auth, supabase) => {
+sap.ui.define(["test/Sample/controller/BaseController", "xlsx", "ui5-app/lib/firebase", "@supabase/supabase-js"], (Controller, xlsx, _firebase, supabase) => {
 	"use strict";
 
-	const { initializeApp } = app;
-	const { getAuth } = auth;
-	const xapp = initializeApp();
+	const { initializeApp, getFirestore } = _firebase;
+	const app = initializeApp({});
 	try {
-		const xauth = getAuth(xapp);
+		getFirestore(app);
 	} catch (ex) {
 		console.error(ex);
 	}

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -21,6 +21,9 @@ const estraverse = require("estraverse");
 // local bundle cache
 const bundleCache = {};
 
+// package.json of app
+const pkg = require(path.join(process.cwd(), "package.json"));
+
 /**
  * Checks whether the given content is a UI5 module or not
  *
@@ -59,6 +62,11 @@ const that = (module.exports = {
 	 * @returns {string} the path of the module in the filesystem
 	 */
 	resolveModule: function resolveModule(moduleName) {
+		// special handling for app-local resources!
+		if (moduleName?.startsWith(`${pkg.name}/`)) {
+			return path.join(process.cwd(), moduleName.substring(`${pkg.name}/`.length) + ".js");
+		}
+		// resolve from node_modules
 		let modulePath;
 		try {
 			// try the regular lookup

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8208,6 +8208,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /follow-redirects/1.15.1_debug@4.3.2:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
@@ -8963,7 +8964,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
To support special scenarios like `firebase` we need to create local bundle definitions to package all individual modules into a single bundle, otherwise this leads to problems that different modules aren't aware of each other. 

Now the ui5-tooling-modules can read project local bundle definitions via the app name + the path in the app folder, e.g. `ui5-app/lib/firebase`. With this module name the UI5 can also load the bundle via the `ui5-tooling-modules` extension.