### PR TITLE
fix(ui5-tooling-transpile): use proper fs path for resource tranform

### DIFF
--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsdoc/check-param-names */
 const log = require("@ui5/logger").getLogger("server:custommiddleware:ui5-tooling-transpile");
 const parseurl = require("parseurl");
-const { createBabelConfig, normalizeLineFeeds } = require("./util");
+const { createBabelConfig, normalizeLineFeeds, determineResourceFSPath } = require("./util");
 const babel = require("@babel/core");
 
 /**
@@ -61,7 +61,7 @@ module.exports = async function ({ resources, options, middlewareUtil }) {
 				const result = await babel.transformAsync(
 					source,
 					Object.assign({}, babelConfig, {
-						filename: resource.getPath() // necessary for source map <-> source assoc
+						filename: determineResourceFSPath(resource) // necessary for source map <-> source assoc
 					})
 				);
 

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -3,7 +3,7 @@ const log = require("@ui5/logger").getLogger("builder:customtask:ui5-tooling-tra
 const path = require("path");
 const fs = require("fs");
 const resourceFactory = require("@ui5/fs").resourceFactory;
-const { createBabelConfig, normalizeLineFeeds } = require("./util");
+const { createBabelConfig, normalizeLineFeeds, determineResourceFSPath } = require("./util");
 const babel = require("@babel/core");
 
 /**
@@ -66,7 +66,7 @@ module.exports = async function ({ workspace /*, dependencies*/, taskUtil, optio
 					const result = await babel.transformAsync(
 						source,
 						Object.assign({}, babelConfig, {
-							filename: resourcePath // necessary for source map <-> source assoc
+							filename: determineResourceFSPath(resource) // necessary for source map <-> source assoc
 						})
 					);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5334,7 +5334,7 @@ packages:
   /axios@1.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@4.3.2)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8497,6 +8497,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -9330,7 +9331,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@4.3.2)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
To benefit from out of the box support of other Babel plugins the `filename` needs to point to the proper `fsPath` of the resource. In Tooling 3.0 this works out-of-the-box and for 2.0 we are using a workaround (which will be removed with the full upgrade to UI5 Tooling 3.0).