### PR TITLE
feat: prepare versions for release for UI5 Tooling V3

### DIFF
--- a/packages/karma-ui5-transpile/package.json
+++ b/packages/karma-ui5-transpile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-ui5-transpile",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "author": "Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-cap/package.json
+++ b/packages/ui5-middleware-cap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-cap",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 tooling middleware embedding the CAP server middlewares",
   "author": "Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-cfdestination",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 middleware for CF destinations",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-iasync/package.json
+++ b/packages/ui5-middleware-iasync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-iasync",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.1-alpha.1",
   "description": "UI5 Tooling middleware to sync browser interactions",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-index/package.json
+++ b/packages/ui5-middleware-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-index",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 middleware for delivering a dedicated welcome/start page",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-livecompileless/package.json
+++ b/packages/ui5-middleware-livecompileless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-livecompileless",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 middleware for live compiling less files",
   "author": "Sebastian Mahr, Marcel Schork",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-livereload/package.json
+++ b/packages/ui5-middleware-livereload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-livereload",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 middleware for live reloading `webapp` sources on change",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-servestatic/package.json
+++ b/packages/ui5-middleware-servestatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-servestatic",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 simple proxy middleware",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-simpleproxy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 simple proxy middleware",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-middleware-webjars/package.json
+++ b/packages/ui5-middleware-webjars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-webjars",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 middleware for delivering content from JAR files",
   "author": "Volker Buzek, Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-task-cachebuster/package.json
+++ b/packages/ui5-task-cachebuster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-cachebuster",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Task for the UI5 tooling for simple cachebusting for standalone applications.",
   "author": "Hanna Olbert",
   "license": "Apache-2.0",

--- a/packages/ui5-task-compileless/package.json
+++ b/packages/ui5-task-compileless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-compileless",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 task for compiling less files",
   "author": "Sebastian Mahr, Marcel Schork",
   "license": "Apache-2.0",

--- a/packages/ui5-task-flatten-library/package.json
+++ b/packages/ui5-task-flatten-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-flatten-library",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Task for the UI5 tooling to flatten the library folder structure. This is required for deployments to SAP NetWeaver.",
   "author": "Matthias Osswald",
   "license": "Apache-2.0",

--- a/packages/ui5-task-i18ncheck/package.json
+++ b/packages/ui5-task-i18ncheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-i18ncheck",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Task for the UI5 tooling to check missing translations in i18n properties used in XML views.",
   "author": "Fatih Pense",
   "license": "Apache-2.0",

--- a/packages/ui5-task-minify-xml/package.json
+++ b/packages/ui5-task-minify-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-minify-xml",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 task for minifying XML resources (like views, fragments, etc.)",
   "author": "Kristian Kraljic",
   "license": "Apache-2.0",

--- a/packages/ui5-task-pwa-enabler/package.json
+++ b/packages/ui5-task-pwa-enabler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-pwa-enabler",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 task to make a PWA out of a UI5 application.",
   "author": "Mona Kaczun, Maximilian Moehl",
   "license": "Apache-2.0",

--- a/packages/ui5-task-zipper/package.json
+++ b/packages/ui5-task-zipper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-zipper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Task for the UI5 tooling to zip the webapp.",
   "author": "Marius Obert",
   "license": "Apache-2.0",

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-tooling-modules",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 tooling extensions to load and convert node modules as UI5 AMD-like modules",
   "author": "Peter Muessig",
   "license": "Apache-2.0",

--- a/packages/ui5-tooling-stringreplace/package.json
+++ b/packages/ui5-tooling-stringreplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-tooling-stringreplace",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 tooling extensions to string replace ",
   "author": "Dominik Feininger",
   "license": "Apache-2.0",

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-tooling-transpile",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "UI5 tooling extensions to transpile code",
   "author": "Jorge Martins, Peter Muessig",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adopted the package.json versions and making a breaking change to finally trigger a major version change with Lerna.

BREAKING CHANGE: The support for UI5 Tooling V2 has been removed

Fixes: #770
Closes: #648