### PR TITLE
feat(cds-plugin-ui5): allow to attach custom app pages to cds server

### DIFF
--- a/packages/cds-plugin-ui5/README.md
+++ b/packages/cds-plugin-ui5/README.md
@@ -21,6 +21,34 @@ npm add cds-plugin-ui5 -D
 
 That's it!
 
+## Info for UI5 Tooling Extension Developers
+
+Custom middlewares may generate virtual app pages which should also be listed as web applications in the welcome page of the `@sap/cds` server. This is possible by assigning a static `getAppPages` function to the middleware function. The following snippet show-cases how this can be done:
+
+```js
+// the middleware factory function
+module.exports = async ({ log, resources, options }) => {
+  // create the middleware function
+  const mwFn = (req, res, next) => {
+    [...]
+  };
+
+  /**
+   * Returns an array of app pages to be added to the welcome
+   * page of the <code>@sap/cds</code> server.
+   * @returns {undefined|string[]} array of app pages
+   */
+  mwFn.getAppPages = function() {
+    return ["/test.html"];
+  };
+
+  // finally return the middleware function
+  return mwFn;
+};
+```
+
+The returned app pages will be added to the welcome page within the respective mount path.
+
 ## Support
 
 Please use the GitHub bug tracking system to post questions, bug reports or to create pull requests.

--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -59,7 +59,7 @@ cds.on("bootstrap", async function bootstrap(app) {
 		// append the HTML pages to the links
 		appInfo.pages.forEach((page) => {
 			const prefix = mountPath !== "/" ? mountPath : "";
-			links.push(`${prefix}${page.getPath()}`);
+			links.push(`${prefix}${page}`);
 		});
 	}
 


### PR DESCRIPTION
If custom middlewares assign a static `getAppPages` function to their middleware function, the app pages returned by that function will be added to the welcome page of the `@sap/cds` server. This enables middlewares providing virtual pages to list them in the welcome page.

Fixes #785