### PR TITLE
feat: Apply `instrumenterOptions` for Istanbul from `coverageReporter` in `karma.config`

### DIFF
--- a/packages/karma-ui5-transpile/lib/index.js
+++ b/packages/karma-ui5-transpile/lib/index.js
@@ -9,7 +9,6 @@ const yaml = require("js-yaml");
  *
  * Kudos goes to: https://github.com/babel/karma-babel-preprocessor
  * which inspired the creation of this Karma preprocessor.
- *
  * @param {object} config Config object of UI5.
  * @param {object} logger Karma's logger.
  * @returns {Function} The preprocess function.
@@ -75,21 +74,23 @@ function createPreprocessor(config, logger) {
 				return plugin.file.request === "istanbul";
 			})
 		) {
+			const istanbunConfig = {
+				include: ["**/*"],
+				exclude: []
+			};
+			// apply the `instrumenterOptions` for istanbul from `coverageReporter` in the `karma.config`
+			const instrumenterOptionsIstanbul = config.coverageReporter?.instrumenterOptions?.istanbul;
+			if (instrumenterOptionsIstanbul && typeof instrumenterOptionsIstanbul === "object") {
+				Object.assign(istanbunConfig, config.coverageReporter.instrumenterOptions.istanbul);
+			}
 			// add istanbul as first plugin into the plugins chain
-			babelOptions.plugins.unshift([
-				"istanbul",
-				{
-					include: ["**/*"],
-					exclude: []
-				}
-			]);
+			babelOptions.plugins.unshift(["istanbul", istanbunConfig]);
 		}
 		return babelOptions;
 	});
 
 	/**
 	 * preprocess function for the individual files to transpile
-	 *
 	 * @param {string} content file content
 	 * @param {object} file file info
 	 * @param {Function} done callback function when done


### PR DESCRIPTION
This pull request addresses an issue with code coverage reporting when running Karma tests for UI5 in an iframe. Previously, coverage was not being correctly reported in such scenarios.

`karma-ui5` [provides a solution to this problem](https://github.com/SAP/karma-ui5#configureiframecoverage) by enabling code coverage for iframes. This is done through the use of the `configureIframeCoverage` helper function, which should be called from the Karma configuration function after the coverage plugin has been configured.

With the changes introduced in this PR, the `karma-ui5-transpile` will now correctly apply these configurations, ensuring accurate coverage reporting when running Karma tests for UI5 applications within an iframe.