### PR TITLE
fix(ui5-tooling-transpile): allow to inject targetBrowsers via env var

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 8.1.0
+          version: 8.6.0
           run_install: |
             - args: [--frozen-lockfile]
 

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 8.1.0
+          version: 8.6.0
           run_install: |
             - args: [--frozen-lockfile]
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 8.1.0
+          version: 8.6.0
           run_install: false
 
       - id: pnpm-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 8.1.0
+          version: 8.6.0
           run_install: false
 
       - id: pnpm-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ A sub-package **may** have an additional CONTRIBUTING.md file if needed.
 
 ### Pre-Requisites
 
-- [PNPM](https://pnpm.io/installation) >= 8.1.0
+- [PNPM](https://pnpm.io/installation) >= 8.6.0
 - A [Long-Term Support version](https://nodejs.org/en/about/releases/) of Node.js
 - (optional) [commitizen](https://github.com/commitizen/cz-cli#installing-the-command-line-tool) for managing commit messages.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.6.0",
   "scripts": {
     "build": "pnpm --filter ui5-app build",
     "build:sc": "pnpm --filter ui5-app build:sc",

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -212,7 +212,11 @@ const _this = (module.exports = {
 			envPreset.push({
 				targets: {
 					// future: consider to read the browserslist config from OpenUI5/SAPUI5?
-					browsers: configuration?.targetBrowsers || "defaults"
+					// env variables must not use "-" or "." and therefore we use "_" only
+					browsers:
+						process.env?.["ui5_tooling_transpile__targetBrowsers"] ||
+						configuration?.targetBrowsers ||
+						"defaults"
 				}
 			});
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   chromedriver: '>=113'


### PR DESCRIPTION
The target browsers configuration for Babel can be passed via the env var "ui5_tooling_transpile__targetBrowsers" when no .babelrc or .browserslistrc is present and the configuration from the ui5.yaml is used. Dots and dashes are not allowed for environment variables and therefore we use underscores as alternative characters.