### PR TITLE
fix(ui5-tooling-modules): revert to node-resolve v13 due to bundling issues

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -133,6 +133,16 @@ const that = (module.exports = {
 									defaultIsModuleExports: true,
 								}),
 								amdCustom(),
+								// between @rollup/plugin-node-resolve 13.3.0 and 14.0.0 something changed which leads
+								// to corrupt bundles for other projects - locally in the ecosystem it seems to work.
+								//
+								// The following change adopted the module resolution:
+								// => https://github.com/rollup/plugins/commit/886debae6b1d9f00c897c866a4c4c6975a5d47db
+								//
+								// TODO: check why the upgrade to version >= 14.0.0 isn't possible?
+								//       - verify with the following projects with ui5-tooling-modules@0.7.2:
+								//         => https://github.com/marianfoo/ui5-cc-excelUpload
+								//         => https://github.com/marianfoo/gh-following-to-rss
 								nodeResolve({
 									browser: true,
 									mainFields: ["module", "main"],

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -16,7 +16,7 @@
     "@buxlabs/amd-to-es6": "^0.16.3",
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/pluginutils": "^5.0.2",
     "@ui5/fs": "^2.0.6",
     "@ui5/logger": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,7 +397,7 @@ importers:
       '@buxlabs/amd-to-es6': ^0.16.3
       '@rollup/plugin-commonjs': ^24.0.0
       '@rollup/plugin-json': ^6.0.0
-      '@rollup/plugin-node-resolve': ^15.0.1
+      '@rollup/plugin-node-resolve': ^13.3.0
       '@rollup/pluginutils': ^5.0.2
       '@ui5/fs': ^2.0.6
       '@ui5/logger': ^2.0.1
@@ -412,7 +412,7 @@ importers:
       '@buxlabs/amd-to-es6': 0.16.3
       '@rollup/plugin-commonjs': 24.0.0_rollup@3.9.1
       '@rollup/plugin-json': 6.0.0_rollup@3.9.1
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.9.1
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@3.9.1
       '@rollup/pluginutils': 5.0.2_rollup@3.9.1
       '@ui5/fs': 2.0.6
       '@ui5/logger': 2.0.1
@@ -3890,21 +3890,30 @@ packages:
       rollup: 3.9.1
     dev: false
 
-  /@rollup/plugin-node-resolve/15.0.1_rollup@3.9.1:
-    resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
-    engines: {node: '>=14.0.0'}
+  /@rollup/plugin-node-resolve/13.3.0_rollup@3.9.1:
+    resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
+    engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^2.78.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
+      rollup: ^2.42.0
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.9.1
-      '@types/resolve': 1.20.2
+      '@rollup/pluginutils': 3.1.0_rollup@3.9.1
+      '@types/resolve': 1.17.1
       deepmerge: 4.2.2
       is-builtin-module: 3.2.0
       is-module: 1.0.0
       resolve: 1.22.1
+      rollup: 3.9.1
+    dev: false
+
+  /@rollup/pluginutils/3.1.0_rollup@3.9.1:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
       rollup: 3.9.1
     dev: false
 
@@ -4262,6 +4271,10 @@ packages:
     resolution: {integrity: sha512-RQul5wEfY7BjWm0sYY86cmUN/pcXWGyVxWX93DFFJvcrxax5zKlieLwA3T77xJGwNcZW0YW6CYG70p1m8xPFmA==}
     dev: true
 
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: false
+
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: false
@@ -4462,8 +4475,10 @@ packages:
       '@types/node': 18.11.18
     dev: true
 
-  /@types/resolve/1.20.2:
-    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+  /@types/resolve/1.17.1:
+    resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+    dependencies:
+      '@types/node': 18.11.18
     dev: false
 
   /@types/responselike/1.0.0:
@@ -8381,6 +8396,10 @@ packages:
   /estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  /estree-walker/1.0.1:
+    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: false
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}


### PR DESCRIPTION
With `@rollup/plugin-node-resolve` version >13 the tooling extension ui5-tooling-modules is producing issues in external projects, the reasoning isn't clear yet and still needs to be verified. 

Between @rollup/plugin-node-resolve 13.3.0 and 14.0.0 something changed which leads to corrupt bundles for other projects - locally in the ecosystem it seems to work. The following change adopted the module resolution:
https://github.com/rollup/plugins/commit/886debae6b1d9f00c897c866a4c4c6975a5d47db

Fixes #673