### PR TITLE
fix(ui5-middleware-simpleproxy): support for express/connect servers

### DIFF
--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -112,7 +112,7 @@ UI5_MIDDLEWARE_SIMPLE_PROXY_PASSWORD=myPassword
 
 ## Hints
 
-If you are using the Microsoft OData services for testing purposes, like [Northwind](https://services.odata.org/v2/northwind/northwind.svc/) for V2 or [TripPin](https://www.odata.org/blog/trippin-new-odata-v4-sample-service/) for V4, please ensure to use the `https` URLs instead of the `http` URLs. The `http` URL will redirect to `https` but instead of the proxy it will try to directly connect to the Microsoft OData services. 
+If you are using the Microsoft OData services for testing purposes, like [Northwind](https://services.odata.org/v2/northwind/northwind.svc/) for V2 or [TripPin](https://www.odata.org/blog/trippin-new-odata-v4-sample-service/) for V4, please ensure to use the `https` URLs instead of the `http` URLs. The `http` URL will redirect to `https` but instead of the proxy it will try to directly connect to the Microsoft OData services.
 
 Another known issue is the the validation of the `csrf-token` fails for the `$batch` requests (e.g. in Chrome). To workaround this issue, also running the dev server in `https` can solve the issue.
 

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -131,6 +131,12 @@ server:
         debug: true
         baseUri: "https://sdk.openui5.org/"
         removeETag: true
+    - name: ui5-middleware-simpleproxy
+      mountPath: /odatav4
+      afterMiddleware: compression
+      configuration:
+        debug: true
+        baseUri: "https://services.odata.org/V4/(S(soab2geixerd5hqzncsoqpba))/TripPinServiceRW/"
     - name: ui5-tooling-stringreplace-middleware
       afterMiddleware: compression
       configuration:

--- a/showcases/ui5-app/webapp/controller/Main.controller.js
+++ b/showcases/ui5-app/webapp/controller/Main.controller.js
@@ -31,6 +31,9 @@ sap.ui.define(["ui5/ecosystem/demo/app/controller/BaseController", "sap/ui/model
 		navFwd() {
 			return this.getOwnerComponent().getRouter().navTo("RouteOther");
 		},
+		navFwdODataV4() {
+			return this.getOwnerComponent().getRouter().navTo("RouteODataV4");
+		},
 		navTest3rd() {
 			return this.getOwnerComponent().getRouter().navTo("RouteThirdparty");
 		},

--- a/showcases/ui5-app/webapp/controller/ODataV4.controller.js
+++ b/showcases/ui5-app/webapp/controller/ODataV4.controller.js
@@ -1,0 +1,15 @@
+sap.ui.define(["ui5/ecosystem/demo/app/controller/BaseController", "sap/ui/util/openWindow"], (Controller, openWindow) => {
+	"use strict";
+
+	return Controller.extend("ui5.ecosystem.demo.app.controller.ODataV4", {
+		onInit() {},
+		handlePeopleClick(event) {
+			const bindingContext = event.getSource().getBindingContext("ODataV4"),
+				serviceUrl = bindingContext.getModel().getServiceUrl(),
+				sanitizedServiceUrl = /^(.*)\/$/.exec(serviceUrl)?.[1] || serviceUrl,
+				path = bindingContext.getPath(),
+				href = new URL(sanitizedServiceUrl + path, location.href).toString();
+			openWindow(href, "_blank");
+		},
+	});
+});

--- a/showcases/ui5-app/webapp/i18n/i18n.properties
+++ b/showcases/ui5-app/webapp/i18n/i18n.properties
@@ -4,13 +4,19 @@ appDescription=App Description
 # ##
 
 startPage.navButton.text=to Other view
+startPage.odatav4Button.text=to ODataV4 view
 startPage.currentUI5.text=most current UI5 version available
 startPage.title.text=#UI5 demo
 
 # ##
 
-otherPage.title=Another View...
-otherPage.listHeader=...bites the dust!
+otherPage.title=ODataV4 View using ui5-middleware-cfdestination
+otherPage.listHeader=People List
+
+# ##
+
+odataV4page.title=ODataV4 View using ui5-middleware-simpleproxy
+odataV4page.listHeader=People List
 
 # ##
 

--- a/showcases/ui5-app/webapp/i18n/i18n_en.properties
+++ b/showcases/ui5-app/webapp/i18n/i18n_en.properties
@@ -4,13 +4,19 @@ appDescription=App Description
 # ##
 
 startPage.navButton.text=to Other view
+startPage.odatav4Button.text=to ODataV4 view
 startPage.currentUI5.text=most current UI5 version available
 startPage.title.text=#UI5 demo
 
 # ##
 
-otherPage.title=Another View...
-otherPage.listHeader=...bites the dust!
+otherPage.title=ODataV4 View using ui5-middleware-cfdestination
+otherPage.listHeader=People List
+
+# ##
+
+odataV4page.title=ODataV4 View using ui5-middleware-simpleproxy
+odataV4page.listHeader=People List
 
 # ##
 

--- a/showcases/ui5-app/webapp/manifest.json
+++ b/showcases/ui5-app/webapp/manifest.json
@@ -19,6 +19,13 @@
           "odataVersion": "4.0"
         }
       },
+      "ODataV4DataSource": {
+        "uri": "/odatav4/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "4.0"
+        }
+      },
       "UI5VersionInfo": {
         "uri": "/versioninfo/version.json",
         "type": "JSON"
@@ -76,6 +83,15 @@
           "synchronizationMode": "None"
         }
       },
+      "ODataV4": {
+        "dataSource": "ODataV4DataSource",
+        "settings": {
+          "autoExpandSelect": true,
+          "operationMode": "Server",
+          "groupId": "$direct",
+          "synchronizationMode": "None"
+        }
+      },
       "UI5VersionInfo": {
         "type": "sap.ui.model.json.JSONModel",
         "dataSource": "UI5VersionInfo"
@@ -102,6 +118,11 @@
           "target": ["TargetOther"]
         },
         {
+          "name": "RouteODataV4",
+          "pattern": "odatav4",
+          "target": ["TargetODataV4"]
+        },
+        {
           "name": "RouteThirdparty",
           "pattern": "thirdparty",
           "target": ["TargetThirdparty"]
@@ -126,6 +147,13 @@
           "clearControlAggregation": false,
           "viewId": "Other",
           "viewName": "Other"
+        },
+        "TargetODataV4": {
+          "viewType": "XML",
+          "transition": "slide",
+          "clearControlAggregation": false,
+          "viewId": "ODataV4",
+          "viewName": "ODataV4"
         },
         "TargetThirdparty": {
           "viewType": "XML",

--- a/showcases/ui5-app/webapp/view/Main.view.xml
+++ b/showcases/ui5-app/webapp/view/Main.view.xml
@@ -8,6 +8,7 @@
       <VBox alignItems="Center" justifyContent="Center" height="100%">
         <Title level="H1" titleStyle="H1" text="{i18n>startPage.title.text}" width="100%" textAlign="Center" />
         <Button id="NavButton" icon="sap-icon://forward" text="{i18n>startPage.navButton.text}" press="navFwd" />
+        <Button icon="sap-icon://forward" text="{i18n>startPage.odatav4Button.text}" press="navFwdODataV4" />
         <Button text="IA Sync" press="onPress" />
         <Panel expandable="true">
           <headerToolbar>

--- a/showcases/ui5-app/webapp/view/ODataV4.view.xml
+++ b/showcases/ui5-app/webapp/view/ODataV4.view.xml
@@ -1,0 +1,13 @@
+<mvc:View controllerName="ui5.ecosystem.demo.app.controller.ODataV4" xmlns:mvc="sap.ui.core.mvc" displayBlock="true" xmlns="sap.m">
+  <Page title="{i18n>odataV4page.title}" showNavButton="true" navButtonPress="onNavBack">
+    <content>
+      <List id="PeopleList" headerText="{i18n>odataV4page.listHeader}" items="{ODataV4>/People}">
+        <CustomListItem>
+          <VBox class="sapUiSmallMarginBegin sapUiSmallMarginTopBottom">
+            <Link text="{ODataV4>FirstName} {ODataV4>LastName}" press=".handlePeopleClick" />
+          </VBox>
+        </CustomListItem>
+      </List>
+    </content>
+  </Page>
+</mvc:View>


### PR DESCRIPTION
This change ensures the compatibility with express/connect servers by using the middlware util from the ui5 tooling to determine the request path.

Support opening of URLs in the browser causing ERR_CONTENT_DECODING_FAILED by using the response-interceptor of the http-proxy-middleware to decode the response. The issue didn't appear for XMLHttpRequests.

Enhanced the demo application to proxy the Tripin service via the ui5-middleware-simpleproxy.