### PR TITLE
fix(ui5-tooling-transpile): correct order of presets

### DIFF
--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -135,20 +135,17 @@ module.exports = {
 		// create the babel configuration based on the ui5.yaml
 		babelConfig = { ignore: ["**/*.d.ts"], plugins: [], presets: [] };
 
-		// add the presets to enable transformation of ES modules to
-		// UI5 modules and ES classes to UI5 classes
-		const transformModulesToUI5 =
-			configuration?.transformModulesToUI5 !== undefined
-				? configuration?.transformModulesToUI5
-				: configuration?.transpileTypeScript;
-		if (transformModulesToUI5) {
-			babelConfig.presets.push("transform-ui5");
-		}
-
-		// add the preset to enable the transpiling of TS to JS
-		if (configuration?.transpileTypeScript) {
-			babelConfig.presets.push("@babel/preset-typescript");
-		}
+		// order of the presets is important: last preset is applied first
+		// which means the .babelrc config should look like that:
+		//
+		//  "presets": [
+		//      "@babel/preset-env",        // applied 3rd
+		//      "transform-ui5",            // applied 2nd
+		//      "@babel/preset-typescript"  // applied 1st
+		//  ],
+		//
+		// so, first transpile typescript, then ES modules/classes to UI5
+		// and finally transpile the rest to the target browser env.
 
 		// add the env preset and configure to support the
 		// last 2 browser versions (can be overruled via
@@ -173,6 +170,21 @@ module.exports = {
 			});
 		}
 		babelConfig.presets.push(envPreset);
+
+		// add the presets to enable transformation of ES modules to
+		// UI5 modules and ES classes to UI5 classes
+		const transformModulesToUI5 =
+			configuration?.transformModulesToUI5 !== undefined
+				? configuration?.transformModulesToUI5
+				: configuration?.transpileTypeScript;
+		if (transformModulesToUI5) {
+			babelConfig.presets.push("transform-ui5");
+		}
+
+		// add the preset to enable the transpiling of TS to JS
+		if (configuration?.transpileTypeScript) {
+			babelConfig.presets.push("@babel/preset-typescript");
+		}
 
 		// add plugin to remove console statements
 		if (configuration?.removeConsoleStatements) {

--- a/showcases/ui5-tsapp/.babelrc
+++ b/showcases/ui5-tsapp/.babelrc
@@ -1,5 +1,17 @@
 {
 	"ignore": ["**/*.d.ts"],
-	"presets": ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"],
+	"presets": [
+		"@babel/preset-env", // applied 3rd
+		"transform-ui5", // applied 2nd
+		"@babel/preset-typescript" // applied 1st
+	],
+	"plugins": [
+		[
+			"transform-async-to-promises",
+			{
+				"inlineHelpers": true
+			}
+		]
+	],
 	"sourceMaps": true
 }

--- a/showcases/ui5-tsapp/.browserslistrc
+++ b/showcases/ui5-tsapp/.browserslistrc
@@ -1,1 +1,1 @@
-defaults
+>0.2% and not dead


### PR DESCRIPTION
order of the presets is important: last preset is applied first which means the .babelrc config should look like that:

```
  "presets": [
     "@babel/preset-env",        // applied 3rd
     "transform-ui5",            // applied 2nd
     "@babel/preset-typescript"  // applied 1st
 ],
```

so, first transpile typescript, then ES modules/classes to UI5 and finally transpile the rest to the target browser env.