### PR TITLE
feat(ui5-task-zipper): allow to specify the deps to include

### DIFF
--- a/packages/ui5-task-zipper/README.md
+++ b/packages/ui5-task-zipper/README.md
@@ -21,10 +21,10 @@ Default value: `<app-id.zip>`
 List of files to be included in the ZIP archive relative to the project root or Map of of files to be included in the ZIP archive relative to the project root and target path in the ZIP archive.
 
 - onlyZip: `true|false`
-Set this to true if you also want to generate the unzipped resources in the `dist` folder. Otherwise, it will only create the zipped archive.
+Set this to `true` if you also want to generate the unzipped resources in the `dist` folder. Otherwise, it will only create the zipped archive.
 
-- includeDependencies: `true|false`
-Set this to true if you also want to include the dependencies (UI5 libraries) in the zip archive. Otherwise, it will only include the workspace files (controller, views, etc).
+- includeDependencies: `true|false` or `String<Array>`
+Set this to `true` if you also want to include the dependencies (UI5 libraries) in the zip archive. Otherwise, it will only include the workspace files (controller, views, etc). In order to select only specific dependencies to be included in the final zip you just need to specify the list of dependencies (value of `ui5.yaml`: `metadata > name`).
 
 ## Usage
 
@@ -47,7 +47,7 @@ Set this to true if you also want to include the dependencies (UI5 libraries) in
 
 > As the devDependencies are not recognized by the UI5 tooling, they need to be listed in the `ui5 > dependencies` array. In addition, once using the `ui5 > dependencies` array you need to list all UI5 tooling relevant dependencies.
 
-2. configure it in `$yourapp/ui5.yaml`:
+2. configure it in `$yourapp/ui5.yaml` for UI5 tooling 2.x:
 
 ```yaml
 builder:
@@ -59,7 +59,8 @@ builder:
       additionalFiles:
       - xs-app.json
 ```
-or
+
+or for UI5 tooling 3.x:
 
 ```yaml
 builder:
@@ -75,6 +76,21 @@ builder:
 ```
 
 > :warning: For UI5 Tooling V3 the configuration `afterTask: uglify` needs to be adopted to `afterTask: generateVersionInfo`. This works for the UI5 Tooling V2 and V3.
+
+### Select the dependencies to include
+
+With the configuration option `includeDependencies` you can also specifiy a list of dependencies to be included in the zip file. To do so, specify a list of dependencies using their `ui5.yaml`: `metadata > name` property:
+
+```yaml
+builder:
+  customTasks:
+  - name: ui5-task-zipper
+    afterTask: generateVersionInfo
+    configuration:
+      includeDependencies:
+      - sap.ui.table
+      - ui5.ecosystem.demo.lib
+```
 
 ## How it works
 

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app-simple/ui5.includeSomeDeps.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app-simple/ui5.includeSomeDeps.yaml
@@ -17,6 +17,7 @@ builder:
       configuration:
         debug: true
         removeConsoleStatements: true
+        transpileAsync: true
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:
@@ -26,6 +27,8 @@ builder:
       afterTask: generateVersionInfo
       configuration:
         archiveName: simpleapp
+        includeDependencies:
+          - sap.ui.layout
 # https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
 server:
   customMiddleware:
@@ -33,7 +36,7 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        removeConsoleStatements: true
+        transpileAsync: true
     - name: ui5-tooling-modules-middleware
       afterMiddleware: ui5-tooling-transpile-middleware
       configuration:

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.includeSomeDeps.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.includeSomeDeps.yaml
@@ -1,0 +1,19 @@
+specVersion: "2.5"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.112.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: uglify
+      configuration:
+        includeDependencies:
+          - sap.ui.layout

--- a/packages/ui5-task-zipper/test/zipper.test.js
+++ b/packages/ui5-task-zipper/test/zipper.test.js
@@ -167,3 +167,44 @@ test("shims are included", async (t) => {
   ]);
   t.true(allDepsFound.every((dep) => dep === true));
 });
+
+test("Some UI5 lib dependencies are included (V2)", async (t) => {
+  const ui5 = {
+    yaml: path.resolve("./test/__assets__/ui5-app/ui5.includeSomeDeps.yaml"),
+  };
+  spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+    stdio: "inherit", // > don't include stdout in test output,
+    shell: true,
+    cwd: path.resolve(__dirname, "../../../showcases/ui5-app"),
+  });
+
+  const zip = path.join(t.context.tmpDir, "dist", "ui5ecosystemdemoapp.zip");
+  // see libraries deps in ui5.includeDepy.yaml
+  const allDepsFound = await Promise.allSettled([
+    promisifiedNeedleInHaystack(zip, "resources/sap/ui/core"),
+    promisifiedNeedleInHaystack(zip, "resources/sap/ui/layout"),
+  ]);
+  t.false(allDepsFound[0].value);
+  t.true(allDepsFound[1].value);
+});
+
+test("Some UI5 lib dependencies are included (V3)", async (t) => {
+  const ui5 = {
+    yaml: path.resolve("./test/__assets__/ui5-app-simple/ui5.includeSomeDeps.yaml"),
+  };
+  spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+    stdio: "inherit", // > don't include stdout in test output,
+    shell: true,
+    cwd: path.resolve(__dirname, "../../../showcases/ui5-app-simple"),
+  });
+
+  const zip = path.join(t.context.tmpDir, "dist", "simpleapp.zip");
+  // see libraries deps in ui5.includeDepy.yaml
+  const allDepsFound = await Promise.allSettled([
+    promisifiedNeedleInHaystack(zip, "resources/sap/ui/core"),
+    promisifiedNeedleInHaystack(zip, "resources/sap/ui/layout"),
+  ]);
+  t.false(allDepsFound[0].value);
+  t.true(allDepsFound[1].value);
+});
+


### PR DESCRIPTION
The task has been extended to allow to specify the list of UI5 dependencies to be included in the final zip analog to the builder settings includeDependency. The configuration option includeDependencies now also accepts an array of strings providing the UI5 dependency name which is the name specifed in the ui5.yaml > metadata > name property.

```yaml
builder:
  customTasks:
    - name: ui5-task-zipper
      afterTask: generateVersionInfo
      configuration:
        archiveName: simpleapp
        includeDependencies:
          - sap.ui.layout
```

Fixes #550