### PR TITLE
feat(ui5-middleware-cfdestination): allow dest. to be maintained in .env

### DIFF
--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -21,7 +21,16 @@ path to the cf-style approuter configuration file `xs-app.json`
 
 - `destinations`: `<Array of name/value pairs>`, default: `[]`
   - `name: <string>` destination name, matching the one used in routes in `xs-app.json`  
-  - `url: <string>` URI to the host to "proxy" to
+  - `url: <string>` URI to the host to "proxy" to  
+  
+  alternatively the destinations can also be defined in a `.env` file. They need to be in encoded in a single JSON string  
+  e.g.
+
+  ```properties
+  xsapp_dest = [{"name": "destination-name", "url": "<some-service-url>"}]
+  ```
+
+  To use these destinations they need to passed to the `destinations` option as a string `"$env:<key-in-env-file>"` (e.g. `destinations: "$env:xsapp_dest"`)
 
 - `allowServices`: `<boolean>`, default: `false`  
 allow [BTP services](https://discovery-center.cloud.sap/serviceCatalog?) to be used at runtime that are configured in `xs-app.json`  

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -103,11 +103,15 @@ module.exports = async ({ resources, options, middlewareUtil }) => {
 
 	// check if destinations exist in .env file as JSON string
 	if (typeof effectiveOptions.destinations === "string" && effectiveOptions.destinations.startsWith("$env:")) {
-		const destinationsEnvKey = effectiveOptions.destinations.substring(5)
-		try {
-			effectiveOptions.destinations = JSON.parse(process.env[destinationsEnvKey])
-		} catch (error) {
-			throw new Error(`No valid destinations JSON in .env file at '${destinationsEnvKey}': ${error}`)
+		const destinationsEnvKey = effectiveOptions.destinations.substring(5).trim()
+		if (destinationsEnvKey && destinationsEnvKey in process.env) {
+			try {
+				effectiveOptions.destinations = JSON.parse(process.env[destinationsEnvKey])
+			} catch (error) {
+				throw new Error(`No valid destinations JSON in .env file at '${destinationsEnvKey}': ${error}`)
+			}
+		} else {
+			throw new Error(`No variable for 'destinations' with name '${destinationsEnvKey}' found in process.env!`)
 		}
 	}
 	// req-use app-router with config file to run in "shadow" mode

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -9,6 +9,8 @@ const proxy = require("express-http-proxy")
 const ct = require("content-type")
 const mime = require("mime-types")
 const portfinder = require("portfinder")
+const dotenv = require("dotenv")
+dotenv.config()
 
 /**
  * Determines the applications base path from the given resource collection.
@@ -99,6 +101,15 @@ module.exports = async ({ resources, options, middlewareUtil }) => {
 	// the default auth mechanism is set to none but the user can pass an auth method using the options
 	xsappConfig.authenticationMethod = effectiveOptions.authenticationMethod
 
+	// check if destinations exist in .env file as JSON string
+	if (typeof effectiveOptions.destinations === "string" && effectiveOptions.destinations.startsWith("$env:")) {
+		const destinationsEnvKey = effectiveOptions.destinations.substring(5)
+		try {
+			effectiveOptions.destinations = JSON.parse(process.env[destinationsEnvKey])
+		} catch (error) {
+			throw new Error(`No valid destinations JSON in .env file at '${destinationsEnvKey}': ${error}`)
+		}
+	}
 	// req-use app-router with config file to run in "shadow" mode
 	process.env.destinations = JSON.stringify(effectiveOptions.destinations || [])
 	let destinations

--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -25,6 +25,7 @@
     "@sap/approuter": "^14.1.2",
     "@ui5/logger": "^2.0.1",
     "content-type": "^1.0.5",
+    "dotenv": "^16.3.1",
     "express-http-proxy": "^1.6.3",
     "mime-types": "^2.1.35",
     "portfinder": "^1.0.32"
@@ -34,6 +35,7 @@
     "@ui5/project": "^2.6.0",
     "@ui5/server": "^2.4.1",
     "ava": "^5.3.1",
+    "envfile": "6.18.0",
     "get-port": "^7.0.0",
     "nock": "^13.3.1",
     "prettier": "^2.8.8",

--- a/packages/ui5-middleware-cfdestination/test/dest-in-env.test.js
+++ b/packages/ui5-middleware-cfdestination/test/dest-in-env.test.js
@@ -1,0 +1,85 @@
+const crypto = require("crypto")
+const fs = require("fs-extra")
+const path = require("path")
+const request = require("supertest")
+const { spawn } = require("child_process")
+const test = require("ava")
+const waitOn = require("wait-on")
+
+const copyUI5app = require("./_fs_app_util")
+const prepUi5ServerConfig = require("./_prep_server_util")
+const { parse: parseDotEnv } = require("dotenv")
+const { stringify: stringifyDotEnv } = require("envfile")
+
+test.beforeEach(async (t) => {
+	// copy ui5 app to a temp dir in test folder scope
+	t.context.tmpDir = path.resolve(`./test/_ui5-app/${crypto.randomBytes(5).toString("hex")}`)
+	await copyUI5app(t.context.tmpDir)
+
+	// dynamic port allocation for ui5 serve
+	const getPort = (await import("get-port")).default
+	t.context.port = {
+		ui5Sserver: await getPort(),
+		appRouter: await getPort()
+	}
+})
+
+test.afterEach.always(async (t) => {
+	// cleanup
+	await fs.remove(t.context.tmpDir)
+})
+
+// https://github.com/avajs/ava/blob/main/docs/03-assertions.md
+
+test("test valid destinations in .env file", async (t) => {
+	// adjust .env file copied from app directory
+	const envFileContent = fs.readFileSync(`${t.context.tmpDir}/.env`)
+	const envFileObj = parseDotEnv(envFileContent)
+
+	// fill valid destination string
+	envFileObj.xsapp_dest = JSON.stringify([
+		{ name: "backend", url: "https://services.odata.org/V4/(S(fdng4tbvlxgzpdtpfap2rqss))/TripPinServiceRW/" }
+	])
+	fs.writeFileSync(`${t.context.tmpDir}/.env`, stringifyDotEnv(envFileObj))
+
+	const { ui5 } = await prepUi5ServerConfig({
+		ui5Yaml: "./test/dest-in-env/ui5.yaml",
+		appRouterPort: t.context.port.appRouter,
+		xsAppJson: "./test/dest-in-env/xs-app.json",
+		tmpDir: t.context.tmpDir
+	})
+
+	// start ui5-app with modified route(s) and config
+	const child = spawn(`ui5 serve --port ${t.context.port.ui5Sserver} --config ${ui5.yaml}`, {
+		// stdio: "inherit", // > don't include stdout in test output,
+		shell: true,
+		cwd: t.context.tmpDir,
+		detached: true // this for being able to kill all subprocesses of above `ui5 serve` later
+	})
+
+	try {
+		// wait for ui5 server and app router to boot
+		await waitOn({ resources: [`tcp:${t.context.port.ui5Sserver}`, `tcp:${t.context.port.appRouter}`] })
+	} catch (error) {
+		process.kill(-child.pid)
+		return
+	}
+
+	const baseUri = `http://localhost:${t.context.port.ui5Sserver}`
+	const app = request(baseUri)
+	// test for the app being started correctly
+	const responseIndex = await app.get("/index.html")
+	t.is(responseIndex.status, 200, "http 200 on index")
+
+	// testing backend being available
+	const respRoot = await app.get("/backend/")
+	t.is(respRoot.status, 200, "http 200 on root")
+
+	// retrieving people
+	const respGET = await app.get("/backend/People")
+	t.is(respGET.status, 200, "http 200 on GET /backend/People")
+	t.true(respGET.body.value.length > 0, "Entries found")
+
+	// kill all processes that are in the same pid group (see detached: true)
+	process.kill(-child.pid)
+})

--- a/packages/ui5-middleware-cfdestination/test/dest-in-env/ui5.yaml
+++ b/packages/ui5-middleware-cfdestination/test/dest-in-env/ui5.yaml
@@ -1,0 +1,21 @@
+specVersion: "2.2"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.115.1"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+server:
+  customMiddleware:
+  - name: ui5-middleware-cfdestination
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      port: 1091
+      xsappJson: "xs-app.json"
+      destinations: "$env:xsapp_dest"

--- a/packages/ui5-middleware-cfdestination/test/dest-in-env/xs-app.json
+++ b/packages/ui5-middleware-cfdestination/test/dest-in-env/xs-app.json
@@ -1,0 +1,11 @@
+{
+  "authenticationMethod": "none",
+  "welcomeFile": "/index.html",
+  "routes": [
+    {
+      "source": "^/backend/(.*)$",
+      "destination": "backend",
+      "target": "$1"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       content-type:
         specifier: ^1.0.5
         version: 1.0.5
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       express-http-proxy:
         specifier: ^1.6.3
         version: 1.6.3
@@ -140,6 +143,9 @@ importers:
       ava:
         specifier: ^5.3.1
         version: 5.3.1
+      envfile:
+        specifier: 6.18.0
+        version: 6.18.0
       get-port:
         specifier: ^7.0.0
         version: 7.0.0
@@ -7912,6 +7918,12 @@ packages:
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  /envfile@6.18.0:
+    resolution: {integrity: sha512-IsYv64dtlNXTm4huvCBpbXsdZQurYUju9WoYCkSj+SDYpO3v4/dq346QsCnNZ3JcnWw0G3E6+saVkVtmPw98Gg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
 
   /envinfo@7.8.1:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}


### PR DESCRIPTION
Provides the option to store destinations as JSON string inside in `.env` file variable. 

Extract from `ui5.yaml` that is using the new option:

```yaml
    - name: ui5-middleware-cfdestination
      afterMiddleware: compression
      configuration:
        authenticationMethod: "route"
        allowServices: true
        debug: true
        xsappJson: "local-xs-app.json"
        destinations: "$env:xsapp_dest"
```

P.S.
As I am new to `ava` which is used for testing I only wrote a positive test. I didn't manage it to also implement a negative test 😊.

Best regards,
Ludwig