### PR TITLE
feat(stringreplace): add path to .env option

### DIFF
--- a/packages/ui5-tooling-stringreplace/README.md
+++ b/packages/ui5-tooling-stringreplace/README.md
@@ -104,7 +104,7 @@ You can keep multiple `.env` files and load a specific environment at build or s
 
 You can define our own prefix in `$yourapp/ui5.yaml` using configuration `prefix` otherwise will default to `UI5_ENV`.
 
-You can specify the `<UI5_ENV>.env` location by setting the `ui5_env_path` property in the configuration. Default path fallback is set to `./` to find the `<UI5_ENV>.env` file in the same location as the executed `package.json` file.  
+You can specify the `<UI5_ENV>.env` location by setting the `path` property in the configuration. Default path fallback is set to `./` to find the `<UI5_ENV>.env` file in the same location as the executed `package.json` file.  
 
 ```json
  "scripts": {

--- a/packages/ui5-tooling-stringreplace/README.md
+++ b/packages/ui5-tooling-stringreplace/README.md
@@ -70,6 +70,8 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
+        prefix: UI5_ENV # default
+        path: ./ # default
         files:
           - "**/*.js"
           - "**/*.xml"
@@ -101,6 +103,8 @@ You can keep multiple `.env` files and load a specific environment at build or s
 ```
 
 You can define our own prefix in `$yourapp/ui5.yaml` using configuration `prefix` otherwise will default to `UI5_ENV`.
+
+You can specify the `<UI5_ENV>.env` location by setting the `ui5_env_path` property in the configuration. Default path fallback is set to `./` to find the `<UI5_ENV>.env` file in the same location as the executed `package.json` file.  
 
 ```json
  "scripts": {

--- a/packages/ui5-tooling-stringreplace/lib/middleware.js
+++ b/packages/ui5-tooling-stringreplace/lib/middleware.js
@@ -36,7 +36,7 @@ module.exports = function createMiddleware({ resources, options, middlewareUtil 
 
 	// get all environment variables
 	const prefix = options.configuration?.prefix ? options.configuration?.prefix : "UI5_ENV"; // default
-	const path = options.configuration?.ui5_env_path ? options.configuration?.ui5_env_path : "./"; // default
+	const path = options.configuration?.path ? options.configuration?.path : "./"; // default
 	const placeholderStrings = readPlaceholderFromEnv(path, prefix, log);
 
 	let filesToInclude = [];

--- a/packages/ui5-tooling-stringreplace/lib/middleware.js
+++ b/packages/ui5-tooling-stringreplace/lib/middleware.js
@@ -36,7 +36,8 @@ module.exports = function createMiddleware({ resources, options, middlewareUtil 
 
 	// get all environment variables
 	const prefix = options.configuration?.prefix ? options.configuration?.prefix : "UI5_ENV"; // default
-	const placeholderStrings = readPlaceholderFromEnv(prefix, log);
+	const path = options.configuration?.ui5_env_path ? options.configuration?.ui5_env_path : "./"; // default
+	const placeholderStrings = readPlaceholderFromEnv(path, prefix, log);
 
 	let filesToInclude = [];
 	if (options.configuration) {

--- a/packages/ui5-tooling-stringreplace/lib/task.js
+++ b/packages/ui5-tooling-stringreplace/lib/task.js
@@ -19,7 +19,7 @@ module.exports = function ({ workspace, options }) {
 
 	// get all environment variables
 	const prefix = options.configuration?.prefix ? options.configuration?.prefix : "UI5_ENV"; // default
-	const path = options.configuration?.ui5_env_path ? options.configuration?.ui5_env_path : "./"; // default
+	const path = options.configuration?.path ? options.configuration?.path : "./"; // default
 	const placeholderStrings = readPlaceholderFromEnv(path, prefix, log);
 
 	// extract the placeholder strings from the configuration

--- a/packages/ui5-tooling-stringreplace/lib/task.js
+++ b/packages/ui5-tooling-stringreplace/lib/task.js
@@ -19,7 +19,8 @@ module.exports = function ({ workspace, options }) {
 
 	// get all environment variables
 	const prefix = options.configuration?.prefix ? options.configuration?.prefix : "UI5_ENV"; // default
-	const placeholderStrings = readPlaceholderFromEnv(prefix, log);
+	const path = options.configuration?.ui5_env_path ? options.configuration?.ui5_env_path : "./"; // default
+	const placeholderStrings = readPlaceholderFromEnv(path, prefix, log);
 
 	// extract the placeholder strings from the configuration
 	options.configuration?.replace?.forEach((entry) => {

--- a/packages/ui5-tooling-stringreplace/lib/util.js
+++ b/packages/ui5-tooling-stringreplace/lib/util.js
@@ -15,10 +15,13 @@ const _self = (module.exports = {
 		}
 		return false;
 	},
-	readPlaceholderFromEnv: function readPlaceholderFromEnv(prefix, log) {
+	readPlaceholderFromEnv: function readPlaceholderFromEnv(path, prefix, log) {
 		if (process.env[prefix]) {
-			log.info(`${prefix} set to ${process.env[prefix]}: loading ./${process.env[prefix]}.env`);
-			require("dotenv").config({ path: `./${process.env[prefix]}.env` });
+			log.info(`${prefix} set to ${process.env[prefix]}: loading ${path}${process.env[prefix]}.env`);
+			const result = require("dotenv").config({ path: `${path}${process.env[prefix]}.env` });
+			if (result.error) {
+				log.warn(result.error);
+			}
 		} else {
 			require("dotenv").config(); //loads './.env'
 		}


### PR DESCRIPTION
add option to specify location of `.env` file.

required e.g. in monorepositories to share environment across packages.