### PR TITLE
chore(ts-app): enable live reload for ts sources

### DIFF
--- a/packages/ui5-app-ts/ui5.yaml
+++ b/packages/ui5-app-ts/ui5.yaml
@@ -36,7 +36,7 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        extraExts: "xml,json,properties"
+        extraExts: "xml,json,properties,ts"
         port: 35729
         path: "webapp"
     - name: ui5-tooling-transpile-middleware


### PR DESCRIPTION
Noticed in #665 livereload is not working in this example -> added `ts` files to the watcher.