### PR TITLE
fix: implement determineRequiredDependencies

### DIFF
--- a/packages/ui5-task-cachebuster/lib/cachebuster.js
+++ b/packages/ui5-task-cachebuster/lib/cachebuster.js
@@ -96,3 +96,16 @@ module.exports = async function ({ workspace, /* dependencies,*/ taskUtil, optio
 			});
 	}
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-task-compileless/lib/compileLess.js
+++ b/packages/ui5-task-compileless/lib/compileLess.js
@@ -105,3 +105,16 @@ module.exports = async function ({ workspace, dependencies, options }) {
 		})
 	);
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-task-flatten-library/lib/flatten-library.js
+++ b/packages/ui5-task-flatten-library/lib/flatten-library.js
@@ -54,3 +54,16 @@ module.exports = async function ({ workspace, taskUtil, options }) {
 		})
 	);
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-task-i18ncheck/lib/i18ncheck.js
+++ b/packages/ui5-task-i18ncheck/lib/i18ncheck.js
@@ -83,3 +83,16 @@ module.exports = async function ({ workspace, dependencies, options }) {
 		log.error(`Error while reading content of i18n property files: ${e}`);
 	}
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-task-pwa-enabler/lib/pwaEnabler.js
+++ b/packages/ui5-task-pwa-enabler/lib/pwaEnabler.js
@@ -283,3 +283,16 @@ async function addManifest(manifestConfig) {
 		});
 	}
 }
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -93,3 +93,27 @@ module.exports = async function ({ workspace, dependencies, options, taskUtil })
 		log.verbose(`Created ${zipName} file.`);
 	});
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @param {object} parameters The parameters
+ * @param {Set} parameters.availableDependencies
+ *      Set containing the names of all direct dependencies of
+ *      the project currently being built.
+ * @param {object} parameters.options
+ *      Identical to the options given to the standard task function.
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function ({ availableDependencies, options }) {
+	const includeDependencies = options && options.configuration && options.configuration.includeDependencies;
+	if (includeDependencies) {
+		return availableDependencies;
+	} else {
+		return new Set();
+	}
+};

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -410,3 +410,20 @@ ${content}`;
 		}
 	}
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @param {object} parameters The parameters
+ * @param {Set} parameters.availableDependencies
+ *      Set containing the names of all direct dependencies of
+ *      the project currently being built.
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function ({ availableDependencies }) {
+	return availableDependencies;
+};

--- a/packages/ui5-tooling-stringreplace/lib/task.js
+++ b/packages/ui5-tooling-stringreplace/lib/task.js
@@ -62,3 +62,16 @@ module.exports = function ({ workspace, options }) {
 			log.error(`Failed to replace strings. Please check file patterns and string placeholders. Initial Error ${err}`);
 		});
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -178,3 +178,16 @@ module.exports = async function ({ workspace /*, dependencies*/, taskUtil, optio
 		}
 	}
 };
+
+/**
+ * Callback function to define the list of required dependencies
+ *
+ * @returns {Promise<Set>}
+ *      Promise resolving with a Set containing all dependencies
+ *      that should be made available to the task.
+ *      UI5 Tooling will ensure that those dependencies have been
+ *      built before executing the task.
+ */
+module.exports.determineRequiredDependencies = async function () {
+	return new Set();
+};


### PR DESCRIPTION
This PR implements the `determineRequiredDependencies` hook for all tasks. With that consumers of these tasks experience better performance when using UI5 Tooling V3.

For further info see https://sap.github.io/ui5-tooling/stable/pages/extensibility/CustomTasks/#required-dependencies