### PR TITLE
fix: consistent request path handling of all middlewares

### DIFF
--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -113,7 +113,6 @@ cds.on("bootstrap", async function bootstrap(app) {
 				}
 				send.apply(this, arguments);
 			};
-			//log.debug(req.url);
 			next();
 		});
 

--- a/packages/cds-plugin-ui5/lib/createPatchedRouter.js
+++ b/packages/cds-plugin-ui5/lib/createPatchedRouter.js
@@ -11,13 +11,21 @@ module.exports = async function createPatchedRouter() {
 	router.use(function (req, res, next) {
 		// disable the compression when livereload is used
 		// for loading html-related content (via accept header)
-		const accept = req.headers["accept"]?.indexOf("html");
+		const accept = req.headers["accept"]?.indexOf("html") !== -1;
 		if (accept && res._livereload) {
 			req.headers["accept-encoding"] = "identity";
 		}
-		// remove the mount path from the url
+		// store the original request information
+		const { url, originalUrl, baseUrl } = req;
+		req["cds-plugin-ui5"] = {
+			url,
+			originalUrl,
+			baseUrl,
+		};
+		// rewite the path to simulate requests on the root level
 		req.originalUrl = req.url;
 		req.baseUrl = "/";
+		// next one!
 		next();
 	});
 	return router;

--- a/packages/ui5-middleware-index/lib/index.js
+++ b/packages/ui5-middleware-index/lib/index.js
@@ -8,25 +8,21 @@
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
  * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
- * @param {object} parameters.middlewareUtil Specification version dependent interface to a
- *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use
  */
-module.exports = ({ log, options, middlewareUtil }) => {
+module.exports = ({ log, options }) => {
 	return (req, res, next) => {
 		const sIndexFile = options?.configuration?.welcomeFile || options?.configuration?.index || "index.html"
-		const reqPath = middlewareUtil.getPathname(req)
-		if (reqPath === "/") {
+		const { url, originalUrl } = req
+		if (url === "/") {
 			options?.configuration?.debug && log.info(`serving ${sIndexFile}!`)
 			// "redirect" the request
 			req.url = `/${sIndexFile}`
-			// FTR
-			req.path = `/${sIndexFile}`
-			req.originalUrl = `/${sIndexFile}`
+			req.originalUrl = req.url
 			// redirect about original request url
 			req["ui5-middleware-index"] = {
-				url: reqPath,
-				path: reqPath
+				url,
+				originalUrl
 			}
 		}
 		next()

--- a/packages/ui5-middleware-livecompileless/lib/index.js
+++ b/packages/ui5-middleware-livecompileless/lib/index.js
@@ -19,9 +19,9 @@ module.exports = async ({ log, resources, options }) => {
 	const isDebug = options?.configuration?.debug;
 
 	return async function injectLess(req, res, next) {
-		let url = req.url;
-		if (url.includes(".css") && !url.includes("resources/")) {
-			let possibleLessFile = await resources.rootProject.byPath(url.replace(".css", ".less"));
+		const pathname = req.url?.match("^[^?]*")[0];
+		if (pathname.includes(".css") && !pathname.includes("resources/")) {
+			let possibleLessFile = await resources.rootProject.byPath(pathname.replace(".css", ".less"));
 			if (possibleLessFile) {
 				isDebug && log.info(`Compiling ${possibleLessFile.getPath()}...`);
 				const { default: fsInterface } = await import("@ui5/fs/fsInterface");

--- a/packages/ui5-middleware-webjars/lib/index.js
+++ b/packages/ui5-middleware-webjars/lib/index.js
@@ -106,7 +106,7 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 	);
 
 	return async function serveWebJARs(req, res, next) {
-		const pathname = middlewareUtil.getPathname(req);
+		const pathname = req.url?.match("^[^?]*")[0];
 		const jarPath = path.join(jarRootPath, pathname.substr(1));
 
 		const jarResource = jarResources[jarPath];
@@ -115,8 +115,8 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 				log.info(`Serving ${pathname}`);
 			}
 
-			// determine charset and content-type
-			let { contentType, charset } = middlewareUtil.getMimeInfo(pathname);
+			// determine content-type
+			let { contentType } = middlewareUtil.getMimeInfo(pathname);
 			if (pathname.endsWith(".properties")) {
 				contentType = "text/plain";
 			}

--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -44,13 +44,13 @@ module.exports = function ({ log, options, middlewareUtil }) {
 	// return the middleware
 	return async (req, res, next) => {
 		// determine the request path
-		const reqPath = middlewareUtil.getPathname(req);
+		const pathname = req.url?.match("^[^?]*")[0];
 
 		// perf
 		const time = Date.now();
 
 		// check for resources requests
-		const match = /^\/resources\/(.*)$/.exec(reqPath);
+		const match = /^\/resources\/(.*)$/.exec(pathname);
 		if (match) {
 			// determine the module name (for JS resources we strip the extension)
 			let moduleName = match[1];
@@ -66,7 +66,7 @@ module.exports = function ({ log, options, middlewareUtil }) {
 					log.verbose(`Processing resource ${moduleName}...`);
 
 					// determine charset and content-type
-					let { contentType, charset } = middlewareUtil.getMimeInfo(reqPath);
+					let { contentType, charset } = middlewareUtil.getMimeInfo(pathname);
 					res.setHeader("Content-Type", contentType);
 
 					// respond the content

--- a/packages/ui5-tooling-stringreplace/lib/middleware.js
+++ b/packages/ui5-tooling-stringreplace/lib/middleware.js
@@ -26,11 +26,9 @@ function isFresh(req, res) {
  *                                        the projects dependencies
  * @param {object} parameters.options Options
  * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
- * @param {object} parameters.middlewareUtil Specification version dependent interface to a
- *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use
  */
-module.exports = function createMiddleware({ log, resources, options, middlewareUtil }) {
+module.exports = function createMiddleware({ log, resources, options }) {
 	const isDebug = options.configuration && options.configuration.debug;
 
 	// get all environment variables
@@ -75,7 +73,7 @@ module.exports = function createMiddleware({ log, resources, options, middleware
 			return;
 		}
 
-		const pathname = middlewareUtil.getPathname(req);
+		const pathname = req.url?.match("^[^?]*")[0];
 		const resource = await resources.all.byPath(pathname);
 		if (!resource) {
 			// Resource not found

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -1,9 +1,10 @@
 /* eslint-disable jsdoc/check-param-names */
 const path = require("path");
-const parseurl = require("parseurl");
 
 /**
  * Custom middleware to transpile resources to JavaScript modules.
+ *
+ * Hint: mime type for TypeScript is "application/x-typescript"
  *
  * @param {object} parameters Parameters
  * @param {module:@ui5/logger/Logger} parameters.log Logger instance
@@ -115,7 +116,7 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 	}
 
 	return async (req, res, next) => {
-		const pathname = parseurl(req)?.pathname;
+		const pathname = req.url?.match("^[^?]*")[0];
 		if (pathname.endsWith(".js") && shouldHandlePath(pathname, config.excludes, config.includes)) {
 			const pathWithFilePattern = pathname.replace(".js", config.filePattern);
 			config.debug && log.verbose(`Lookup resource ${pathWithFilePattern}`);

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -17,8 +17,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-transform-ui5": "^7.2.4",
     "browserslist": "^4.21.10",
-    "comment-json": "^4.2.3",
-    "parseurl": "^1.3.3"
+    "comment-json": "^4.2.3"
   },
   "devDependencies": {
     "ava": "^5.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,9 +472,6 @@ importers:
       comment-json:
         specifier: ^4.2.3
         version: 4.2.3
-      parseurl:
-        specifier: ^1.3.3
-        version: 1.3.3
     devDependencies:
       ava:
         specifier: ^5.3.1

--- a/showcases/ui5-app/webapp/controller/ODataV2.controller.js
+++ b/showcases/ui5-app/webapp/controller/ODataV2.controller.js
@@ -5,7 +5,7 @@ sap.ui.define(["ui5/ecosystem/demo/app/controller/BaseController", "sap/ui/util/
 		onInit() {},
 		handleEmployeeClick(event) {
 			const bindingContext = event.getSource().getBindingContext("ODataV2"),
-				serviceUrl = bindingContext.getModel().getServiceUrl(),
+				serviceUrl = bindingContext.getModel().sServiceUrl, // THIS IS A HACK! NOT FOR PRODUCTIVE USAGE!!
 				sanitizedServiceUrl = /^(.*)\/$/.exec(serviceUrl)?.[1] || serviceUrl,
 				path = bindingContext.getPath(),
 				href = new URL(sanitizedServiceUrl + path, location.href).toString();


### PR DESCRIPTION
This fix aligns the request path handling of all middlewares which
rely on the request url to retrieve the proper resource. In case of
loading resources via express.Router the `req.url`, `req.baseUrl`,
and `req.originalUrl` contains all relevant information to know the
context path and the local path. The `baseUrl` and the `originalUrl`
must not be overwritten by middlewares to be able to identify the
source context path of the request.

This cleanup is a precondition to ge the nested routing for the
combination of `cds-plugin-ui5`, `ui5-middleware-cfdestination`,
`approuter` and an underlying UAA.

Related to discussion of https://github.com/ui5-community/ui5-ecosystem-showcase/issues/817