### PR TITLE
fix(ui5-tooling-modules): include ignore-walk as dependency

### DIFF
--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -24,6 +24,7 @@
     "espree": "^9.5.1",
     "estraverse": "^5.3.0",
     "fast-xml-parser": "^4.2.0",
+    "ignore-walk": "^6.0.2",
     "minimatch": "^7.4.6",
     "rollup": "^3.20.2",
     "rollup-plugin-inject-process-env": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       fast-xml-parser:
         specifier: ^4.2.0
         version: 4.2.0
+      ignore-walk:
+        specifier: ^6.0.2
+        version: 6.0.2
       minimatch:
         specifier: ^7.4.6
         version: 7.4.6
@@ -445,6 +448,9 @@ importers:
       '@octokit/core':
         specifier: 4.2.0
         version: 4.2.0
+      '@stomp/stompjs':
+        specifier: ^7.0.0
+        version: 7.0.0
       '@supabase/supabase-js':
         specifier: ^2.19.0
         version: 2.19.0
@@ -457,9 +463,6 @@ importers:
       firebase:
         specifier: ^9.19.1
         version: 9.19.1
-      ignore-walk:
-        specifier: ^6.0.2
-        version: 6.0.2
       node-fetch:
         specifier: ^2.6.9
         version: 2.6.9
@@ -645,6 +648,9 @@ importers:
 
   showcases/ui5-tsapp:
     dependencies:
+      '@stomp/stompjs':
+        specifier: ^7.0.0
+        version: 7.0.0
       jspdf:
         specifier: ^2.5.1
         version: 2.5.1
@@ -3714,6 +3720,10 @@ packages:
 
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
+
+  /@stomp/stompjs@7.0.0:
+    resolution: {integrity: sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw==}
+    dev: false
 
   /@supabase/functions-js@2.1.0:
     resolution: {integrity: sha512-vRziB+AqRXRaGHjEFHwBo0kuNDTuAxI7VUeqU24Fe86ISoD8YEQm0dGdpleJEcqgDGWaO6pxT1tfj1BRY5PwMg==}

--- a/showcases/ui5-app/package.json
+++ b/showcases/ui5-app/package.json
@@ -40,11 +40,11 @@
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.3",
     "@octokit/core": "4.2.0",
+    "@stomp/stompjs": "^7.0.0",
     "@supabase/supabase-js": "^2.19.0",
     "axios": "^1.3.5",
     "cmis": "^1.0.3",
     "firebase": "^9.19.1",
-    "ignore-walk": "^6.0.2",
     "node-fetch": "^2.6.9",
     "tui-image-editor": "^3.15.3",
     "ui5-lib": "^0.2.1",

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -11,6 +11,9 @@ framework:
     - name: sap.ui.layout
     - name: themelib_sap_horizon
 builder:
+  componentPreload:
+    excludes:
+      - "ui5/ecosystem/demo/app/thirdparty/stomp/**"
   customTasks:
     - name: ui5-tooling-stringreplace-task
       afterTask: replaceVersion

--- a/showcases/ui5-app/webapp/controller/Thirdparty.controller.js
+++ b/showcases/ui5-app/webapp/controller/Thirdparty.controller.js
@@ -9,8 +9,9 @@ sap.ui.define(
 		"@octokit/core", // requires node-fetch@2
 		"axios",
 		"@js-temporal/polyfill",
+		"@stomp/stompjs",
 	],
-	(Controller, xlsx, cmis, _firebase, supabase, octokit, axios, temporal) => {
+	(Controller, xlsx, cmis, _firebase, supabase, octokit, axios, temporal, stompjs) => {
 		"use strict";
 
 		console.log(xlsx);
@@ -20,6 +21,7 @@ sap.ui.define(
 		console.log(octokit);
 		console.log(axios);
 		console.log(temporal);
+		console.log(stompjs);
 
 		const { initializeApp, getFirestore } = _firebase;
 		const app = initializeApp({});

--- a/showcases/ui5-tsapp/package.json
+++ b/showcases/ui5-tsapp/package.json
@@ -25,6 +25,7 @@
     "directory": "showcases/ui5-tsapp"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.0.0",
     "jspdf": "^2.5.1",
     "luxon": "^3.3.0",
     "ui5-tslib": "^0.3.6",

--- a/showcases/ui5-tsapp/ui5.yaml
+++ b/showcases/ui5-tsapp/ui5.yaml
@@ -14,6 +14,9 @@ builder:
   settings:
     includeDependency:
       - ui5.ecosystem.demo.tslib
+  componentPreload:
+    excludes:
+      - "ui5/ecosystem/demo/tsapp/thirdparty/@stomp/**"
   customTasks:
     - name: ui5-tooling-transpile-task
       afterTask: replaceVersion

--- a/showcases/ui5-tsapp/webapp/controller/Main.controller.ts
+++ b/showcases/ui5-tsapp/webapp/controller/Main.controller.ts
@@ -13,6 +13,15 @@ import("luxon")
 		console.log("Failed to load luxon from application runtime environment!", ex);
 	});
 
+// dynamic import of an existing library
+import("@stomp/stompjs")
+	.then(({ Client }) => {
+		console.log(`STOMP.js loaded: ${Client.toString()}`);
+	})
+	.catch((ex) => {
+		console.log("Failed to load STOMP.js from application runtime environment!", ex);
+	});
+
 /**
  * @namespace ui5.ecosystem.demo.tsapp.controller
  */


### PR DESCRIPTION
The dependency `ignore-walk` has been added by accident to the showcase instead of the tooling extensions. Will be fixed with this change - plus some more 3rd party libs included for testing.

Fixes #713