### PR TITLE
feat(ui5-tooling-transpile): rework to avoid configurations for default usage

### DIFF
--- a/packages/karma-ui5-transpile/README.md
+++ b/packages/karma-ui5-transpile/README.md
@@ -4,7 +4,7 @@ The `karma-ui5-transpile` preprocessor transpiles code of UI5 projects having a 
 
 ## Installation
 
-The plugin requires [`karma`](https://www.npmjs.com/package/karma) `>=6.4.1`, and [ui5-tooling-transpile](https://www.npmjs.com/package/ui5-tooling-transpile) `>=0.6.0`. You can install the required dependencies with the following command: 
+The plugin requires [`karma`](https://www.npmjs.com/package/karma) `>=6.4.1`, and [ui5-tooling-transpile](https://www.npmjs.com/package/ui5-tooling-transpile) `>=0.7.0`. You can install the required dependencies with the following command:
 
 ```sh
 npm install --save-dev karma ui5-tooling-transpile karma-ui5-transpile

--- a/packages/karma-ui5-transpile/lib/index.js
+++ b/packages/karma-ui5-transpile/lib/index.js
@@ -4,7 +4,7 @@ const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
 
-const { createBabelConfig, transform } = require("ui5-tooling-transpile/lib/util");
+const { createConfiguration, createBabelConfig, transform } = require("ui5-tooling-transpile/lib/util");
 
 /**
  * This Karma preprocessor is used to transpile code respecting the
@@ -41,7 +41,7 @@ function createPreprocessor(config, logger) {
 	// determine the ui5-tooling-transpile-task configuration
 	const customTasks = configs?.[0]?.builder?.customTasks;
 	const transpileTask = customTasks?.find((customTask) => customTask.name === "ui5-tooling-transpile-task");
-	const configuration = transpileTask?.configuration;
+	const configuration = createConfiguration(transpileTask?.configuration);
 
 	// create the Babel configuration using the ui5-tooling-tranpile-task util
 	const babelConfigCreated = createBabelConfig({ configuration, isMiddleware: false }).then((babelOptions) => {

--- a/packages/karma-ui5-transpile/package.json
+++ b/packages/karma-ui5-transpile/package.json
@@ -24,7 +24,7 @@
   ],
   "peerDependencies": {
     "karma": ">=6.4.1",
-    "ui5-tooling-transpile": ">=0.5.1"
+    "ui5-tooling-transpile": ">=0.7.0"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -28,25 +28,25 @@ npm install ui5-tooling-transpile --save-dev
 - excludes: `String<Array>` (old alias: excludePatterns)
   array of paths your application to exclude from transpilation, e.g. 3-rd party libs in `/lib/`
 
-- transpileTypeScript: `boolean`
-  if enabled the tooling extensions handle TypeScript files instead of JavaScript files and enable other TypeScript related configuration options (such as `generateDts`) - although `babelConfig` is inlined or available as external Babel configuration file, this option needs to be enabled for TypeScript support but in such cases the [`@babel/preset-typescript`](https://babeljs.io/docs/babel-preset-typescript) needs to be included manually in the Babel configuration
-
 - filePattern: `String`
-  source file pattern for the resources to transpile, defaults to `.js` and will be changed to `.ts` if `transpileTypeScript` is set to `true` (to handle multiple file extensions you can specify the extensions like that: `.+(js|jsx)` or `.+(ts|tsx)`)
+  source file pattern for the resources to transpile, defaults to `.js` and will be changed to `.ts` if a `tsconfig.json` file is located in the project or by explicitly setting the configuration option transformTypeScript to `true` (multiple file extensions can be handled by specifying mutliple extensions using the glob syntax, e.g.: `.+(js|jsx)` or `.+(ts|tsx)`)
+
+- transformTypeScript: `boolean` (old alias: transpileTypeScript)
+  if enabled, the tooling extension transforms TypeScript sources; the default value is derived from the existence of a `tsconfig.json` in the root folder of the project - if the file exists the configuration option is `true` otherwise `false`; setting this configuration option overrules the automatic determination
 
 - generateDts: `boolean`
-  if enabled, the tooling extension will generate the d.ts files (for projects of type `library` this option is considered as `true` (enabled) by default and for other projects such as `application` this option is considered as `false` (disabled by default)
+  if enabled, the tooling extension will generate type definitions (`.d.ts`) files; by default for projects of type `library` this option is considered as `true` and for other projects such as `application` this option is considered as `false` by default (is only relevant in case of transformTypeScript is `true`)
 
 - transpileDependencies: `boolean` (*experimental feature*)
-  if enabled, the middleware also transpile the TypeScript sources from the dependencies which is needed for development scenarios when referring to other TypeScript projects - the task ignores this configuration option
+  if enabled, the middleware also transpile the sources from the dependencies which is needed for development scenarios when referring to other projects (this configuration option is ignored by the task)
 
 The following configuration options will only be taken into account if no inline babel configuration is maintained in the `ui5.yaml` as `babelConfig` or no external babel configuration exists in any configuration file as described in [Babels configuration section](https://babeljs.io/docs/configuration):
 
-- transpileTypeScript: `boolean`
-  includes the Babel presets [`@babel/preset-typescript`](https://babeljs.io/docs/babel-preset-typescript) and [`babel-preset-transform-ui5`](https://github.com/ui5-community/babel-plugin-transform-modules-ui5) into Babels preset configuration (if `transformModulesToUI5` is explicitely set to `false` the `babel-preset-transform-ui5` will not be added to the presets)
-
 - targetBrowsers: `String` (default: [`"defaults"`](https://browsersl.ist/#q=defaults))
   first, the config will be looked up in the `package.json` `browserslist` property, second the config is searched in an external `.browserlistrc` file and if nothing has been found, the targeted browsers can be defined with the shared browser compatibility config from [browserslist](https://github.com/browserslist/browserslist) within this configuration option; to transpile back to ES5 you can i.e. use the browserslist configuration: `">0.2% and not dead"`
+
+- transformTypeScript: `boolean` (old: `transpileTypeScript`)
+  includes the Babel presets [`@babel/preset-typescript`](https://babeljs.io/docs/babel-preset-typescript) and [`babel-preset-transform-ui5`](https://github.com/ui5-community/babel-plugin-transform-modules-ui5) into Babels preset configuration (if `transformModulesToUI5` is explicitely set to `false` the `babel-preset-transform-ui5` will not be added to the presets)
 
 - transformModulesToUI5: `boolean`
   includes the [`babel-preset-transform-ui5`](https://github.com/ui5-community/babel-plugin-transform-modules-ui5) into Babels preset configuration (included implicitly when `transpileTypeScript` is set to `true` and this configuration option is omitted); this preset ensures that ES module `import`s will be transpiled to UI5 classic `sap.ui.define` or `sap.ui.require` calls and ES UI5 classes to classic UI5 classes using the `extend` API
@@ -57,7 +57,11 @@ The following configuration options will only be taken into account if no inline
 - removeConsoleStatements: `boolean`  
   includes the [babel-plugin-transform-remove-console](https://babeljs.io/docs/en/babel-plugin-transform-remove-console) which removes the console statement from the transpiled code
 
-## Setup
+> :warning: When using `builder` > `settings` > `includeDependency` to add references to other projects (libraries, modules, ...) which also require a Babel transformation, the Babel configuration lookup or the `tsconfig.json` lookup will take place relative to the current working directory. If you want to ensure to use project local configurations in this case, inline the Babel configuration `babelConfig` and the `transformTypeScript` (with `true`=TS or `false`=JS) switch explicitly in the `ui5.yaml`.
+
+## Usage
+
+By default, the tooling extension is configuration free and works out-of-the-box. The programming language is derived from the existence of the `tsconfig.json` in the project root.
 
 Define the dependency in `$yourapp/package.json`:
 
@@ -80,9 +84,27 @@ Define the dependency in `$yourapp/package.json`:
 >
 > :speech_balloon: For UI5 Tooling 3.0 the `ui5 > dependencies` section in the `package.json` isn't necessary anymore and can be removed.
 
-### Configuration of `ui5.yaml` for JavaScript
+Register the task and middleware in your `$yourapp/ui5.yaml`:
 
-The configuration for the custom task:
+```yaml
+builder:
+  customTasks:
+  - name: ui5-tooling-transpile-task
+    afterTask: replaceVersion
+[...]
+server:
+  customMiddleware:
+  - name: ui5-tooling-transpile-middleware
+    afterMiddleware: compression
+```
+
+That's it. Now you can transpile your sources with the help of Babel.
+
+### Advanced Options
+
+Configuration options are added in the configuration section. For JavaScript projects, ensure that no `tsconfig.json` is present in the project root. This would turn the tooling extension into the TypeScript mode.
+
+Example configuration for a JavaScript project without external Babel configuration which removes console statements and exclude specific paths:
 
 ```yaml
 builder:
@@ -96,11 +118,7 @@ builder:
       - "lib/"
       - "another/dir/in/webapp"
       - "yet/another/dir"
-```
-
-The configuration for the custom middleware:
-
-```yaml
+[...]
 server:
   customMiddleware:
   - name: ui5-tooling-transpile-middleware
@@ -114,9 +132,7 @@ server:
       - "yet/another/dir"
 ```
 
-### Configuration of `ui5.yaml` for TypeScript
-
-The configuration for the custom task:
+Example configuration for a TypeScript project without external Babel configuration which transforms `async/await` to `Promises` and removes console statements:
 
 ```yaml
 builder:
@@ -125,30 +141,26 @@ builder:
     afterTask: replaceVersion
     configuration:
       debug: true
-      transpileTypeScript: true
+      transformAsyncToPromise: true
       removeConsoleStatements: true
-```
-
-The configuration for the custom middleware:
-
-```yaml
+[...]
 server:
   customMiddleware:
   - name: ui5-tooling-transpile-middleware
     afterMiddleware: compression
     configuration:
       debug: true
-      transpileTypeScript: true
+      transformAsyncToPromise: true
       removeConsoleStatements: true
 ```
 
-## How to obtain support
+## Support
 
 Please use the GitHub bug tracking system to post questions, bug reports or to create pull requests.
 
 ## Contributing
 
-Any type of contribution (code contributions, pull requests, issues) to this showcase will be equally appreciated.
+Any type of contribution (code contributions, pull requests, issues) to this set of tooling extensions will be equally appreciated.
 
 ## License
 

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -1,7 +1,13 @@
 /* eslint-disable jsdoc/check-param-names */
 const log = require("@ui5/logger").getLogger("server:custommiddleware:ui5-tooling-transpile");
 const parseurl = require("parseurl");
-const { createBabelConfig, normalizeLineFeeds, determineResourceFSPath, transformAsync } = require("./util");
+const {
+	createConfiguration,
+	createBabelConfig,
+	normalizeLineFeeds,
+	determineResourceFSPath,
+	transformAsync
+} = require("./util");
 
 /**
  * Custom middleware to transpile resources to JavaScript modules.
@@ -21,19 +27,8 @@ const { createBabelConfig, normalizeLineFeeds, determineResourceFSPath, transfor
  * @returns {function} Middleware function to use
  */
 module.exports = async function ({ resources, options, middlewareUtil }) {
-	const config = options?.configuration || {};
-	config.includes = config.includes || config.includePatterns;
-
-	// never transpile these default exclusion types
-	const defaultExcludes = [".png", ".jpeg", ".jpg"];
-	config.excludes = defaultExcludes.concat(config.excludes || config.excludePatterns || []);
-
+	const config = createConfiguration(options?.configuration || {});
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true });
-
-	let filePatternConfig = config.filePattern; // .+(ts|tsx)
-	if (!filePatternConfig) {
-		filePatternConfig = config.transpileTypeScript ? ".ts" : ".js";
-	}
 
 	const reader = config.transpileDependencies ? resources.all : resources.rootProject;
 
@@ -43,7 +38,7 @@ module.exports = async function ({ resources, options, middlewareUtil }) {
 			(pathname.endsWith(".js") && !(config.excludes || []).some((pattern) => pathname.includes(pattern))) ||
 			(config.includes || []).some((pattern) => pathname.includes(pattern))
 		) {
-			const pathWithFilePattern = pathname.replace(".js", filePatternConfig);
+			const pathWithFilePattern = pathname.replace(".js", config.filePattern);
 			config.debug && log.verbose(`Lookup resource ${pathWithFilePattern}`);
 
 			const matchedResources = await reader.byGlob(pathWithFilePattern);

--- a/showcases/ui5-app-simple/ui5.yaml
+++ b/showcases/ui5-app-simple/ui5.yaml
@@ -34,6 +34,7 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
+        removeConsoleStatements: true
     - name: ui5-tooling-modules-middleware
       afterMiddleware: ui5-tooling-transpile-middleware
       configuration:

--- a/showcases/ui5-app-simple/webapp/controller/App.controller.js
+++ b/showcases/ui5-app-simple/webapp/controller/App.controller.js
@@ -2,7 +2,8 @@ sap.ui.define(["ui5/ecosystem/demo/simpleapp/controller/BaseController"], (Contr
 	"use strict";
 	return Controller.extend("ui5.ecosystem.demo.simpleapp.controller.App", {
 		onInit() {
-			/* do nothing */
+			// next line should be removed!
+			console.log(`App#onInit`);
 		},
 	});
 });

--- a/showcases/ui5-app-simple/webapp/controller/Main.controller.js
+++ b/showcases/ui5-app-simple/webapp/controller/Main.controller.js
@@ -3,6 +3,8 @@ sap.ui.define(["ui5/ecosystem/demo/simpleapp/controller/BaseController", "sap/m/
 
 	return Controller.extend("ui5.ecosystem.demo.simpleapp.controller.Main", {
 		onBoo() {
+			// next line should be removed!
+			console.log(`👻`);
 			MessageToast.show(`👻`);
 		},
 	});

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -12,27 +12,6 @@ framework:
     - name: themelib_sap_horizon
 builder:
   customTasks:
-    - name: ui5-tooling-transpile-task
-      afterTask: replaceVersion
-      configuration:
-        debug: true
-        removeConsoleStatements: true
-        excludePatterns:
-          - "resources/"
-          - "lib/"
-          - "test/"
-        #babelConfig: &babelConfig
-        #  plugins:
-        #    - - "@babel/plugin-transform-computed-properties"
-        #      - loose: true
-        #    - - "@babel/plugin-transform-for-of"
-        #      - assumeArray: true
-        #    - - "babel-plugin-transform-async-to-promises"
-        #      - inlineHelpers: true
-        #  presets:
-        #    - - "@babel/preset-env"
-        #      - targets:
-        #          browsers: "last 2 versions, ie 10-11"
     - name: ui5-tooling-stringreplace-task
       afterTask: replaceVersion
       configuration:
@@ -62,8 +41,31 @@ builder:
           - "yet/another/dir"
     - name: ui5-task-i18ncheck
       afterTask: replaceVersion
-    - name: ui5-tooling-modules-task
+    - name: ui5-tooling-transpile-task
       afterTask: replaceVersion
+      configuration: &cfgTranspile
+        debug: true
+        transformAsyncToPromise: true
+        removeConsoleStatements: true
+        targetBrowsers: ">0.2% and not dead"
+        excludePatterns:
+          - "resources/"
+          - "lib/"
+          - "test/"
+        #babelConfig: &babelConfig
+        #  plugins:
+        #    - - "@babel/plugin-transform-computed-properties"
+        #      - loose: true
+        #    - - "@babel/plugin-transform-for-of"
+        #      - assumeArray: true
+        #    - - "babel-plugin-transform-async-to-promises"
+        #      - inlineHelpers: true
+        #  presets:
+        #    - - "@babel/preset-env"
+        #      - targets:
+        #          browsers: "last 2 versions, ie 10-11"
+    - name: ui5-tooling-modules-task
+      afterTask: ui5-tooling-transpile-task
       configuration:
         prependPathMappings: true
         addToNamespace: true
@@ -118,15 +120,6 @@ server:
         baseUri: "https://sdk.openui5.org/"
         limit: "5mb"
         removeETag: true
-    - name: ui5-tooling-transpile-middleware
-      afterMiddleware: compression
-      configuration:
-        debug: true
-        excludePatterns:
-          - "lib/"
-        #babelConfig:
-        #  <<: *babelConfig
-        #  sourceMaps: "inline"
     - name: ui5-tooling-stringreplace-middleware
       afterMiddleware: compression
       configuration:
@@ -168,8 +161,12 @@ server:
       configuration:
         debug: true
         jarRootPath: "META-INF/"
-    - name: ui5-tooling-modules-middleware
+    - name: ui5-tooling-transpile-middleware
       afterMiddleware: compression
+      configuration:
+        <<: *cfgTranspile
+    - name: ui5-tooling-modules-middleware
+      afterMiddleware: ui5-tooling-transpile-middleware
       configuration:
         #skipCache: true
     - name: ui5-middleware-livecompileless

--- a/showcases/ui5-tsapp-simple/ui5.yaml
+++ b/showcases/ui5-tsapp-simple/ui5.yaml
@@ -14,10 +14,8 @@ builder:
   customTasks:
     - name: ui5-tooling-transpile-task
       afterTask: replaceVersion
-      configuration: &cfgTranspile
+      configuration:
         debug: true
-        transpileTypeScript: true
-        generateDTS: true
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:
@@ -28,8 +26,7 @@ server:
     - name: ui5-tooling-transpile-middleware
       afterMiddleware: compression
       configuration:
-        <<: *cfgTranspile
-        transpileDependencies: true
+        debug: true
     - name: ui5-tooling-modules-middleware
       afterMiddleware: ui5-tooling-transpile-middleware
       configuration:

--- a/showcases/ui5-tsapp/.eslintrc.js
+++ b/showcases/ui5-tsapp/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
 		node: true,
 	},
 	extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/recommended-requiring-type-checking"],
-	ignorePatterns: [".eslintignore.js", "**/*.js"],
+	ignorePatterns: ["**/*.js"],
 	parser: "@typescript-eslint/parser",
 	parserOptions: {
 		project: ["./tsconfig.json"],

--- a/showcases/ui5-tsapp/ui5.yaml
+++ b/showcases/ui5-tsapp/ui5.yaml
@@ -20,16 +20,7 @@ builder:
       configuration: &cfgTranspile
         debug: true
         filePattern: .+(ts|tsx)
-        transpileTypeScript: true
         generateDTS: true
-        # using external .babelrc and .browserslistrc
-        #transformAsyncToPromise: true
-        #removeConsoleStatements: true
-        #includes:
-        #  - /controller/App
-        #  - /controller/Main
-        #excludes:
-        #  - /controller/
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:

--- a/showcases/ui5-tslib/ui5.yaml
+++ b/showcases/ui5-tslib/ui5.yaml
@@ -15,18 +15,10 @@ builder:
       afterTask: replaceVersion
       configuration: &cfgTranspile
         debug: true
-        filePattern: .+(ts|tsx)
-        transpileTypeScript: true
-        #transformAsyncToPromise: true
-        removeConsoleStatements: true
-        includes:
-          - /controller/App
-        excludes:
-          - /controller/
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:
-        prependPathMappings: false
+        debug: true
         addToNamespace: true
 server:
   customMiddleware:


### PR DESCRIPTION
The programming language is now derived by the existence of the tsconfig.json which means the project is a TypeScript project and if no tsconfig.json is present the tooling extension assumes the project to be of type JavaScript.

The decision of the tooling extension can be overruled by providing config options in the ui5.yaml. E.g. the TypeScript transpiling can be enabled by setting the transformTypeScript option to true. Setting it to false will overrule the existence of tsconfig.json and just transpile JavaScript.

The config option transpileTypeScript renamed to transformTypeScript.

Adopted the tooling extension task and middleware as well as the Karma preprocessor to use the getConfiguration function to normalize the configuration.