### PR TITLE
Add support for use of chokidar legacy polling

### DIFF
--- a/packages/ui5-middleware-livereload/README.md
+++ b/packages/ui5-middleware-livereload/README.md
@@ -19,7 +19,7 @@ npm install ui5-middleware-livereload --save-dev
 - watchPath|path: `string`, default: `webapp`  
   path inside `$yourapp` the reload server monitors for changes
 - exclusions: one or many `regex`. By default, this includes `.git/`, `.svn/`, and `.hg/`
-- usePolling: true|false, default: true. 
+- usePolling: true|false, default: false. 
   Enables chokidar polling to support virtualised filesystems(eg. WSL2.0).
 
 ## Usage

--- a/packages/ui5-middleware-livereload/README.md
+++ b/packages/ui5-middleware-livereload/README.md
@@ -19,6 +19,8 @@ npm install ui5-middleware-livereload --save-dev
 - watchPath|path: `string`, default: `webapp`  
   path inside `$yourapp` the reload server monitors for changes
 - exclusions: one or many `regex`. By default, this includes `.git/`, `.svn/`, and `.hg/`
+- usePolling: true|false, default: true. 
+  Enables chokidar polling to support virtualised filesystems(eg. WSL2.0).
 
 ## Usage
 

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -78,12 +78,17 @@ module.exports = async ({ resources, options }) => {
 	if (options.configuration && options.configuration.debug) {
 		debug = options.configuration.debug;
 	}
+	let usePolling = false;
+	if (options.configuration && options.configuration.usePolling) {
+		usePolling = options.configuration.usePolling;
+	}
 
 	let serverOptions = {
 		debug: debug,
 		extraExts: extraExts ? extraExts.split(",") : undefined,
 		port: port,
 		exclusions: exclusions,
+		usePolling: usePolling,
 	};
 
 	const cli = require("yargs");


### PR DESCRIPTION
Currently, using the livereload-middleware does not support running in virtualized filesystems, such as WSL 2.0

Adding configuration to enable/disable Chokidar Legacy polling allows a user to overcome this issue