### PR TITLE
fix(karma-ui5-transpile): ensure to instrument test files 

### DIFF
--- a/packages/karma-ui5-transpile/lib/index.js
+++ b/packages/karma-ui5-transpile/lib/index.js
@@ -76,7 +76,13 @@ function createPreprocessor(config, logger) {
 			})
 		) {
 			// add istanbul as first plugin into the plugins chain
-			babelOptions.plugins.unshift("istanbul");
+			babelOptions.plugins.unshift([
+				"istanbul",
+				{
+					include: ["**/*"],
+					exclude: []
+				}
+			]);
 		}
 		return babelOptions;
 	});

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -185,7 +185,7 @@ module.exports = function (log) {
 			configuration?.debug && log.info(`Create Babel configuration based on ui5.yaml configuration options...`);
 
 			// create the babel configuration based on the ui5.yaml
-			babelConfig = { ignore: ["**/*.d.ts"], plugins: [], presets: [] };
+			babelConfig = { plugins: [], presets: [] };
 
 			// order of the presets is important: last preset is applied first
 			// which means the .babelrc config should look like that:

--- a/packages/ui5-tooling-transpile/test/__assets__/external/.babelrc
+++ b/packages/ui5-tooling-transpile/test/__assets__/external/.babelrc
@@ -1,5 +1,4 @@
 {
-	"ignore": ["**/*.d.ts"],
 	"presets": ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"],
 	"sourceMaps": true
 }

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -43,7 +43,6 @@ test("inject configuration options", async (t) => {
 	});
 	let babelConfig = await t.context.util.createBabelConfig({ configuration });
 	t.deepEqual(babelConfig, {
-		ignore: ["**/*.d.ts"],
 		plugins: [],
 		presets: [
 			[
@@ -69,7 +68,6 @@ test("inject configuration options", async (t) => {
 	});
 	babelConfig = await t.context.util.createBabelConfig({ configuration });
 	t.deepEqual(babelConfig, {
-		ignore: ["**/*.d.ts"],
 		plugins: [],
 		presets: [
 			[
@@ -103,7 +101,6 @@ test("inject configuration options", async (t) => {
 	});
 	babelConfig = await t.context.util.createBabelConfig({ configuration });
 	t.deepEqual(babelConfig, {
-		ignore: ["**/*.d.ts"],
 		plugins: [],
 		presets: [
 			[

--- a/showcases/ui5-tsapp/.babelrc
+++ b/showcases/ui5-tsapp/.babelrc
@@ -1,5 +1,4 @@
 {
-	"ignore": ["**/*.d.ts"],
 	"presets": ["@babel/preset-env", "transform-ui5", "@babel/preset-typescript"],
 	"plugins": [
 		[

--- a/showcases/ui5-tslib/.babelrc.json
+++ b/showcases/ui5-tslib/.babelrc.json
@@ -1,5 +1,4 @@
 {
-  "ignore": ["**/*.d.ts"],
   "presets": ["@babel/preset-env", "transform-ui5", "@babel/preset-typescript"],
   "plugins": [
     [


### PR DESCRIPTION
TypeScript-based projects don't instrument test resources because
of the defaults used from nyc-config. Therefore, the istanbul
configuration must include the opts for the instrumentation defining
the include and exclude options.