### PR TITLE
fix(karma-ui5-transpile): also instrument in Babel transformation

### DIFF
--- a/packages/karma-ui5-transpile/README.md
+++ b/packages/karma-ui5-transpile/README.md
@@ -4,13 +4,13 @@ The `karma-ui5-transpile` preprocessor transpiles code of UI5 projects having a 
 
 ## Installation
 
-The plugin requires [`karma`](https://www.npmjs.com/package/karma) `>=6.4.1`, and [ui5-tooling-transpile](https://www.npmjs.com/package/ui5-tooling-transpile) `>=0.7.0`. You can install the required dependencies with the following command:
+The plugin requires [`karma`](https://www.npmjs.com/package/karma) `>=6.4.1`, [`karma-coverage`](https://www.npmjs.com/package/karma-coverage) `>=2.2.0`, and [ui5-tooling-transpile](https://www.npmjs.com/package/ui5-tooling-transpile) `>=0.7.0`. You can install the required dependencies with the following command:
 
 ```sh
-npm install --save-dev karma ui5-tooling-transpile karma-ui5 karma-ui5-transpile
+npm install --save-dev karma karma-coverage ui5-tooling-transpile karma-ui5 karma-ui5-transpile
 ```
 
-The usage of the [`karma-ui5`](https://www.npmjs.com/package/karma-ui5) plugin is obligatory as it integrates UI5 into the Karma testing flow although it is not directly needed by the `karma-ui5-transpile` plugin. Only the configuration is read from the `karma-ui5` plugin.
+The usage of the [`karma-ui5`](https://www.npmjs.com/package/karma-ui5) plugin is obligatory as it integrates UI5 into the Karma testing flow although it is not directly necessary for the `karma-ui5-transpile` plugin. Only the configuration is read from the `karma-ui5` plugin.
 
 ## Configuration
 
@@ -30,17 +30,17 @@ module.exports = function (config) {
 };
 ```
 
-## Code Coverage for UI5 TypeScript projects
+## Code Coverage for UI5 projects using `ui5-tooling-transpile`
 
-To enable code coverage for your TypeScript-based UI5 project, you can use the `karma-ui5-transpile` to preprocess your TypeScript files in your project before passing them to the `karma-coverage` preprocessor to instrument them. Therefore, you first need to install the required Karma dependencies:
+To enable code coverage for your UI5 project using `ui5-tooling-transpile`, you can install and use the `karma-ui5-transpile` to preprocess your source files of your project. It uses the same configuration as the `ui5-tooling-transpile` and `karma-ui5`.
+
+Let's assume you already use the tooling extension `ui5-tooling-transpile` and all is configured properly in `ui5.yaml`. To add code coverage, we first need to install all required dependencies `karma`, `karma-ui5`, `karma-ui5-transpile`, `karma-coverage`, and `karma-chrome-launcher` which are needed for the automated execution of your e.g. QUnit or OPA tests:
 
 ```sh
-npm install --save-dev karma ui5-tooling-transpile karma-ui5 karma-ui5-transpile karma-coverage karma-chrome-launcher
+npm install --save-dev karma karma-ui5 karma-ui5-transpile karma-coverage karma-chrome-launcher
 ```
 
-In the scenario above, we assume that you already use the dependency to `ui5-tooling-transpile` and you have a proper configuration in the `ui5.yaml` for this tooling extension. The above installation script installs the dependencies for `karma`, `karma-ui5-transpile`, `karma-coverage`, and `karma-chrome-launcher` which are needed for the automated execution of your e.g. QUnit tests.
-
-In your `karma.conf.js` (or better you create separate ones for different scenarios), you need to configure the preprocessors (for which local folder they will run - below we use the preprocessor for all `.ts` resources in the `webapp` folder - also defining multiple folders is possible, e.g. `src/**/*.ts` and `test/**/*.ts` for typical UI5 library projects):
+Second, in your `karma.conf.js` (or better you create separate ones for different scenarios), you need to configure the preprocessor `ui5-transpile` for which local paths is should run. Below we use the preprocessor for all `.ts` resources in the `webapp` folder - also defining multiple folders is possible, e.g. `src/**/*.ts` and `test/**/*.ts` for typical UI5 library projects:
 
 ```js
 module.exports = function (config) {
@@ -49,7 +49,7 @@ module.exports = function (config) {
     browsers: ["Chrome"],
     reporters: ["progress", "coverage"],
     preprocessors: {
-      "webapp/**/*.ts": ["ui5-transpile", "coverage"],
+      "webapp/**/*.ts": ["ui5-transpile"],
     },
     coverageReporter: {
       dir: "coverage",
@@ -63,6 +63,8 @@ module.exports = function (config) {
   });
 };
 ```
+
+:warning: When using the `ui5-transpile` preprocessor please avoid using the `coverage` preprocessor as the instrumentation will also take place during the `ui5-transpile` Babel transformation process. If you use both, you will see a warning in the console and instrument your source files twice!
 
 That's it! Now, you are able to run your coverage tests with Karma for your TypeScript-based UI5 projects. To do so, just run:
 

--- a/packages/karma-ui5-transpile/package.json
+++ b/packages/karma-ui5-transpile/package.json
@@ -18,6 +18,7 @@
     "karma-preprocessor",
     "babel",
     "transpile",
+    "istanbul",
     "ui5",
     "openui5",
     "sapui5"
@@ -27,6 +28,7 @@
     "ui5-tooling-transpile": ">=0.7.0"
   },
   "dependencies": {
+    "babel-plugin-istanbul": "^6.1.1",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
 
   packages/karma-ui5-transpile:
     dependencies:
+      babel-plugin-istanbul:
+        specifier: ^6.1.1
+        version: 6.1.1
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1031,7 +1034,7 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.3
+      '@babel/types': 7.21.4
 
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
@@ -1987,14 +1990,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/types@7.21.3:
-    resolution: {integrity: sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
-
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
     engines: {node: '>=6.9.0'}
@@ -2766,10 +2761,20 @@ packages:
     resolution: {integrity: sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==}
     dev: true
 
+  /@istanbuljs/load-nyc-config@1.1.0:
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.1
+      resolve-from: 5.0.0
+    dev: false
+
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
-    dev: true
 
   /@javascript-obfuscator/escodegen@2.3.0:
     resolution: {integrity: sha512-QVXwMIKqYMl3KwtTirYIA6gOCiJ0ZDtptXqAv/8KWLG9uQU2fZqTVy7a/A5RvcoZhbDoFfveTxuGxJ5ibzQtkw==}
@@ -5181,7 +5186,6 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
-    dev: true
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -5438,6 +5442,19 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  /babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.4):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -8890,6 +8907,11 @@ packages:
       has: 1.0.3
       has-symbols: 1.0.3
 
+  /get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /get-pkg-repo@4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
     engines: {node: '>=6.9.0'}
@@ -10234,7 +10256,6 @@ packages:
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
-    dev: true
 
   /istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
@@ -10247,7 +10268,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /istanbul-lib-report@3.0.0:
     resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
@@ -10368,7 +10388,6 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -14044,7 +14063,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-global@1.0.0:
     resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
@@ -14719,7 +14737,6 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-    dev: true
 
   /ssf@0.11.2:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
@@ -15175,6 +15192,15 @@ packages:
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+    dev: false
 
   /text-extensions@1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}

--- a/showcases/ui5-tsapp/karma-ci-cov.conf.js
+++ b/showcases/ui5-tsapp/karma-ci-cov.conf.js
@@ -3,8 +3,8 @@ module.exports = function (config) {
 	config.set({
 		reporters: ["progress", "coverage"],
 		preprocessors: {
-			//"webapp/**/!(*.d.)ts": ["ui5-transpile", "coverage"],
-			"webapp/{*.ts,!(test)/**/*.ts}": ["ui5-transpile", "coverage"],
+			//"webapp/**/!(*.d.)ts": ["ui5-transpile"],
+			"webapp/{*.ts,!(test)/**/*.ts}": ["ui5-transpile"],
 			"webapp/**/*.js": ["coverage"],
 		},
 		coverageReporter: {

--- a/showcases/ui5-tslib/karma-ci-cov.conf.js
+++ b/showcases/ui5-tslib/karma-ci-cov.conf.js
@@ -3,8 +3,8 @@ module.exports = function (config) {
 	config.set({
 		reporters: ["progress", "coverage"],
 		preprocessors: {
-			"src/**/*.ts": ["ui5-transpile", "coverage"],
-			"test/**/*.ts": ["ui5-transpile", "coverage"],
+			"src/**/*.ts": ["ui5-transpile"],
+			"test/**/*.ts": ["ui5-transpile"],
 		},
 		coverageReporter: {
 			dir: "coverage",


### PR DESCRIPTION
The karma-coverage preprocessor instruments the final content of the Babel transformation done by the karma-ui5-transpile preprocessor. This leads to wrong code coverage results since the UI5 AMD-like module is instrumented rather than the JS code without TypeScript. Therefore the karma-ui5-transpile preprocessor injects the istanbul plugin into the Babel transformation that it instruments at the right point in time.

With this change the "coverage" preprocessor must not be used in combination with the "ui5-transpile". Only the "coverage" reporter can be used to create the reports finally.