### PR TITLE
fix(ui5-middleware-cfdestination): support UAA flow

### DIFF
--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -49,15 +49,29 @@ allow [BTP services](https://discovery-center.cloud.sap/serviceCatalog?) to be u
 whether to equip routes with authentication
 
 - `allowLocalDir`: `<boolean>`, default: `false`  
-allow static assets to be picked up by the included `approuter`  
-defaults to `false` as usually all local files/assets are supposedly served by `ui5-server`
+allow static assets to be picked up by the included `approuter`; defaults to `false` as usually all local files/assets are supposedly served by `ui5-server`
 
 - `rewriteContent`: `<boolean>`, default: `true`  
-enables/disables rewriting of the content by replacing
-the proxied url in the response body with the server url
+enables/disables rewriting of the content by replacing the proxied url in the response body with the server url
 
 - `rewriteContentTypes`: `<Array of strings>`, default: `["application/json", "application/atom+xml", "application/xml"]`  
 defines the content types which are included for rewriting the content by enabling the `rewriteContent` option
+
+- `disableWelcomeFile`: `<boolean>`, default: `false` *experimental*
+disables the welcome file handling of the approuter based on the `welcomeFile` property in the `xsappJson` file
+
+- `appendAuthRoute`: `<boolean>`, default: `false` *experimental*
+if `true` the middleware adds a custom route for all HTML pages to trigger authentication:
+
+  ```json
+  {
+    "source": "^/([^.]+\\.html?(?:\\?.*)?)$",
+    "localDir": relativeSourcePath,
+    "target": "$1",
+    "cacheControl": "no-store",
+    "authenticationType": "xsuaa"
+  }
+  ```
 
 - `enableWebSocket`: `<boolean>`, default: `false` *experimental*
 enables support for proxying web sockets

--- a/packages/ui5-middleware-index/README.md
+++ b/packages/ui5-middleware-index/README.md
@@ -19,9 +19,11 @@ npm install ui5-middleware-index --save-dev
 
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
-- index: `<string>`, default: `index.html`  
-  file inside `$yourapp` to deliver for `http://<host>:<port>/`
 - debug: `<boolean>`, default: `false`
+- welcomeFile: `<string>`, default: `index.html`
+  the file to redirect to when the root path `/` is requested
+- index: `<string>`, default: `index.html`  *deprecated*
+  file inside `$yourapp` to deliver for `http://<host>:<port>/`
 
 ## Usage
 
@@ -43,7 +45,7 @@ server:
   - name: ui5-middleware-index
     afterMiddleware: compression
     configuration:
-      index: "index_peter.html"
+      welcomeFile: "index_peter.html"
 ```
 
 ## How it works
@@ -53,7 +55,6 @@ The middleware delivers the configured `index` HTML-file to the client if the FQ
 ## Development
 
 If you want to contribute to `ui5-middleware-index`, please use [`Prettier`](https://prettier.io) for code formatting/style and apply the rules from `./.prettierrc`. Thanks 🙏!
-
 
 ## License
 

--- a/packages/ui5-middleware-index/lib/index.js
+++ b/packages/ui5-middleware-index/lib/index.js
@@ -14,7 +14,7 @@
  */
 module.exports = ({ log, options, middlewareUtil }) => {
 	return (req, res, next) => {
-		const sIndexFile = options?.configuration?.index || "index.html"
+		const sIndexFile = options?.configuration?.welcomeFile || options?.configuration?.index || "index.html"
 		const reqPath = middlewareUtil.getPathname(req)
 		if (reqPath === "/") {
 			options?.configuration?.debug && log.info(`serving ${sIndexFile}!`)
@@ -23,6 +23,11 @@ module.exports = ({ log, options, middlewareUtil }) => {
 			// FTR
 			req.path = `/${sIndexFile}`
 			req.originalUrl = `/${sIndexFile}`
+			// redirect about original request url
+			req["ui5-middleware-index"] = {
+				url: reqPath,
+				path: reqPath
+			}
 		}
 		next()
 	}


### PR DESCRIPTION
To enable support for the UAA flow, the option `xfwd` of the
`http-proxy-middleware` is necessary to forward the redirect
host information for the SAML auth flow.

In the `xs-security.json` you need to configure the UI5 server
URL:

```json
{
  "xsappname": "sample-ui5-uaa-uaa",
  [...],
  "oauth2-configuration": {
    "redirect-uris": [
      "http://localhost:8080/login/callback",
      "http://localhost:5000/login/callback"
    ]
  }
}
```

next to the approuter server URL, so that it gets accepted
by the SAML auth flow as a callback.

The change also makes the disabling of the welcome file
configurable to allow the usage of the redirect handling
of the approuter.

The `ui5-middleware-index` has been extended to play properly
together with the `ui5-middleware-cfdestination` so that the
handling of the welcomeFile requests are detected properly and
redirected and handled by the cfdestination middleware.

To support authentication of HTML pages not served by the
approuter coming from the local UI5 server, you can make use
of the `appendAuthRoute` configuration option in the `ui5.yaml`
for the `ui5-middleware-cfdestination`.

Fixes #817