### PR TITLE
feat(ui5-middleware-websocket): enable websocket support for UI5 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ packages
 ├── ui5-middleware-servestatic      // middleware extension: serve static resources
 ├── ui5-middleware-simpleproxy      // middleware extension: simple express proxy
 ├── ui5-middleware-webjars          // middleware extension: deliver content from JAR files
+├── ui5-middleware-websocket        // middleware extension: enable web sockets for the UI5 Tooling
 ├── ui5-task-cachebuster            // task extension: enables cachebusting for standalone applications
 ├── ui5-task-compileless            // task extension: compile less files in the app folder
 ├── ui5-task-flatten-library        // task extension: prepares build result for deployment to SAP NetWeaver
@@ -146,13 +147,14 @@ The tasks developed in this monorepo are also publicly available on NPM right he
 * https://www.npmjs.com/package/ui5-task-cachebuster
 * https://www.npmjs.com/package/ui5-task-compileless
 * https://www.npmjs.com/package/ui5-task-flatten-library
-* https://www.npmjs.com/package/ui5-task-minify-xml
 * https://www.npmjs.com/package/ui5-task-i18ncheck 
+* https://www.npmjs.com/package/ui5-task-minify-xml
 * https://www.npmjs.com/package/ui5-task-pwa-enabler
 * https://www.npmjs.com/package/ui5-task-zipper
 
 The middlewares developed in this monorepo are also publicly available on NPM right here:
 
+* https://www.npmjs.com/package/ui5-middleware-cap
 * https://www.npmjs.com/package/ui5-middleware-cfdestination
 * https://www.npmjs.com/package/ui5-middleware-iasync (alpha! careful!)
 * https://www.npmjs.com/package/ui5-middleware-index
@@ -162,6 +164,7 @@ The middlewares developed in this monorepo are also publicly available on NPM ri
 * https://www.npmjs.com/package/ui5-middleware-servestatic
 * https://www.npmjs.com/package/ui5-middleware-simpleproxy
 * https://www.npmjs.com/package/ui5-middleware-webjars
+* https://www.npmjs.com/package/ui5-middleware-websocket
 
 The tooling extensions (contains tasks and middlewares) developed in this monorepo are available on NPM right here:
 
@@ -197,6 +200,7 @@ Available middlewares in this project:
 | [ui5-middleware-onelogin](packages/ui5-middleware-onelogin/README.md) | enable a generic login support | [![npm version](https://badge.fury.io/js/ui5-middleware-onelogin.svg)](https://badge.fury.io/js/ui5-middleware-onelogin) |
 | [ui5-middleware-simpleproxy](packages/ui5-middleware-simpleproxy/README.md) | simple express proxy | [![npm version](https://badge.fury.io/js/ui5-middleware-simpleproxy.svg)](https://badge.fury.io/js/ui5-middleware-simpleproxy) |
 | [ui5-middleware-webjars](packages/ui5-middleware-webjars/README.md) | deliver content from JAR files | [![npm version](https://badge.fury.io/js/ui5-middleware-webjars.svg)](https://badge.fury.io/js/ui5-middleware-webjars) |
+| [ui5-middleware-websocket](packages/ui5-middleware-websocket/README.md) | enable web sockets for UI5 tooling | [![npm version](https://badge.fury.io/js/ui5-middleware-websocket.svg)](https://badge.fury.io/js/ui5-middleware-websocket) |
 
 Available tooling extensions in this project:
 

--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -27,7 +27,8 @@
     "dotenv": "^16.3.1",
     "http-proxy-middleware": "^2.0.6",
     "mime-types": "^2.1.35",
-    "portfinder": "^1.0.32"
+    "portfinder": "^1.0.32",
+    "ui5-middleware-websocket": "workspace:^"
   },
   "devDependencies": {
     "@ui5/cli": "^3.4.0",

--- a/packages/ui5-middleware-cfdestination/test/websocket.test.js
+++ b/packages/ui5-middleware-cfdestination/test/websocket.test.js
@@ -1,0 +1,141 @@
+const test = require("ava")
+const path = require("path")
+
+const express = require("express")
+const expressws = require("ui5-middleware-websocket/lib/expressws")
+
+const supertest = require("supertest")
+const superwstest = require("superwstest")
+const nock = require("nock")
+
+// Start server before running tests
+test.before(async (t) => {
+	// create the ports for the proxy server
+	const getPort = (await import("get-port")).default
+	const appRouterPort = await getPort()
+	const ui5ServerPort = await getPort()
+	const wsServerPort = await getPort()
+
+	// setup the WebSocket echo server (as counterpart)
+	const wsApp = express()
+	expressws(wsApp) // enhance the express app for websocket support
+	wsApp.ws("/", function (ws /*, req, next */) {
+		ws.on("message", function (message) {
+			console.log(`message: ${message}`)
+			ws.send(`echo ${message}`)
+		})
+		ws.send(`hello`)
+	})
+	t.context.wsServer = wsApp.listen(wsServerPort)
+
+	// start the UI5 development server with multiple proxy middlewares
+	const { graphFromPackageDependencies } = await import("@ui5/project/graph")
+	const debug = false
+	const graph = await graphFromPackageDependencies({
+		cwd: "../../showcases/ui5-app",
+		rootConfiguration: {
+			specVersion: "3.0",
+			metadata: {
+				name: "ui5-middleware-cfdestination-test"
+			},
+			type: "application",
+			server: {
+				customMiddleware: [
+					{
+						name: "ui5-middleware-cfdestination",
+						afterMiddleware: "compression",
+						configuration: {
+							debug: true,
+							port: appRouterPort,
+							xsappJson: path.resolve(__dirname, "./websocket/xs-app.json"),
+							destinations: [
+								{
+									name: "express",
+									url: `ws://localhost:${wsServerPort}`
+								},
+								{
+									name: "ui5",
+									url: `ws://localhost:${ui5ServerPort}/wsecho/`
+								}
+							],
+							enableWebSocket: true
+						}
+					},
+					{
+						name: "ui5-middleware-websocket-echo",
+						afterMiddleware: "compression",
+						mountPath: "/wsecho/"
+					}
+				]
+			}
+		}
+	})
+
+	// start the UI5 server
+	const { serve } = await import("@ui5/server")
+	t.context.server = await serve(graph, {
+		port: ui5ServerPort
+	})
+	const wsRequest = superwstest
+	t.context.wsRequest = wsRequest(`http://localhost:${ui5ServerPort}`)
+})
+
+test.after.always((t) => {
+	// eslint-disable-next-line jsdoc/require-jsdoc
+	function close(server) {
+		return new Promise((resolve, reject) => {
+			server.close((error) => {
+				if (error) {
+					reject(error)
+				} else {
+					resolve()
+				}
+			})
+		})
+	}
+
+	// stop all servers
+	return Promise.all([close(t.context.wsServer), close(t.context.server)])
+})
+
+test("WebSocket basic test (express server)", async (t) => {
+	const { wsRequest } = t.context
+	await wsRequest
+		.ws("/express", {
+			origin: "http://localhost"
+		})
+		.expectText((msg) => {
+			t.is(msg, "hello")
+			return true
+		})
+		.sendText("XXX")
+		.expectText((msg) => {
+			t.is(msg, "echo XXX")
+			return true
+		})
+		.close()
+})
+
+// Using the ui5-app the websocket-echo service works, but not in the test!
+// This is something to be followed up in the future - but nevertheless no
+// typical scenario - normally the websocket service is on other machines
+// and not proxied from the UI5 server via the approuter to the UI5 server!!
+/*
+test("WebSocket basic test (ui5 server)", async (t) => {
+	const { wsRequest } = t.context;
+	await wsRequest
+		.ws("/ui5", {
+			origin: "http://localhost:1081"
+		})
+		.expectText((msg) => {
+			t.is(msg, "hello");
+			return true;
+		})
+		.sendText("XXX")
+		.expectText((msg) => {
+			t.is(msg, "echo XXX");
+			return true;
+		})
+		.close();
+});
+*/

--- a/packages/ui5-middleware-cfdestination/test/websocket/xs-app.json
+++ b/packages/ui5-middleware-cfdestination/test/websocket/xs-app.json
@@ -1,0 +1,18 @@
+{
+  "authenticationMethod": "none",
+  "routes": [
+    {
+      "source": "^/express(.*)$",
+      "destination": "express",
+      "target": "$1"
+    },
+    {
+      "source": "^/ui5(.*)$",
+      "destination": "ui5",
+      "target": "$1"
+    }
+  ],
+  "websockets": {
+    "enabled": true
+  }
+}

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -17,24 +17,26 @@ npm install ui5-middleware-simpleproxy --save-dev
 
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
-- baseUri: `string`
-  The baseUri to proxy. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI` environment variable.
-- strictSSL: `boolean`
+- `baseUri`: `string`
+  The baseUri to proxy. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI` environment variable. To proxy WebSockets just use a WebSocket URL, e.g. `ws://echo.websocket.org`
+- `strictSSL`: `boolean`
   Ignore strict SSL checks. Default value `true`. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL` environment variable.
-- removeETag:  `boolean`
+- `removeETag`:  `boolean`
   Removes the ETag header from the response to avoid conditional requests.
-- username:  `string`
+- `username`:  `string`
   Username used for Basic Authentication.
-- password:  `string`
+- `password`:  `string`
   Password used for Basic Authentication.
-- httpHeaders: `map`
+- `httpHeaders`: `map`
   Http headers set for the proxied request. Will overwrite the http headers from the request. 
-- query: `map`
+- `query`: `map`
   Query parameters set for the proxied request. Will overwrite the parameters from the request. 
-- excludePatterns: `string[]`
+- `excludePatterns`: `string[]`
   Array of exclude patterns using glob syntax
-- skipCache: `boolean`
+- `skipCache`: `boolean`
   Remove the cache guid when serving from the FLP launchpad if it matches an excludePattern
+- `enableWebSocket`: `<boolean>`, default: `false` *experimental*
+enables support for proxying web sockets
 
 In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
 

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -26,7 +26,8 @@
     "http-proxy-middleware": "^2.0.6",
     "https-proxy-agent": "^7.0.1",
     "minimatch": "^7.4.6",
-    "proxy-from-env": "^1.1.0"
+    "proxy-from-env": "^1.1.0",
+    "ui5-middleware-websocket": "workspace:^"
   },
   "devDependencies": {
     "@ui5/project": "^3.6.0",
@@ -35,6 +36,9 @@
     "get-port": "^7.0.0",
     "nock": "^13.3.3",
     "node-tcp-proxy": "^0.0.28",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "superwstest": "^2.0.3",
+    "ui5-middleware-websocket": "workspace:^",
+    "ws": "^8.13.0"
   }
 }

--- a/packages/ui5-middleware-simpleproxy/test/index.html
+++ b/packages/ui5-middleware-simpleproxy/test/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>TEST</title>
+	</head>
+	<body></body>
+</html>

--- a/packages/ui5-middleware-websocket/README.md
+++ b/packages/ui5-middleware-websocket/README.md
@@ -1,0 +1,71 @@
+# UI5 middleware to enable websockets
+
+> :wave: This is a **community project** and there is no official support for this package! Feel free to use it, open issues, contribute, and help answering questions.
+
+Middleware for [ui5-server](https://github.com/SAP/ui5-server) to demo WebSocket usage with an simple echo service.
+
+## Prerequisites
+
+- Requires at least [`@ui5/cli@3.0.0`](https://sap.github.io/ui5-tooling/v3/pages/CLI/) (to support [`specVersion: "3.0"`](https://sap.github.io/ui5-tooling/pages/Configuration/#specification-version-30))
+
+> :warning: **UI5 Tooling Compatibility**
+> All releases of this tooling extension using the major version `3` require UI5 Tooling V3. Any previous releases below major version `3` (if available) also support older versions of the UI5 Tooling. But the usage of the latest UI5 Tooling is strongly recommended!
+
+## Install
+
+```bash
+npm install ui5-middleware-websocket --save-dev
+```
+
+## Usage
+
+1. Define the dependency in `$yourapp/package.json`:
+
+```json
+"devDependencies": {
+    // ...
+    "ui5-middleware-websocket-echo": "*"
+    // ...
+}
+```
+
+2. configure it in `$yourapp/ui5.yaml`:
+
+```yaml
+server:
+  customMiddleware:
+  - name: ui5-middleware-websocket-echo
+    afterMiddleware: compression
+    mountPath: /wsecho
+```
+
+## How it works
+
+The middleware uses the utility function `websocket` which allows to inject a WebSocket middleware function into a UI5 middleware function:
+
+```js
+const websocket = require("ui5-middleware-websocket/lib/websocket");
+
+/**
+ * WebSocket middleware to act as an echo service.
+ *
+ * @param {object} parameters Parameters
+ * @param {@ui5/logger/Logger} parameters.log Logger instance
+ * @returns {Function} Middleware function to use
+ */
+module.exports = ({ log }) => {
+  return websocket(function echo(ws, req /*, next */) {
+    ws.on("message", function (message) {
+      log.info(`message: ${message}`);
+      ws.send(`echo ${message}`);
+    });
+    log.info(`Connection established with ${req.url}`);
+  });
+};
+```
+
+## License
+
+This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+
+When you like this stuff, buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see him.

--- a/packages/ui5-middleware-websocket/lib/echo.js
+++ b/packages/ui5-middleware-websocket/lib/echo.js
@@ -1,0 +1,21 @@
+const websocket = require("./websocket");
+
+/**
+ * WebSocket middleware to act as an echo server. This is just
+ * a demo middleware to test/showcase a WebSocket middleware
+ * function in the UI5 tooling.
+ *
+ * @param {object} parameters Parameters
+ * @param {@ui5/logger/Logger} parameters.log Logger instance
+ * @returns {Function} Middleware function to use
+ */
+module.exports = ({ log }) => {
+	// simulate a non-express app to get access to the app!
+	return websocket(function echo(ws, req /*, next */) {
+		ws.on("message", function (message) {
+			log.info(`message: ${message}`);
+			ws.send(`echo ${message}`);
+		});
+		log.info(`Connection established with ${req.url}`);
+	});
+};

--- a/packages/ui5-middleware-websocket/lib/expressws.js
+++ b/packages/ui5-middleware-websocket/lib/expressws.js
@@ -1,0 +1,135 @@
+// INSPIRED BY: https://github.com/HenningM/express-ws
+
+const http = require("http");
+const { Server: WebSocketServer } = require("ws");
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function suffixWsPath(path) {
+	const url = new URL(path.replace(/(\/+)$/, "") + "/.ws", "ws://localhost");
+	return `${url.pathname}${url.search}`;
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function wrapMiddleware(middleware) {
+	return (req, res, next) => {
+		if (req.ws != null) {
+			// request is a websocket request => delegate
+			middleware(req.ws, req, next);
+			req.ws._handled = true;
+		} else {
+			// no websocket request => ignore
+			next();
+		}
+	};
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function createWebSocketServer(app, server) {
+	// install the handler
+	const wss = new WebSocketServer({ noServer: true });
+	server.on(
+		"upgrade",
+		function upgrade(req, socket, head) {
+			const { wssRoutes } = this["ui5-middleware-websocket"];
+			const pathname = suffixWsPath(req.url?.match("^[^?]*")[0]);
+			if (wssRoutes.indexOf(pathname) !== -1) {
+				wss.handleUpgrade(req, socket, head, function done(ws) {
+					// emit the connection event
+					wss.emit("connection", ws, req);
+					// send a dummy request
+					sendDummyRequest(app, req, ws);
+				});
+			}
+			/*
+		} else {
+			socket.destroy();
+		}
+		*/
+		}.bind(app)
+	);
+	return wss;
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function sendDummyRequest(app, req, socket) {
+	// add the websocket to the request
+	req.ws = socket;
+	req.ws._handled = false;
+	// the fake url delegates the request to the fake GET handler we used to register
+	// the middleware functions which take unpack the websocket again from the request
+	req["ui5-middleware-websocket"] = {
+		url: req.url,
+	};
+	req.url = suffixWsPath(req.url);
+	// let express validate whether the websocket works or not
+	const res = new http.ServerResponse(req);
+	app.handle(req, res, (err) => {
+		// if the request wasn't handled as websocket there must be an error
+		if (err) {
+			throw err;
+		} else if (!req.ws?._handled) {
+			socket.close();
+		}
+	});
+}
+
+/**
+ * Middleware callback function to handle the websocket request
+ *
+ * @callback WSMiddlewareFunction
+ * @param {WebSocket} ws websocket object
+ * @param {Express.Request} req express request object
+ * @param {function} next function to trigger the next middleware
+ * @returns {void}
+ */
+
+/**
+ * Routes websocket requests to the specified path with the specified callback functions.
+ *
+ * @param {string} path
+ * @param  {...WSMiddlewareFunction} middlewares middleware callback functions
+ * @returns
+ */
+function wsRoute(path, ...middlewares) {
+	const wrappedMiddlewares = middlewares.flat().map(wrapMiddleware);
+	// add a suffix to identify the router again and use the express server
+	// for the routing and the error handling (reuse as much as possible!!)
+	const wsPath = suffixWsPath(path);
+	// register the route to know which one should be handled by the WebSocketServer
+	this["ui5-middleware-websocket"].wssRoutes.push(wsPath);
+	// create a GET router for internal usage only to reuse express functionality
+	this.get(wsPath, ...wrappedMiddlewares);
+	// the usual express chaining support ;-)
+	return this;
+}
+
+/**
+ * Enhances an Express application to support WebSockets by adding
+ * a WebSocketServer and adding a custom `ws` function which allows
+ * to register custom routes for WebSockets to the Express app.
+ *
+ * @param {Express.Application} app the express application
+ * @param {http.Server} server the http server instance
+ * @param {object} options some options
+ * @returns {void}
+ */
+module.exports = function expressws(app, server /*, options = {} */) {
+	if (app.ws == null) {
+		// create an own server if not provided
+		if (!server) {
+			server = http.createServer(app);
+			app.listen = function serverListen(...args) {
+				return server.listen(...args);
+			};
+		}
+		// store the reference to the WebSocketServer
+		app["ui5-middleware-websocket"] = {
+			wss: createWebSocketServer(app, server),
+			wssRoutes: [], // filled by wsRoute function
+		};
+		// install the custom ws function on the app instance
+		app.ws = wsRoute;
+	} else {
+		throw new Error("Express application has been upgraded for WebSocket support already!");
+	}
+};

--- a/packages/ui5-middleware-websocket/lib/hook.js
+++ b/packages/ui5-middleware-websocket/lib/hook.js
@@ -1,0 +1,106 @@
+/* ------------------------------------------------------------------------- *
+ *     .----..-.    .--.  .---..-. .-.   .-.   .-. .--.  .---..-..---.       *
+ *     | {}  | |   / {} \/  ___| |/ /    |  `.'  |/ {} \/   __| /  ___}      *
+ *     | {}  | `--/  /\  \     | |\ \    | |\ /| /  /\  \  {_ | \     }      *
+ *     `----'`----`-'  `-'`---'`-' `-'   `-' ` `-`-'  `-'`---'`-'`---'       *
+ *                        PROVIDED BY PETER MUESSIG                          *
+ *   .-. .-..----.    .-. . .-. .--. .----..----.  .--. .-. .-..---.-.  .-.  *
+ *   |  `| /  {}  \   | |/ \| |/ {} \| {}  | {}  }/ {} \|  `| {_   _\ \/ /   *
+ *   | |\  \      /   |  .'.  /  /\  | .-. | .-. /  /\  | |\  | | |  }  {    *
+ *   `-' `-'`----'    `-'   `-`-'  `-`-' `-`-' `-`-'  `-`-' `-' `-'  `--'    *
+ *                          USE AT YOUR OWN RISK!                            *
+ * ------------------------------------------------------------------------- */
+// Created with the text ASCII art generator https://patorjk.com/software/taag/
+//   => #p=display&h=3&f=JS%20Bracket%20Letters&t=BLACK%20MAGIC%0ANO%20WARRANTY
+
+const http = require("http");
+
+/**
+ * Callback function to inform when the server is listening which provides access to
+ * the server instance and the express app.
+ *
+ * @callback ServerListenCallback
+ * @param {object} parameters the callback parameters
+ * @param {Express.Application} parameters.app the express application
+ * @param {http.Server} parameters.server the http server instance
+ * @param {function} parameters.on function to register event handlers for the server which raise only if the mountpath matches
+ * @param {object} parameters.options some options
+ * @param {string} parameters.options.mountpath mount path of the middleware function
+ * @param {string} [parameters.options.host] host the server is listening on
+ * @param {number} [parameters.options.port] port the server is listening to
+ * @returns {void}
+ */
+
+/**
+ * Middleware callback function to handle the request
+ *
+ * @callback MiddlewareFunction
+ * @param {Express.Request} req express request object
+ * @param {Express.Response} res express response object
+ * @param {function} next function to trigger the next middleware
+ * @returns {void}
+ */
+
+/**
+ * This function installs an express app-like middleware function
+ * to get access to the express app and intercepts the listen function
+ * to get access to the server instance.
+ *
+ * @param {string} name name of the middleware function
+ * @param {ServerListenCallback} callback callback function when the middleware has been mounted and the server is listening
+ * @param {MiddlewareFunction} [middleware] optional middleware function which is called to handle the request
+ * @returns {Function} Middleware function to use
+ */
+module.exports = function hook(name, callback, middleware) {
+	// simulate a non-express app to get access to the app!
+	if (typeof callback === "function") {
+		const fn = function () {};
+		Object.defineProperty(fn, "name", {
+			value: name || "hook",
+			writable: false,
+		});
+		Object.assign(fn, {
+			handle: function handle(req, res, next) {
+				if (typeof middleware === "function") {
+					middleware.apply(this, arguments);
+				} else {
+					next(); // ignore requests, just delegate
+				}
+			},
+			set: () => {
+				/* noop! */
+			},
+			emit: (event, app) => {
+				// intercept the mount event to get access to the app
+				if (event === "mount") {
+					// intercept the listen call to get access to the server
+					const { listen } = app;
+					app.listen = function () {
+						const server = listen.apply(this, arguments);
+						const options =
+							typeof arguments[0] === "object"
+								? arguments[0]
+								: {
+										host: typeof arguments[0] === "number" ? arguments[1] : undefined,
+										port: typeof arguments[0] === "number" ? arguments[0] : undefined,
+								  };
+						options.mountpath = fn.mountpath;
+						//options.parent = fn.parent;
+						callback({
+							app: this,
+							server,
+							on: server.on.bind(server),
+							options,
+						});
+						return server;
+					};
+				}
+			},
+		});
+		return fn;
+	} else {
+		return async function (req, res, next) {
+			/* dummy middleware function */ next();
+		};
+	}
+};

--- a/packages/ui5-middleware-websocket/lib/websocket.js
+++ b/packages/ui5-middleware-websocket/lib/websocket.js
@@ -1,0 +1,29 @@
+const hook = require("./hook");
+const expressws = require("./expressws");
+
+/**
+ * Middleware callback function to handle the WebSocket request
+ *
+ * @callback WSMiddlewareFunction
+ * @param {WebSocket} ws websocket object
+ * @param {Express.Request} req express request object
+ * @param {function} next function to trigger the next middleware
+ * @returns {void}
+ */
+
+/**
+ * Function to inject a WebSocket middleware function into an Express middleware.
+ *
+ * @param {WSMiddlewareFunction} middleware the websocket middleware function to wrap
+ * @returns {Function} Middleware function for the UI5 Tooling
+ */
+module.exports = function websocket(middleware) {
+	return hook(middleware.name || "generic-ui5-middleware-websocket", ({ app, server, options }) => {
+		// enhance the express server for websocket support
+		expressws(app, server);
+		// register the mountpath or the root path if no mountpath is defined
+		app.ws(options.mountpath || "/", function (/*ws, req, next */) {
+			middleware.apply(this, arguments);
+		});
+	});
+};

--- a/packages/ui5-middleware-websocket/package.json
+++ b/packages/ui5-middleware-websocket/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ui5-middleware-websocket",
+  "version": "3.0.0-alpha.0",
+  "description": "UI5 middleware utilities to enable WebSockets for Express servers like the UI5 server",
+  "author": "Peter Muessig",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",
+    "directory": "packages/ui5-middleware-websocket"
+  },
+  "dependencies": {
+    "ws": "^8.13.0"
+  },
+  "scripts": {
+    "lint": "eslint lib"
+  }
+}

--- a/packages/ui5-middleware-websocket/ui5.yaml
+++ b/packages/ui5-middleware-websocket/ui5.yaml
@@ -1,0 +1,8 @@
+# https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
+specVersion: "3.0"
+metadata:
+  name: ui5-middleware-websocket-echo
+kind: extension
+type: server-middleware
+middleware:
+  path: lib/echo.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       portfinder:
         specifier: ^1.0.32
         version: 1.0.32
+      ui5-middleware-websocket:
+        specifier: workspace:^
+        version: link:../ui5-middleware-websocket
     devDependencies:
       '@ui5/cli':
         specifier: ^3.4.0
@@ -281,6 +284,9 @@ importers:
       proxy-from-env:
         specifier: ^1.1.0
         version: 1.1.0
+      ui5-middleware-websocket:
+        specifier: workspace:^
+        version: link:../ui5-middleware-websocket
     devDependencies:
       '@ui5/project':
         specifier: ^3.6.0
@@ -303,12 +309,24 @@ importers:
       supertest:
         specifier: ^6.3.3
         version: 6.3.3
+      superwstest:
+        specifier: ^2.0.3
+        version: 2.0.3(supertest@6.3.3)
+      ws:
+        specifier: ^8.13.0
+        version: 8.13.0
 
   packages/ui5-middleware-webjars:
     dependencies:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+
+  packages/ui5-middleware-websocket:
+    dependencies:
+      ws:
+        specifier: ^8.13.0
+        version: 8.13.0
 
   packages/ui5-task-cachebuster:
     devDependencies:
@@ -674,6 +692,9 @@ importers:
       ui5-middleware-webjars:
         specifier: workspace:^
         version: link:../../packages/ui5-middleware-webjars
+      ui5-middleware-websocket:
+        specifier: workspace:^
+        version: link:../../packages/ui5-middleware-websocket
       ui5-task-cachebuster:
         specifier: workspace:^
         version: link:../../packages/ui5-task-cachebuster
@@ -4668,6 +4689,10 @@ packages:
     resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
     dev: true
 
+  /@types/cookiejar@2.1.2:
+    resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
+    dev: true
+
   /@types/cors@2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
@@ -4960,6 +4985,19 @@ packages:
     resolution: {integrity: sha512-qU/K1tb2yUdhXkLIATzsIPwbtX6BpZk0l3dPW6xqWyhfzzM1ECaQ/8faEnu3CNraLiQ9LHyQQPBGp7N9Fbs25w==}
     dependencies:
       '@types/node': 20.4.10
+    dev: true
+
+  /@types/superagent@4.1.18:
+    resolution: {integrity: sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==}
+    dependencies:
+      '@types/cookiejar': 2.1.2
+      '@types/node': 20.4.10
+    dev: true
+
+  /@types/supertest@2.0.12:
+    resolution: {integrity: sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==}
+    dependencies:
+      '@types/superagent': 4.1.18
     dev: true
 
   /@types/supports-color@8.1.1:
@@ -16753,6 +16791,23 @@ packages:
       - supports-color
     dev: true
 
+  /superwstest@2.0.3(supertest@6.3.3):
+    resolution: {integrity: sha512-NRZMg+1UU1KNWzkE/QBqBDuTKPG2vFBLvG4xahcPqzZynVnbs3idllwgUL7zglPXymPP1g04+3NDGhbt6NCa5A==}
+    peerDependencies:
+      supertest: '*'
+    peerDependenciesMeta:
+      supertest:
+        optional: true
+    dependencies:
+      '@types/supertest': 2.0.12
+      '@types/ws': 8.5.5
+      supertest: 6.3.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
     engines: {node: '>=0.8.0'}
@@ -18183,7 +18238,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /ws@8.2.3:
     resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}

--- a/showcases/ui5-app/package.json
+++ b/showcases/ui5-app/package.json
@@ -82,6 +82,7 @@
     "ui5-middleware-servestatic": "workspace:^",
     "ui5-middleware-simpleproxy": "workspace:^",
     "ui5-middleware-webjars": "workspace:^",
+    "ui5-middleware-websocket": "workspace:^",
     "ui5-task-cachebuster": "workspace:^",
     "ui5-task-compileless": "workspace:^",
     "ui5-task-i18ncheck": "workspace:^",

--- a/showcases/ui5-app/ui5-dist.yaml
+++ b/showcases/ui5-app/ui5-dist.yaml
@@ -74,6 +74,8 @@ server:
             url: "https://services.odata.org/V2/Northwind/Northwind.svc/"
           - name: "todos"
             url: "https://jsonplaceholder.typicode.com/todos/"
+          - name: "cfwsecho"
+            url: "ws://localhost:1081/wsecho/"
     - name: ui5-middleware-index
       afterMiddleware: compression
       configuration:

--- a/showcases/ui5-app/ui5-min.yaml
+++ b/showcases/ui5-app/ui5-min.yaml
@@ -54,9 +54,22 @@ server:
       mountPath: /ui5
       afterMiddleware: compression
       configuration:
+        debug: true
         baseUri: "https://sdk.openui5.org/"
-        limit: "5mb"
         removeETag: true
+    - name: ui5-middleware-simpleproxy
+      mountPath: /odatav4
+      afterMiddleware: compression
+      configuration:
+        debug: true
+        baseUri: "https://services.odata.org/V4/(S(soab2geixerd5hqzncsoqpba))/TripPinServiceRW/"
+    - name: ui5-middleware-simpleproxy
+      mountPath: /spwsecho
+      afterMiddleware: compression
+      configuration:
+        debug: true
+        baseUri: "ws://localhost:1081/wsecho/"
+        enableWebSocket: true
     - name: ui5-middleware-cfdestination
       afterMiddleware: compression
       configuration:
@@ -71,6 +84,8 @@ server:
             url: "https://services.odata.org/V2/Northwind/Northwind.svc/"
           - name: "todos"
             url: "https://jsonplaceholder.typicode.com/todos/"
+          - name: "cfwsecho"
+            url: "ws://localhost:1081/wsecho/"
     - name: ui5-middleware-index
       afterMiddleware: compression
       configuration:

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -137,6 +137,13 @@ server:
       configuration:
         debug: true
         baseUri: "https://services.odata.org/V4/(S(soab2geixerd5hqzncsoqpba))/TripPinServiceRW/"
+    - name: ui5-middleware-simpleproxy
+      mountPath: /spwsecho
+      afterMiddleware: compression
+      configuration:
+        debug: true
+        baseUri: "ws://localhost:1081/wsecho/"
+        enableWebSocket: true
     - name: ui5-tooling-stringreplace-middleware
       afterMiddleware: compression
       configuration:
@@ -162,6 +169,9 @@ server:
             url: "https://services.odata.org/V2/Northwind/Northwind.svc/"
           - name: "todos"
             url: "https://jsonplaceholder.typicode.com/todos/"
+          - name: "cfwsecho"
+            url: "ws://localhost:1081/wsecho/"
+        enableWebSocket: true
     #- name: ui5-middleware-iasync
     #  beforeMiddleware: serveResources
     #  configuration:
@@ -190,6 +200,9 @@ server:
       beforeMiddleware: serveResources
       configuration:
         debug: true
+    - name: ui5-middleware-websocket-echo
+      afterMiddleware: compression
+      mountPath: /wsecho/
     # Last middleware (for the same afterMiddleware) comes first!
     - name: ui5-middleware-livereload
       afterMiddleware: compression

--- a/showcases/ui5-app/webapp/controller/Main.controller.js
+++ b/showcases/ui5-app/webapp/controller/Main.controller.js
@@ -1,51 +1,112 @@
-sap.ui.define(["ui5/ecosystem/demo/app/controller/BaseController", "sap/ui/model/json/JSONModel", "sap/m/MessageToast"], (Controller, JSONModel, MessageToast) => {
-	"use strict";
+sap.ui.define(
+	["ui5/ecosystem/demo/app/controller/BaseController", "sap/ui/model/json/JSONModel", "sap/m/MessageToast", "sap/ui/core/ws/WebSocket"],
+	(Controller, JSONModel, MessageToast, WebSocket) => {
+		"use strict";
 
-	return Controller.extend("ui5.ecosystem.demo.app.controller.Main", {
-		// (live) transpiling async functions to ES5 generators not yet doable in ui5-tooling ecosys :)
-		/* async */ onInit() {
-			var versionModel = new JSONModel();
-			this.getView().setModel(versionModel, "UI5Version");
+		const wsMap = new Map();
+		const createWebSocket = function (wsUrl, onMessage, onError) {
+			return (
+				wsMap.get(wsUrl) ||
+				wsMap
+					.set(
+						wsUrl,
+						new Promise(function (res, rej) {
+							const ws = new WebSocket(wsUrl);
+							ws.attachOpen(
+								function (event) {
+									// give the socket connection some time to be setup
+									setTimeout(function () {
+										res([ws, event.getParameter("data")]);
+									}, 100);
+								}.bind(ws)
+							);
+							ws.attachMessage(
+								(
+									(typeof onMessage === "function" && onMessage) ||
+									function (event) {
+										MessageToast.show(`ℹ [WS] Server responded: ${event.getParameter("data")}`);
+									}
+								).bind(ws)
+							);
+							ws.attachError(
+								(
+									(typeof onError === "function" && onError) ||
+									function (event) {
+										rej([this, event.getParameter("data")]);
+									}
+								).bind(ws)
+							);
+							ws.attachClose(function (event) {
+								const { data, code, reason } = event.getParameters();
+								if (event.wasClean) {
+									MessageToast.show(`ℹ [WS] Connection closed (code=${code} reason=${reason})`);
+								} else {
+									MessageToast.show(`⚠️ [WS] Connection died! Reason: ${data}`);
+								}
+							});
+						})
+					)
+					.get(wsUrl)
+			);
+		};
 
-			sap.ui.getVersionInfo({ async: true }).then((versionInfo) => {
-				versionModel.setData({
-					current: versionInfo.libraries.find((lib) => lib.name === "sap.ui.core"),
+		return Controller.extend("ui5.ecosystem.demo.app.controller.Main", {
+			async onInit() {
+				var versionModel = new JSONModel();
+				this.getView().setModel(versionModel, "UI5Version");
+
+				sap.ui.getVersionInfo({ async: true }).then((versionInfo) => {
+					versionModel.setData({
+						current: versionInfo.libraries.find((lib) => lib.name === "sap.ui.core"),
+					});
 				});
-			});
 
-			fetch("docs/index.md")
-				.then((response) => response.text())
-				.then((content) => {
-					this.byId("doc").setValue(content);
-				})
-				.catch((err) => console.error(err));
+				try {
+					const indexResponse = await fetch("docs/index.md");
+					const indexContent = await indexResponse.text();
+					this.byId("doc").setValue(indexContent);
+				} catch (err) {
+					console.error(err);
+				}
 
-			fetch("/proxy/local/hello.txt")
-				.then((response) => response.text())
-				.then((content) => {
-					console.log(content);
-				})
-				.catch((err) => console.error(err));
-		},
+				try {
+					const helloResponse = await fetch("/proxy/local/hello.txt");
+					const helloContent = await helloResponse.text();
+					console.log(helloContent);
+				} catch (err) {
+					console.error(err);
+				}
+			},
 
-		navFwd() {
-			return this.getOwnerComponent().getRouter().navTo("RouteOther");
-		},
-		navFwdODataV4() {
-			return this.getOwnerComponent().getRouter().navTo("RouteODataV4");
-		},
-		navFwdODataV2() {
-			return this.getOwnerComponent().getRouter().navTo("RouteODataV2");
-		},
-		navTest3rd() {
-			return this.getOwnerComponent().getRouter().navTo("RouteThirdparty");
-		},
+			navTo: function (route) {
+				return this.getOwnerComponent().getRouter().navTo(route);
+			},
 
-		onPress(oEvent) {
-			MessageToast.show(`${oEvent.getSource().getId()} pressed`);
-		},
-		onBoo() {
-			MessageToast.show(`👻`);
-		},
-	});
-});
+			onPress(oEvent) {
+				MessageToast.show(`${oEvent.getSource().getId()} pressed`);
+			},
+			onBoo() {
+				MessageToast.show(`👻`);
+			},
+
+			async testWebSocket() {
+				const ws = (await createWebSocket(`ws${location.protocol === "https:" ? "s" : ""}://${location.host}/wsecho`))?.[0];
+				if (ws) {
+					ws.send("Hello ui5-middleware-websocket! 👋");
+				}
+			},
+			async testWebSocketSP() {
+				const ws = (await createWebSocket(`ws${location.protocol === "https:" ? "s" : ""}://${location.host}/spwsecho`))?.[0];
+				if (ws) {
+					ws.send("Hello ui5-middleware-simpleproxy! 👋");
+				}
+			},
+			async testWebSocketCF() {
+				const ws = (await createWebSocket(`ws${location.protocol === "https:" ? "s" : ""}://${location.host}/cfwsecho`))?.[0];
+				if (ws) {
+					ws.send("Hello ui5-middleware-cfdestination! 👋");
+				}
+			},
+		});
+	}
+);

--- a/showcases/ui5-app/webapp/manifest.json
+++ b/showcases/ui5-app/webapp/manifest.json
@@ -34,7 +34,7 @@
         }
       },
       "UI5VersionInfo": {
-        "uri": "/versioninfo/version.json",
+        "uri": "versioninfo/version.json",
         "type": "JSON"
       }
     }
@@ -91,7 +91,10 @@
         }
       },
       "ODataV2": {
-        "dataSource": "ODataV2DataSource"
+        "dataSource": "ODataV2DataSource",
+        "settings": {
+          "disableHeadRequestForToken": true
+        }
       },
       "ODataV4": {
         "dataSource": "ODataV4DataSource",

--- a/showcases/ui5-app/webapp/test/unit/controller/Main.controller.js
+++ b/showcases/ui5-app/webapp/test/unit/controller/Main.controller.js
@@ -21,7 +21,7 @@ sap.ui.define(["ui5/ecosystem/demo/app/controller/Main.controller", "sap/ui/thir
 			getRouter: sinon.stub().returnsThis(),
 			navTo: sinon.stub().returns("stubbed"),
 		});
-		const stubbedRet = oAppController.navFwd();
+		const stubbedRet = oAppController.navTo("RouteOther");
 		oRouterStub.restore();
 		assert.strictEqual(stubbedRet, "stubbed");
 	});

--- a/showcases/ui5-app/webapp/view/Main.view.xml
+++ b/showcases/ui5-app/webapp/view/Main.view.xml
@@ -7,9 +7,11 @@
     <content>
       <VBox alignItems="Center" justifyContent="Center" height="100%">
         <Title level="H1" titleStyle="H1" text="{i18n>startPage.title.text}" width="100%" textAlign="Center" />
-        <Button id="NavButton" icon="sap-icon://forward" text="{i18n>startPage.navButton.text}" press="navFwd" />
-        <Button icon="sap-icon://forward" text="{i18n>startPage.odatav4Button.text}" press="navFwdODataV4" />
-        <Button icon="sap-icon://forward" text="{i18n>startPage.odatav2Button.text}" press="navFwdODataV2" />
+        <HBox>
+          <Button id="NavButton" icon="sap-icon://forward" text="{i18n>startPage.navButton.text}" press="navTo('RouteOther')" />
+          <Button icon="sap-icon://forward" text="{i18n>startPage.odatav4Button.text}" press="navTo('RouteODataV4')" />
+          <Button icon="sap-icon://forward" text="{i18n>startPage.odatav2Button.text}" press="navTo('RouteODataV2')" />
+        </HBox>
         <Button text="IA Sync" press="onPress" />
         <Panel expandable="true">
           <headerToolbar>
@@ -33,7 +35,12 @@
         </Panel>
         <DateTimePicker id="DateTimePicker" placeholder="Enter Date ..." />
         <Button text="Don't press me!" press="onBoo" />
-        <Button text="Test 3rd party!" press="navTest3rd" />
+        <Button text="Test 3rd party!" press="navTo('RouteThirdparty')" />
+        <HBox>
+          <Button text="Test WebSocket!" press="testWebSocket" />
+          <Button text="Test WebSocket SimpleProxy!" press="testWebSocketSP" />
+          <Button text="Test WebSocket CF!" press="testWebSocketCF" />
+        </HBox>
         <lib:Example text="Hello World" />
       </VBox>
     </content>

--- a/showcases/ui5-app/xs-app.json
+++ b/showcases/ui5-app/xs-app.json
@@ -18,9 +18,17 @@
       "target": "$1"
     },
     {
+      "source": "^/cfwsecho(.*)$",
+      "destination": "cfwsecho",
+      "target": "$1"
+    },
+    {
       "source": "^/(.*)",
       "localDir": "./webapp",
       "cacheControl": "no-cache, no-store, must-revalidate"
     }
-  ]
+  ],
+  "websockets": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This commit introduces a new middleware package `ui5-middleware-websocket`
which provides helper functions to create WebSocket middlewares inside the
UI5 server:

```js
const websocket = require("ui5-middleware-websocket/lib/websocket");

/**
 * WebSocket middleware to act as an echo service.
 *
 * @param {object} parameters Parameters
 * @param {@ui5/logger/Logger} parameters.log Logger instance
 * @returns {Function} Middleware function to use
 */
module.exports = ({ log }) => {
  return websocket(function echo(ws, req /*, next */) {
    ws.on("message", function (message) {
      log.info(`message: ${message}`);
      ws.send(`echo ${message}`);
    });
    log.info(`Connection established with ${req.url}`);
  });
};
```

The function `websocket` provided by the module:
`const websocket = require("ui5-middleware-websocket/lib/websocket");`
can be used in middlewares to install a WebSocket callback function.

In addition, the middleware package provides an WebSocket echo service
which can be installed for testing in your UI5 server:

```yaml
server:
  customMiddleware:
  - name: ui5-middleware-websocket-echo
    afterMiddleware: compression
    mountPath: /wsecho
```

This allows to test basic WebSocket functions, e.g. by using the
`sap.ui.core.ws.WebSocket` helper (see `Main.controller.js`).

All proxies `ui5-middleware-simpleproxy` and `ui5-middleware-cfdestination`
have been enabled to support proxying WebSockets. The functionality has
to be enabled by a configuration option `enableWebSocket`:

```yaml
    - name: ui5-middleware-simpleproxy
      mountPath: /spwsecho
      afterMiddleware: compression
      configuration:
        debug: true
        baseUri: "ws://localhost:1081/wsecho/"
        enableWebSocket: true
    - name: ui5-middleware-cfdestination
      afterMiddleware: compression
      configuration:
        port: 1091
        xsappJson: "xs-app.json"
        destinations:
          - name: "cfwsecho"
            url: "ws://localhost:1081/wsecho/"
        enableWebSocket: true
```

Bonus: tests have been added which showcases the usage of `superwstest` to
test the websocket functionality in both middlewares.

Fixes https://github.com/ui5-community/ui5-ecosystem-showcase/issues/557