### PR TITLE
feat(ui5-task-flatten-library): migrate to UI5 Tooling v3.0.0 and Specification v3.0

### DIFF
--- a/packages/ui5-task-flatten-library/.eslintrc.cjs
+++ b/packages/ui5-task-flatten-library/.eslintrc.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+	parserOptions: {
+		sourceType: "module",
+	},
+	env: {
+		node: true,
+		es2021: true,
+	},
+	extends: ["eslint:recommended"],
+	ignorePatterns: [".eslintignore.js"],
+	root: true,
+};

--- a/packages/ui5-task-flatten-library/.eslintrc.cjs
+++ b/packages/ui5-task-flatten-library/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	env: {
 		node: true,
-		es2021: true,
+		es2022: true,
 	},
 	extends: ["eslint:recommended"],
 	ignorePatterns: [".eslintignore.js"],

--- a/packages/ui5-task-flatten-library/README.md
+++ b/packages/ui5-task-flatten-library/README.md
@@ -4,8 +4,7 @@ Task for [ui5-builder](https://github.com/SAP/ui5-builder), to prepare build res
 
 ## Prerequisites
 
-- Requires `@ui5/cli` v2.4.0+ (to support [specVersion 2.2](https://sap.github.io/ui5-tooling/pages/Configuration/#specification-version-22))
-
+- Requires `@ui5/cli` v3.0.0+ because of ES Module usage
 ## Install
 
 ```bash

--- a/packages/ui5-task-flatten-library/lib/flatten-library.js
+++ b/packages/ui5-task-flatten-library/lib/flatten-library.js
@@ -1,19 +1,33 @@
-import logger from "@ui5/logger";
-const log = logger.getLogger("builder:customtask:ui5-task-flatten-library");
-
 /**
  * Task to flatten the library folder structure.
  * This is required for deployments to SAP NetWeaver.
  *
- * @param {object} parameters Parameters
- * @param {@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/builder.tasks.TaskUtil} [parameters.taskUtil] TaskUtil
+ * @param {object} parameters
+ *
+ * @param {module:@ui5/fs.AbstractReader} parameters.dependencies
+ *      Reader to access resources of the project's dependencies
+ * @param {@ui5/logger/Logger} parameters.log
+ *      Logger instance for use in the custom task.
  * @param {object} parameters.options Options
- * @param {object} parameters.options.projectName Project name
- * @param {object} parameters.options.projectNamespace Project namespace
- * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
+ * @param {string} parameters.options.projectName
+ *      Name of the project currently being built
+ * @param {string} parameters.options.projectNamespace
+ *      Namespace of the project currently being built
+ * @param {string} parameters.options.configuration
+ *      Custom task configuration, as defined in the project's ui5.yaml
+ * @param {string} parameters.options.taskName
+ *      Name of the custom task.
+ * @param {@ui5/builder.tasks.TaskUtil} parameters.taskUtil
+ *      Specification Version-dependent interface to a TaskUtil instance.
+ *      See the corresponding API reference for details:
+ *      https://sap.github.io/ui5-tooling/v3/api/@ui5_project_build_helpers_TaskUtil.html
+ * @param {module:@ui5/fs.DuplexCollection} parameters.workspace
+ *      Reader/Writer to access and modify resources of the
+ *      project currently being built
+ * @returns {Promise<undefined>}
+ *      Promise resolving once the task has finished
  */
-export default async function ({ workspace, taskUtil, options }) {
+export default async function ({ log, options, taskUtil, workspace }) {
 	if (!taskUtil.isRootProject()) {
 		// Flattening is only done when library is built as root project
 		log.info(`Skipping execution. Current project '${options.projectName}' is not the root project.`);

--- a/packages/ui5-task-flatten-library/lib/flatten-library.js
+++ b/packages/ui5-task-flatten-library/lib/flatten-library.js
@@ -1,18 +1,19 @@
-const log = require("@ui5/logger").getLogger("builder:customtask:ui5-task-flatten-library");
+import logger from "@ui5/logger";
+const log = logger.getLogger("builder:customtask:ui5-task-flatten-library");
 
 /**
  * Task to flatten the library folder structure.
  * This is required for deployments to SAP NetWeaver.
  *
  * @param {object} parameters Parameters
- * @param {module:@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {module:@ui5/builder.tasks.TaskUtil} [parameters.taskUtil] TaskUtil
+ * @param {@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
+ * @param {@ui5/builder.tasks.TaskUtil} [parameters.taskUtil] TaskUtil
  * @param {object} parameters.options Options
  * @param {object} parameters.options.projectName Project name
  * @param {object} parameters.options.projectNamespace Project namespace
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
-module.exports = async function ({ workspace, taskUtil, options }) {
+export default async function ({ workspace, taskUtil, options }) {
 	if (!taskUtil.isRootProject()) {
 		// Flattening is only done when library is built as root project
 		log.info(`Skipping execution. Current project '${options.projectName}' is not the root project.`);
@@ -53,4 +54,4 @@ module.exports = async function ({ workspace, taskUtil, options }) {
 			}
 		})
 	);
-};
+}

--- a/packages/ui5-task-flatten-library/package.json
+++ b/packages/ui5-task-flatten-library/package.json
@@ -13,10 +13,5 @@
   "scripts": {
     "lint": "eslint lib"
   },
-  "dependencies": {
-    "@ui5/logger": "^3.0.1-alpha.3"
-  },
-  "ui5": {
-    "dependencies": []
-  }
+  "dependencies": {}
 }

--- a/packages/ui5-task-flatten-library/package.json
+++ b/packages/ui5-task-flatten-library/package.json
@@ -9,11 +9,12 @@
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",
     "directory": "packages/ui5-task-flatten-library"
   },
+  "type": "module",
   "scripts": {
     "lint": "eslint lib"
   },
   "dependencies": {
-    "@ui5/logger": "^2.0.1"
+    "@ui5/logger": "^3.0.1-alpha.3"
   },
   "ui5": {
     "dependencies": []

--- a/packages/ui5-task-flatten-library/ui5.yaml
+++ b/packages/ui5-task-flatten-library/ui5.yaml
@@ -1,5 +1,5 @@
 # https://sap.github.io/ui5-tooling/pages/extensibility/CustomTasks/
-specVersion: "2.2"
+specVersion: "3.0"
 metadata:
   name: ui5-task-flatten-library
 kind: extension


### PR DESCRIPTION
This PR demonstrates how a custom task can be migrated to UI5 Tooling V3 and Specification Version 3.0 using the newly added APIs providing logging and writing/reading capabilities.