### PR TITLE
feat(ui5-tooling-transpile): resolve presets/plugins for babel config options

### DIFF
--- a/packages/karma-ui5-transpile/package.json
+++ b/packages/karma-ui5-transpile/package.json
@@ -33,6 +33,6 @@
   },
   "peerDependencies": {
     "karma": ">=6.4.1",
-    "ui5-tooling-transpile": ">=3.0.0"
+    "ui5-tooling-transpile": ">=3.2.0"
   }
 }

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -87,28 +87,26 @@ test("inject configuration options", async (t) => {
 	let babelConfig = await t.context.util.createBabelConfig({ configuration }, cwd);
 	t.deepEqual(
 		babelConfig,
-		(
-			await t.context.util._helpers.loadBabelConfig(
-				{
-					plugins: [],
-					presets: [
-						[
-							"@babel/preset-env",
-							{
-								targets: {
-									browsers: "defaults"
-								}
+		await t.context.util._helpers.loadBabelConfigOptions(
+			{
+				plugins: [],
+				presets: [
+					[
+						"@babel/preset-env",
+						{
+							targets: {
+								browsers: "defaults"
 							}
-						],
-						"transform-ui5",
-						"@babel/preset-typescript"
+						}
 					],
-					sourceMaps: true
-				},
-				true,
-				cwd
-			)
-		).options
+					"transform-ui5",
+					"@babel/preset-typescript"
+				],
+				sourceMaps: true
+			},
+			true,
+			cwd
+		)
 	);
 
 	// typescript, custom transform-ui5 config
@@ -125,33 +123,31 @@ test("inject configuration options", async (t) => {
 	babelConfig = await t.context.util.createBabelConfig({ configuration }, cwd);
 	t.deepEqual(
 		babelConfig,
-		(
-			await t.context.util._helpers.loadBabelConfig(
-				{
-					plugins: [],
-					presets: [
-						[
-							"@babel/preset-env",
-							{
-								targets: {
-									browsers: "defaults"
-								}
+		await t.context.util._helpers.loadBabelConfigOptions(
+			{
+				plugins: [],
+				presets: [
+					[
+						"@babel/preset-env",
+						{
+							targets: {
+								browsers: "defaults"
 							}
-						],
-						[
-							"transform-ui5",
-							{
-								overridesToOverride: true
-							}
-						],
-						"@babel/preset-typescript"
+						}
 					],
-					sourceMaps: true
-				},
-				true,
-				cwd
-			)
-		).options
+					[
+						"transform-ui5",
+						{
+							overridesToOverride: true
+						}
+					],
+					"@babel/preset-typescript"
+				],
+				sourceMaps: true
+			},
+			true,
+			cwd
+		)
 	);
 
 	// typescript, custom typescript and transform-ui5 config
@@ -171,37 +167,35 @@ test("inject configuration options", async (t) => {
 	babelConfig = await t.context.util.createBabelConfig({ configuration }, cwd);
 	t.deepEqual(
 		babelConfig,
-		(
-			await t.context.util._helpers.loadBabelConfig(
-				{
-					plugins: [],
-					presets: [
-						[
-							"@babel/preset-env",
-							{
-								targets: {
-									browsers: "defaults"
-								}
+		await t.context.util._helpers.loadBabelConfigOptions(
+			{
+				plugins: [],
+				presets: [
+					[
+						"@babel/preset-env",
+						{
+							targets: {
+								browsers: "defaults"
 							}
-						],
-						[
-							"transform-ui5",
-							{
-								overridesToOverride: true
-							}
-						],
-						[
-							"@babel/preset-typescript",
-							{
-								optimizeConstEnums: true
-							}
-						]
+						}
 					],
-					sourceMaps: true
-				},
-				true,
-				cwd
-			)
-		).options
+					[
+						"transform-ui5",
+						{
+							overridesToOverride: true
+						}
+					],
+					[
+						"@babel/preset-typescript",
+						{
+							optimizeConstEnums: true
+						}
+					]
+				],
+				sourceMaps: true
+			},
+			true,
+			cwd
+		)
 	);
 });

--- a/showcases/ui5-tsapp/karma-ci-cov.conf.js
+++ b/showcases/ui5-tsapp/karma-ci-cov.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
 		preprocessors: {
 			//"webapp/**/!(*.d.)ts": ["ui5-transpile"],
 			"webapp/{*.ts,!(test)/**/*.ts}": ["ui5-transpile"],
-			"webapp/**/*.js": ["coverage"],
+			"webapp/{*.js,!(test)/**/*.js}": ["coverage"],
 		},
 		coverageReporter: {
 			dir: "coverage",


### PR DESCRIPTION
Ensure to resolve all presets and plugins in the babel configuration options before running the transform functions - which is necessary for pnpm monorepo scenarios or when running a build or serve with the globally installed UI5 tooling.

fix(karma-ui5-transpile): use new preprocess step for babel config

To check the existence of the istanbul plugin in the babel configuration the plugin hooks into the new pre-process phase of the createBabelConfig function from ui5-tooling-transpile and now is able to handle the babel plugin config entries which can be string, an array or a config item.

Fixes #810