### PR TITLE
fix(ui5-middleware-cfdestination): keep content-type parameters intact

### DIFF
--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -187,11 +187,11 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 	}
 
 	// helper to determine the mime type either from the req path or if provided
-	// we parse the content-type value and retunr content type and charset
+	// we parse the content-type value and return the content-type and charset
 	const getMimeInfo = (reqPath, ctValue) => {
 		if (ctValue) {
 			const parsedCtHeader = ct.parse(ctValue)
-			const contentType = parsedCtHeader?.type || "application/octet-stream"
+			const contentType = parsedCtHeader?.type ? ctValue : "application/octet-stream"
 			const charset = parsedCtHeader?.parameters?.charset || mime.charset(contentType)
 			return {
 				contentType,

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -209,7 +209,7 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 
 		// determine and update content type (avoid no content type!)
 		let { contentType, charset } = getMimeInfo(reqPath, proxyRes.headers["content-type"])
-		res.setHeader("content-type", contentType)
+		res.setHeader("content-type", contentType + (charset ? `; charset=${charset}` : ""))
 
 		// only rewrite content when enabled and the content type is supported!
 		if (

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -209,7 +209,7 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 
 		// determine and update content type (avoid no content type!)
 		let { contentType, charset } = getMimeInfo(reqPath, proxyRes.headers["content-type"])
-		res.setHeader("content-type", contentType + (charset ? `; charset=${charset}` : ""))
+		res.setHeader("content-type", contentType)
 
 		// only rewrite content when enabled and the content type is supported!
 		if (


### PR DESCRIPTION
Fixes: #817 

P.S. I'm not familiar with the reason that content-type should ever be changed here or defaulted to `application/octet-stream`, so I've added this fix while keeping the original fallback logic.