### PR TITLE
fix(ui5-tooling-transpile): ensure loadPartialConfigAsync works with include/excludes/ignore patterns

### DIFF
--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -62,10 +62,10 @@ async function loadBabelConfigOptions(babelConfigOptions, skipBabelPresetPluginR
 	// let babel load the babel config
 	const partialConfig = await babel.loadPartialConfigAsync(
 		Object.assign(
-			{},
 			{
 				configFile: false,
-				babelrc: false
+				babelrc: false,
+				filename: "src/dummy.js" // necessary for ignore/include/exclude
 			},
 			babelConfigOptions
 		)


### PR DESCRIPTION
As soon as a pattern is used in the Babel config, a dummy filename needs to be provided!