### PR TITLE
chore: proxy resources through approuter

### DIFF
--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -159,6 +159,8 @@ server:
         xsappJson: "xs-app.json"
         destinations:
           # check that the destination name (here: "backend") matches your router in xssppJson
+          - name: "app"
+            url: "http://localhost:1081/"
           - name: "backend"
             url: "https://services.odata.org/V4/(S(fdng4tbvlxgzpdtpfap2rqss))/TripPinServiceRW/"
           - name: "odatav2"

--- a/packages/ui5-app/xs-app.json
+++ b/packages/ui5-app/xs-app.json
@@ -3,6 +3,11 @@
   "welcomeFile": "/index.html",
   "routes": [
     {
+      "source": "^/app/resources/(.*)$",
+      "destination": "app",
+      "target": "/resources/$1"
+    },
+    {
       "source": "^/backend/(.*)$",
       "destination": "backend",
       "target": "$1"


### PR DESCRIPTION
To test the AppRouter proxy of UI5 resource from the UI5 server, run the AppRouter in the UI5 server via:

`pnpm dev`

Then open the following URL:
http://localhost:1091/app/resources/xlsx.js

This requests the xlsx module from the app running on the UI5 server through the AppRouter.

http://localhost:1091/app/resources/xlsx.js
=> 
http://localhost:1081/app/resources/xlsx.js
=> 
node_modules/xlsx/...
