### PR TITLE
no replace for mime types images, videos in [ui5-middleware-stringreplace]

### DIFF
--- a/packages/ui5-middleware-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-middleware-stringreplacer/lib/stringreplacer.js
@@ -131,6 +131,14 @@ module.exports = function createMiddleware({ resources, options, middlewareUtil 
 			return;
 		}
 
+		// determine charset and content-type
+		const { contentType, charset } = middlewareUtil.getMimeInfo(resource.getPath());
+		// never replace strings in these mime types
+		if (contentType.includes("image") || contentType.includes("video")) {
+			next();
+			return;
+		}
+
 		if (handleRequest(pathname)) {
 			//isDebug && log.info(`handling ${pathname}`);
 
@@ -144,8 +152,6 @@ module.exports = function createMiddleware({ resources, options, middlewareUtil 
 				return;
 			}
 
-			// determine charset and content-type
-			const { contentType, charset } = middlewareUtil.getMimeInfo(resource.getPath());
 			if (!res.getHeader("Content-Type")) {
 				res.setHeader("Content-Type", contentType);
 			}


### PR DESCRIPTION
I had trouble with images when using the stringreplacer middleware.

It seems to change some encoding since the images were loaded with http status 200 but not displayed correctly.

An easy solution seems to exclude `content-type: image/*` and `content-type: video/*`.