### PR TITLE
default exclude images in [ui5-transpile-middleware]

### DIFF
--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -25,7 +25,7 @@ module.exports = async function ({ resources, options /*, middlewareUtil */ }) {
 	config.includes = config.includes || config.includePatterns;
 
 	// never transpile these default exclusion types
-	const defaultExcludes = [".png", "jpeg", ".jpg"];
+	const defaultExcludes = [".png", ".jpeg", ".jpg"];
 	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns || []);
 
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true });

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -26,7 +26,7 @@ module.exports = async function ({ resources, options /*, middlewareUtil */ }) {
 
 	// never transpile these default exclusion types
 	const defaultExcludes = [".png", "jpeg", ".jpg"];
-	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns);
+	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns || []);
 
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true });
 

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -23,7 +23,10 @@ const { createBabelConfig, normalizeLineFeeds } = require("./util");
 module.exports = async function ({ resources, options /*, middlewareUtil */ }) {
 	const config = options?.configuration || {};
 	config.includes = config.includes || config.includePatterns;
-	config.excludes = config.excludes || config.excludePatterns;
+
+	// never transpile these default exclusion types
+	const defaultExcludes = [".png", "jped", ".jpg"];
+	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns);
 
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true });
 

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -25,7 +25,7 @@ module.exports = async function ({ resources, options /*, middlewareUtil */ }) {
 	config.includes = config.includes || config.includePatterns;
 
 	// never transpile these default exclusion types
-	const defaultExcludes = [".png", "jped", ".jpg"];
+	const defaultExcludes = [".png", "jpeg", ".jpg"];
 	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns);
 
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true });


### PR DESCRIPTION
I had trouble when filetypes like images are handled by the transpile middleware. 

So I figured it helps to always exclude them, since there shouldn't be any purpose to transpile images.