### PR TITLE
feat(ui5-tooling-transpile): align and clean-up configuration options

### DIFF
--- a/packages/ui5-app-simple/ui5.yaml
+++ b/packages/ui5-app-simple/ui5.yaml
@@ -17,7 +17,6 @@ builder:
       configuration:
         debug: true
         removeConsoleStatements: true
-        transpileAsync: true
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:
@@ -30,7 +29,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
     - name: ui5-tooling-modules-middleware
       afterMiddleware: ui5-tooling-transpile-middleware
       configuration:

--- a/packages/ui5-app-ts/.babelrc
+++ b/packages/ui5-app-ts/.babelrc
@@ -1,0 +1,5 @@
+{
+	"ignore": ["**/*.d.ts"],
+	"presets": ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"],
+	"sourceMaps": true
+}

--- a/packages/ui5-app-ts/.babelrc.json
+++ b/packages/ui5-app-ts/.babelrc.json
@@ -1,5 +1,0 @@
-{
-  "ignore": ["**/*.d.ts"],
-  "presets": ["transform-ui5", "@babel/preset-typescript"],
-  "sourceMaps": true
-}

--- a/packages/ui5-app-ts/.browserslistrc
+++ b/packages/ui5-app-ts/.browserslistrc
@@ -1,0 +1,1 @@
+>0.5% and not dead

--- a/packages/ui5-app-ts/ui5.yaml
+++ b/packages/ui5-app-ts/ui5.yaml
@@ -22,8 +22,9 @@ builder:
         filePattern: .+(ts|tsx)
         transpileTypeScript: true
         generateDTS: true
-        transpileAsync: true
-        removeConsoleStatements: true
+        # using external .babelrc and .browserslistrc
+        #transformAsyncToPromise: true
+        #removeConsoleStatements: true
         #includes:
         #  - /controller/App
         #  - /controller/Main

--- a/packages/ui5-app-ts/webapp/controller/Main.controller.ts
+++ b/packages/ui5-app-ts/webapp/controller/Main.controller.ts
@@ -20,7 +20,7 @@ export default class Main extends Controller {
 			});
 	}
 
-	public downloadXLSX(): void {
+	public async downloadXLSX(): Promise<void> {
 		const book = utils.book_new();
 		const sheet = utils.json_to_sheet([
 			{
@@ -40,5 +40,6 @@ export default class Main extends Controller {
 		link.href = "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64," + data;
 		link.download = "speakers.xlsx";
 		link.click();
+		await Promise.resolve();
 	}
 }

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -17,7 +17,6 @@ builder:
       configuration:
         debug: true
         removeConsoleStatements: true
-        transpileAsync: true
         excludePatterns:
           - "resources/"
           - "lib/"
@@ -123,7 +122,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
         excludePatterns:
           - "lib/"
         #babelConfig:

--- a/packages/ui5-app/webapp/test/e2e/interaction.test.js
+++ b/packages/ui5-app/webapp/test/e2e/interaction.test.js
@@ -37,6 +37,7 @@ describe("interaction", function () {
 
 	it("should input date via popup + click", async function () {
 		const today = new Date();
+		today.setDate(1); // always use the first day of the month (avoid issues at month end!)
 		today.setMonth(today.getMonth() + 1); // we want next month
 		let month = `${today.getMonth() + 1}`.padStart(2, "0");
 		const year = today.getFullYear().toString();

--- a/packages/ui5-lib-ts/ui5.yaml
+++ b/packages/ui5-lib-ts/ui5.yaml
@@ -16,9 +16,8 @@ builder:
       configuration: &cfgTranspile
         debug: true
         filePattern: .+(ts|tsx)
-        #transpileDependencies: true
         transpileTypeScript: true
-        transpileAsync: true
+        #transformAsyncToPromise: true
         removeConsoleStatements: true
         includes:
           - /controller/App

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -1,6 +1,12 @@
-# UI5 Tooling Extensions for JS/TS transpiling
+# UI5 Tooling Extension for Transpiling JS/TS
 
 > **DISCLAIMER**: This is a community project and there is no official support for this package! Also the functionality may stop working at any time in future with newer versions of the UI5 tooling!
+
+The tooling extension provides a middleware and a task which transpiles JavaScript or TypeScript code to ES5 by using Babel. A default Babel configuration will be provided by the tooling extension unless a inline Babel configuration in the `ui5.yaml` or any Babel configuration as described at [Babel config files](https://babeljs.io/docs/en/config-files) will be provided.
+
+The middleware handles by default all requests to `.js`-files. For JavaScript transpilation the matching `.js`-file or for TypeScript the matching `.ts`-file will be transpiled on-the-fly via Babel. The transpiled JavaScript file will inline the `sourcemap`. Because of the `sourcemap`, setting breakpoints in the **original (ES6+ or TS) source** will cause the debugger to stop **when the corresponding transpiled source code is reached**.
+
+The task finally transpiles the relevant source files during the UI5 Tooling build process. In case of TypeScript is enabled, for libraries, the task also generates the `d.ts`-files. For applications, this option can be enabled on demand.
 
 ## Install
 
@@ -10,11 +16,8 @@ npm install ui5-tooling-transpile --save-dev
 
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
-- debug: `true|false`  
-  enable basic logging
-
-- verbose: `true|false`  
-  enable verbose logging
+- debug: `boolean`  
+  enable detailed logging (can be even more verbose by using the `--verbose` argument)
 
 - babelConfig: `Object`
   object to use as configuration for babel instead of the babel configuration from the file system (as described at [Babel config files](https://babeljs.io/docs/en/config-files)), or the default configuration defined in this middleware (just using the `@babel/preset-env`)
@@ -25,27 +28,38 @@ npm install ui5-tooling-transpile --save-dev
 - excludes: `String<Array>` (old alias: excludePatterns)
   array of paths your application to exclude from transpilation, e.g. 3-rd party libs in `/lib/`
 
+- transpileTypeScript: `boolean`
+  if enabled the tooling extensions handle TypeScript files instead of JavaScript files and enable other TypeScript related configuration options (such as `generateDts`) - although `babelConfig` is inlined or available as external Babel configuration file, this option needs to be enabled for TypeScript support but in such cases the [`@babel/preset-typescript`](https://babeljs.io/docs/babel-preset-typescript) needs to be included manually in the Babel configuration
+
 - filePattern: `String`
-  source file pattern for the resources to transpile, defaults to `.js`; to handle multiple file extensions you can specify the extensions like that: `.+(js|jsx)` or `.+(ts|tsx)`
+  source file pattern for the resources to transpile, defaults to `.js` and will be changed to `.ts` if `transpileTypeScript` is set to `true` (to handle multiple file extensions you can specify the extensions like that: `.+(js|jsx)` or `.+(ts|tsx)`)
 
-- transpileTypeScript: `true|false`
-  flag is only supported if no `filePattern` is provided; flag to set the value of `filePattern` to either `.ts` if true (transpiling TypeScript) or `.js` if false
+- generateDts: `boolean`
+  if enabled, the tooling extension will generate the d.ts files (for projects of type `library` this option is considered as `true` (enabled) by default and for other projects such as `application` this option is considered as `false` (disabled by default)
 
-- transpileDependencies: `true|false`
-  if option is enabled, the tooling extensions also transpile the TypeScript sources from the dependencies (*experimental feature*)
+- transpileDependencies: `boolean` (*experimental feature*)
+  if enabled, the middleware also transpile the TypeScript sources from the dependencies which is needed for development scenarios when referring to other TypeScript projects - the task ignores this configuration option
 
-- transpileAsync: `true|false`  
-  flag is only supported if no `babelConfig` is provided; transpiling `async/await` using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
+The following configuration options will only be taken into account if no inline babel configuration is maintained in the `ui5.yaml` as `babelConfig` or no external babel configuration exists in any configuration file as described in [Babels configuration section](https://babeljs.io/docs/configuration):
 
-- removeConsoleStatements: `true|false`  
-  flag is only supported if no `babelConfig` is provided; removes console statements while transpiling using [Babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-remove-console)
+- transpileTypeScript: `boolean`
+  includes the Babel presets [`@babel/preset-typescript`](https://babeljs.io/docs/babel-preset-typescript) and [`babel-preset-transform-ui5`](https://github.com/ui5-community/babel-plugin-transform-modules-ui5) into Babels preset configuration (if `transformModulesToUI5` is explicitely set to `false` the `babel-preset-transform-ui5` will not be added to the presets)
 
-- generateDts: `true|false`
-  if option is enabled, the tooling extension will generate the d.ts files (for projects of type `library` this option is considered as `true` (enabled) by default and for other projects such as `application` this option is considered as `false` (disabled) by default)
+- targetBrowsers: `String` (default: [`"defaults"`](https://browsersl.ist/#q=defaults))
+  first, the config will be looked up in the `package.json` `browserslist` property, second the config is searched in an external `.browserlistrc` file and if nothing has been found, the targeted browsers can be defined with the shared browser compatibility config from [browserslist](https://github.com/browserslist/browserslist) within this configuration option; to transpile back to ES5 you can i.e. use the browserslist configuration: `">0.2% and not dead"`
 
-## Usage
+- transformModulesToUI5: `boolean`
+  includes the [`babel-preset-transform-ui5`](https://github.com/ui5-community/babel-plugin-transform-modules-ui5) into Babels preset configuration (included implicitly when `transpileTypeScript` is set to `true` and this configuration option is omitted); this preset ensures that ES module `import`s will be transpiled to UI5 classic `sap.ui.define` or `sap.ui.require` calls and ES UI5 classes to classic UI5 classes using the `extend` API
 
-1. Define the dependency in `$yourapp/package.json`:
+- transformAsyncToPromise: `boolean` (old: `transpileAsync`)
+  includes the [`babel-plugin-transform-async-to-promises`](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises) into Babels presert configuration which transpiles `async/await` statements into `Promise`s; otherwise Babel uses `@babel/plugin-transform-regenerator` to transpile `async/await` with [`regenerator-runtime`](https://www.npmjs.com/package/regenerator-runtime) which isn't [CSP](https://en.wikipedia.org/wiki/Content_Security_Policy) compliant
+
+- removeConsoleStatements: `boolean`  
+  includes the [babel-plugin-transform-remove-console](https://babeljs.io/docs/en/babel-plugin-transform-remove-console) which removes the console statement from the transpiled code
+
+## Setup
+
+Define the dependency in `$yourapp/package.json`:
 
 ```json
 "devDependencies": {
@@ -62,9 +76,11 @@ npm install ui5-tooling-transpile --save-dev
 }
 ```
 
-> As the devDependencies are not recognized by the UI5 tooling, they need to be listed in the `ui5 > dependencies` array. In addition, once using the `ui5 > dependencies` array you need to list all UI5 tooling relevant dependencies.
+> :warning: As the devDependencies are not recognized by the UI5 tooling, they need to be listed in the `ui5 > dependencies` array. In addition, once using the `ui5 > dependencies` array you need to list all UI5 tooling relevant dependencies.
+>
+> :speech_balloon: For UI5 Tooling 3.0 the `ui5 > dependencies` section in the `package.json` isn't necessary anymore and can be removed.
 
-2. Configure it in `$yourapp/ui5.yaml`:
+### Configuration of `ui5.yaml` for JavaScript
 
 The configuration for the custom task:
 
@@ -76,7 +92,6 @@ builder:
     configuration:
       debug: true
       removeConsoleStatements: true
-      transpileAsync: true
       excludePatterns:
       - "lib/"
       - "another/dir/in/webapp"
@@ -92,22 +107,40 @@ server:
     afterMiddleware: compression
     configuration:
       debug: true
-      transpileAsync: true
+      removeConsoleStatements: true
       excludePatterns:
       - "lib/"
       - "another/dir/in/webapp"
       - "yet/another/dir"
 ```
 
-## How it works
+### Configuration of `ui5.yaml` for TypeScript
 
-The custom middleware handles all requests to `.js`-files. The file is then transpiled on-the-fly via `babel`, including dynamic creation of `sourcemap`s.
+The configuration for the custom task:
 
-The transpiled code and the `sourcemap` are subsequently delivered to the client instead of the original `.js/.ts`-file. Because of the `sourcemap`, setting breakpoints in the **original (ES6+) source** will cause the debugger to stop **when the corresponding transpiled source code is reached**.
+```yaml
+builder:
+  customTasks:
+  - name: ui5-tooling-transpile-task
+    afterTask: replaceVersion
+    configuration:
+      debug: true
+      transpileTypeScript: true
+      removeConsoleStatements: true
+```
 
-> `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately. Alternatively you can use the option `transpileAsync` which transpiles the `async/await` into `Promise`s.
+The configuration for the custom middleware:
 
-By default the tooling extensions can be used to transpile ES6+ JavaScript ot Typescript code to ES5 by using `babel`. By enabling the option `transpileTypeScript` the tooling extensions can be used to transpile your TypeScript sources into JavaScript.
+```yaml
+server:
+  customMiddleware:
+  - name: ui5-tooling-transpile-middleware
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      transpileTypeScript: true
+      removeConsoleStatements: true
+```
 
 ## How to obtain support
 

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -1,7 +1,8 @@
-const babel = require("@babel/core");
+/* eslint-disable jsdoc/check-param-names */
 const log = require("@ui5/logger").getLogger("server:custommiddleware:ui5-tooling-transpile");
 const parseurl = require("parseurl");
 const { createBabelConfig, normalizeLineFeeds } = require("./util");
+const babel = require("@babel/core");
 
 /**
  * Custom middleware to transpile resources to JavaScript modules.

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -1,8 +1,9 @@
+/* eslint-disable jsdoc/check-param-names */
 const log = require("@ui5/logger").getLogger("builder:customtask:ui5-tooling-transpile");
-const resourceFactory = require("@ui5/fs").resourceFactory;
-const { createBabelConfig, normalizeLineFeeds } = require("./util");
 const path = require("path");
 const fs = require("fs");
+const resourceFactory = require("@ui5/fs").resourceFactory;
+const { createBabelConfig, normalizeLineFeeds } = require("./util");
 const babel = require("@babel/core");
 
 /**

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -3,7 +3,13 @@ const log = require("@ui5/logger").getLogger("builder:customtask:ui5-tooling-tra
 const os = require("os");
 const path = require("path");
 const fs = require("fs");
+
+// https://babeljs.io/docs/
 const babel = require("@babel/core");
+
+// https://browsersl.ist/
+// https://github.com/browserslist/browserslist#queries
+const browserslist = require("browserslist");
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function multiply(fileName, exts) {
@@ -21,9 +27,8 @@ const PRJ_CFG_FILES = [...multiply("babel.config", [".json", ".js", ".cjs", ".mj
 const CFG_FILES = [...multiply(".babelrc", [".json", ".js", ".cjs", ".mjs"]), ".babelrc", "package.json"];
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-async function findBabelConfig(dir = ".") {
+async function findBabelConfig(dir) {
 	let configFile;
-	dir = path.resolve(process.cwd(), dir);
 
 	const findConfigFile = function (cfgFiles, dir) {
 		const configFile = cfgFiles.find((cfgFile) => {
@@ -73,6 +78,27 @@ module.exports = {
 	 * @returns {object} the babel plugins configuration
 	 */
 	createBabelConfig: async function createBabelConfig({ configuration, isMiddleware }) {
+		// Things to consider:
+		//   - middleware uses configs from app also for dependencies
+		//   - task uses .babelrc and .browserslistrc from app but config
+		//     in ui5.yaml from the different projects (since the config
+		//     files are loaded relative to process.cwd())
+
+		// for testing purposes we store the cwd of the initial function call
+		const cwd = process.cwd();
+
+		// report usage of configuration options in case ofan external
+		//  configuration file or inline Babel config is used
+		const warnAboutIgnoredConfig = function () {
+			["transpileAsync", "transformModulesToUI5", "transformAsyncToPromise", "removeConsoleStatements"].forEach(
+				(config) => {
+					if (configuration?.[config] !== undefined) {
+						log.warn(`Ignoring configuration option "${config}" due to external configuration!`);
+					}
+				}
+			);
+		};
+
 		// utility to add source maps support for middleware usage
 		const enhanceForSourceMaps = function (babelConfig) {
 			if (isMiddleware) {
@@ -84,14 +110,22 @@ module.exports = {
 		// the inline babel configuration in the ui5.yaml wins
 		let babelConfig = configuration?.babelConfig;
 		if (babelConfig) {
-			configuration?.debug && log.info(`Using inline Babel configuration from ui5.yaml...`);
+			if (configuration?.debug) {
+				log.info(`Using inline Babel configuration from ui5.yaml...`);
+				warnAboutIgnoredConfig();
+				log.verbose(`${JSON.stringify(babelConfig, null, 2)}`);
+			}
 			return enhanceForSourceMaps(babelConfig);
 		}
 
 		// lookup the babel config by file
-		let config = await findBabelConfig();
+		const config = await findBabelConfig(cwd);
 		if (config) {
-			configuration?.debug && log.info(`Using Babel configuration from ${config.configFile}...`);
+			if (configuration?.debug) {
+				log.info(`Using Babel configuration from ${config.configFile}...`);
+				warnAboutIgnoredConfig();
+				log.verbose(`${JSON.stringify(config.options, null, 2)}`);
+			}
 			return enhanceForSourceMaps(config.options);
 		}
 
@@ -99,33 +133,67 @@ module.exports = {
 		configuration?.debug && log.info(`Create Babel configuration based on ui5.yaml configuration options...`);
 
 		// create the babel configuration based on the ui5.yaml
-		babelConfig = { plugins: [], presets: [] };
+		babelConfig = { ignore: ["**/*.d.ts"], plugins: [], presets: [] };
 
-		// include additional plugins as configured in the ui5.yaml
-		if (configuration.removeConsoleStatements) {
+		// add the presets to enable transformation of ES modules to
+		// UI5 modules and ES classes to UI5 classes
+		const transformModulesToUI5 =
+			configuration?.transformModulesToUI5 !== undefined
+				? configuration?.transformModulesToUI5
+				: configuration?.transpileTypeScript;
+		if (transformModulesToUI5) {
+			babelConfig.presets.push("transform-ui5");
+		}
+
+		// add the preset to enable the transpiling of TS to JS
+		if (configuration?.transpileTypeScript) {
+			babelConfig.presets.push("@babel/preset-typescript");
+		}
+
+		// add the env preset and configure to support the
+		// last 2 browser versions (can be overruled via
+		// configuration option defined in the ui5.yaml
+		// using https://github.com/browserslist/browserslist)
+		const browserListConfigFile = browserslist.findConfig(cwd);
+		const envPreset = ["@babel/preset-env"];
+		if (browserListConfigFile) {
+			configuration?.debug && log.info(`Using external browserslist configuration...`);
+		} else {
+			configuration?.debug && log.info(`Using browserslist configuration from ui5.yaml...`);
+			envPreset.push({
+				targets: {
+					// future: consider to read the browserslist config from OpenUI5/SAPUI5?
+					browsers: configuration?.targetBrowsers || "defaults"
+				}
+			});
+		}
+		babelConfig.presets.push(envPreset);
+
+		// add plugin to remove console statements
+		if (configuration?.removeConsoleStatements) {
 			babelConfig.plugins.push("transform-remove-console");
 		}
-		if (configuration.transpileAsync) {
+
+		// add plugin to transform async statements to promises
+		// by default Babel uses the regenerator runtime but this
+		// requires bigger redundant inline code and it is also
+		// not CSP compliant => therefore the Promise is the better
+		// solution than using the regenerator runtime (by default)
+		const transformAsyncToPromise =
+			configuration?.transformAsyncToPromise !== undefined
+				? configuration?.transformAsyncToPromise
+				: configuration?.transpileAsync;
+		if (transformAsyncToPromise) {
 			babelConfig.plugins.push([
-				"babel-plugin-transform-async-to-promises",
+				"transform-async-to-promises",
 				{
 					inlineHelpers: true
 				}
 			]);
-		}
-		if (configuration.transpileTypeScript) {
-			// the TypeScript babel configuration
-			babelConfig.presets.push("transform-ui5", "@babel/preset-typescript");
-		} else {
-			// the default babel configuration
-			babelConfig.presets.push([
-				"@babel/preset-env",
-				{
-					targets: {
-						browsers: "last 2 versions, ie 10-11"
-					}
-				}
-			]);
+		} else if (configuration?.targetBrowsers === undefined) {
+			log.warn(
+				"Babel uses regenerator runtime to transpile async/await for older target browsers. As this is not CSP compliant consider the usage of transformAsyncToPromise to convert async/await to Promises!"
+			);
 		}
 
 		// in the middleware case we generate the sourcemaps inline for
@@ -137,6 +205,8 @@ module.exports = {
 			babelConfig.sourceMaps = true;
 		}
 
+		configuration?.debug && log.verbose(`${JSON.stringify(babelConfig, null, 2)}`);
+
 		return babelConfig;
 	},
 
@@ -144,7 +214,7 @@ module.exports = {
 	 * Normalizes the line feeds of the code to OS default
 	 *
 	 * @param {string} code the code
-	 * @returns the normalized code
+	 * @returns {string} the normalized code
 	 */
 	normalizeLineFeeds: function normalizeLineFeeds(code) {
 		// since Babel does not care about linefeeds, see here:

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -19,7 +19,24 @@
     "babel-plugin-transform-async-to-promises": "^0.8.18",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-transform-ui5": "^7.1.1",
+    "browserslist": "^4.21.5",
     "parseurl": "^1.3.3"
+  },
+  "devDependencies": {
+    "ava": "^5.1.1"
+  },
+  "scripts": {
+    "lint": "eslint lib",
+    "test": "ava --no-worker-threads"
+  },
+  "ava": {
+    "files": [
+      "test/**/*",
+      "!test/_ui5-app",
+      "!__assets__"
+    ],
+    "verbose": true,
+    "timeout": "20s"
   },
   "ui5": {
     "dependencies": []

--- a/packages/ui5-tooling-transpile/test/__assets__/external/.babelrc
+++ b/packages/ui5-tooling-transpile/test/__assets__/external/.babelrc
@@ -1,0 +1,5 @@
+{
+	"ignore": ["**/*.d.ts"],
+	"presets": ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"],
+	"sourceMaps": true
+}

--- a/packages/ui5-tooling-transpile/test/__assets__/external/.browserslistrc
+++ b/packages/ui5-tooling-transpile/test/__assets__/external/.browserslistrc
@@ -1,0 +1,1 @@
+>0.5% and not dead

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -1,0 +1,31 @@
+const test = require("ava");
+const path = require("path");
+
+const cwd = process.cwd();
+test.beforeEach(async (/*t*/) => {
+	/* nothing to do */
+});
+test.afterEach.always(async (/*t*/) => {
+	process.chdir(cwd);
+});
+
+test("simple creation of babel config", async (t) => {
+	const util = require("../lib/util");
+	const config = await util.createBabelConfig({
+		configuration: {
+			debug: true
+		}
+	});
+	t.true(config !== undefined);
+});
+
+test("usage of external babel config", async (t) => {
+	const util = require("../lib/util");
+	process.chdir(path.join(__dirname, "__assets__/external"));
+	const config = await util.createBabelConfig({
+		configuration: {
+			debug: true
+		}
+	});
+	t.true(config !== undefined);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,9 +505,11 @@ importers:
       '@babel/preset-typescript': ^7.21.0
       '@ui5/fs': ^2.0.6
       '@ui5/logger': ^2.0.1
+      ava: ^5.1.1
       babel-plugin-transform-async-to-promises: ^0.8.18
       babel-plugin-transform-remove-console: ^6.9.4
       babel-preset-transform-ui5: ^7.1.1
+      browserslist: ^4.21.5
       parseurl: ^1.3.3
     dependencies:
       '@babel/core': 7.21.3
@@ -519,7 +521,10 @@ importers:
       babel-plugin-transform-async-to-promises: 0.8.18
       babel-plugin-transform-remove-console: 6.9.4
       babel-preset-transform-ui5: 7.1.1
+      browserslist: 4.21.5
       parseurl: 1.3.3
+    devDependencies:
+      ava: 5.2.0
 
 packages:
 


### PR DESCRIPTION
Cleanup of configuration options and properly describe their meaning and their usage. Explain the usage of external configuration for Babel and the browserslist.

Defaults the `@babel/preset-env` to use the `defaults` setting from browserslist which equals `>0.5%, last 2 versions, Firefox ESR, not dead` as the target to transpile the classes to.

Renamed the `transpileAsync` to `transformAsyncToPromises` to clarify that this transpiles `async/await` to `Promises` instead of using the regenerator runtime which is the default of Babel. In case of transpiling `async/await` with an older browserslist configuration this option is recommended to be enabled to avoid CSP compliance issues with the regenerator runtime.