### PR TITLE
feat(ui5-tooling-modules): include assets of npm packages

### DIFF
--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -49,6 +49,9 @@ npm install ui5-tooling-modules --save-dev
 - *providedDependencies*: `String<Array>`
   An array of NPM package names which will be available in the development server via the middleware but will be ignored for the build process via the task. Provided dependencies are considered as being provided by the application runtime rather than it must be shipped with the current project. Provided dependencies will ignore any of the configurations above.
 
+- *includeAssets*: `Map<String, String<Array>>` *experimental feature*
+  A map of NPM package names to list of glob patterns which defines the assets to be included. The list of glob patterns can be omitted in case of copying all resources of the NPM package. (the configuration option is only relevant for the task!)
+
 ## Usage
 
 1. Define the dependency in `$yourapp/package.json`:

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -24,6 +24,7 @@
     "espree": "^9.5.1",
     "estraverse": "^5.3.0",
     "fast-xml-parser": "^4.1.4",
+    "minimatch": "^7.4.3",
     "rollup": "^3.20.2",
     "rollup-plugin-inject-process-env": "^1.3.1",
     "rollup-plugin-polyfill-node": "^0.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       fast-xml-parser:
         specifier: ^4.1.4
         version: 4.1.4
+      minimatch:
+        specifier: ^7.4.3
+        version: 7.4.3
       rollup:
         specifier: ^3.20.2
         version: 3.20.2
@@ -454,6 +457,9 @@ importers:
       firebase:
         specifier: ^9.19.0
         version: 9.19.0
+      ignore-walk:
+        specifier: ^6.0.2
+        version: 6.0.2
       node-fetch:
         specifier: ^2.6.9
         version: 2.6.9
@@ -9606,12 +9612,11 @@ packages:
       minimatch: 5.1.6
     dev: true
 
-  /ignore-walk@6.0.1:
-    resolution: {integrity: sha512-/c8MxUAqpRccq+LyDOecwF+9KqajueJHh8fz7g3YqjMZt+NSfJzx05zrKiXwa2sKwFCzaiZ5qUVfRj0pmxixEA==}
+  /ignore-walk@6.0.2:
+    resolution: {integrity: sha512-ezmQ1Dg2b3jVZh2Dh+ar6Eu2MqNSTkyb32HU2MAQQQX9tKM3q/UQ/9lf03lQ5hW+fOeoMnwxwkleZ0xcNp0/qg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minimatch: 6.2.0
-    dev: true
+      minimatch: 7.4.3
 
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -12228,7 +12233,7 @@ packages:
     resolution: {integrity: sha512-d6RGEuRrNS5/N84iglPivjaJPxhDbZmlbTwTDX2IbcRHG5bZCdtysYMhwiPvcF4GisXHGn7xsxv+GQ7T/02M5Q==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      ignore-walk: 6.0.1
+      ignore-walk: 6.0.2
     dev: true
 
   /npm-pick-manifest@3.0.2:

--- a/showcases/ui5-app/package.json
+++ b/showcases/ui5-app/package.json
@@ -44,6 +44,7 @@
     "axios": "^1.3.4",
     "cmis": "^1.0.3",
     "firebase": "^9.19.0",
+    "ignore-walk": "^6.0.2",
     "node-fetch": "^2.6.9",
     "tui-image-editor": "^3.15.3",
     "ui5-lib": "^0.2.0",

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -70,6 +70,12 @@ builder:
         prependPathMappings: true
         addToNamespace: true
         removeScopePrefix: true
+        includeAssets:
+          "@octokit/core":
+            - "dist-web/*.map"
+          "tui-image-editor":
+            - "dist/**/*.css"
+            - "dist/**/*.svg"
     - name: ui5-task-zipper
       afterTask: generateVersionInfo
       configuration:


### PR DESCRIPTION
This feature enables the ui5-tooling-modules tooling extension to include assets from npm packages. The assets to be included can be either just the npm package name including all assets or a list of glob patterns to select the assets to be included. The assets will be put into the proper folder like the required dependencies. In case of including JS files, those files will not be processed by the ui5-tooling-modules just copied.

```yaml
builder:
  customTasks:
    - name: ui5-tooling-modules-task
      afterTask: ui5-tooling-transpile-task
      configuration:
        includeAssets:
          "@octokit/core":
            - "dist-web/*.map"
          "tui-image-editor":
            - "dist/**/*.css"
            - "dist/**/*.svg"
```

Fixes #590