### PR TITLE
fix(ui5-middleware-cfdestination): fixed mime info detection

### DIFF
--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -177,7 +177,7 @@ module.exports = async ({ log, resources, options, middlewareUtil }) => {
 	}
 
 	const getMimeInfo = (reqPath, headers) => {
-		const ctHeader = Object.keys(headers).find((header) => /content-type/i.test(header))
+		const ctHeader = Object.keys(headers).find((header) => /^content-type$/i.test(header))
 		if (ctHeader) {
 			const parsedCtHeader = ct.parse(headers[ctHeader])
 			const contentType = parsedCtHeader?.type || "application/octet-stream"


### PR DESCRIPTION
The mime info is derived from the `content-type` header. The regex to identify this header wasn't specific enough. Now the header is identified correctly and side-effect with headlers like: `X-Content-Type-Options` are prevented.

Fixes: #797