### PR TITLE
feat(cds-plugin-ui5): support for configuration options

### DIFF
--- a/packages/cds-plugin-ui5/README.md
+++ b/packages/cds-plugin-ui5/README.md
@@ -27,20 +27,25 @@ The plugin can be configured using the `cds-plugin-ui5` section in the `package.
 
 ```json
 {
+  "name": "cds-bookshop",
+  [...]
+  "cds": {
+    [...]
     "cds-plugin-ui5": {
       "modules": {
         "ui5-bookshop": {
-          "configFile": "ui5.yaml"
-        },
-        "cds-ui5-bookshopviewer": {
-          "configFile": "ui5-dist.yaml"
+          "configFile": "ui5.yaml",
+          "workspaceConfigFile": "ui5-workspace.yaml",
+          "workspaceName": "default",
+          "versionOverride": "1.117.0"
         }
       }
     }
+  }
 }
 ```
 
-The key is the `moduleId` which is either the directory name for local apps in the `app` directory of the CAP server or for dependencies the `name` from the `package.json`. As value you can specify an alternative `configFile` name.
+The key is the `moduleId` which is either the directory name for local apps in the `app` directory of the CAP server or for dependencies the `name` from the `package.json`. As value you can specify an alternative `configFile`, `workspaceConfigFile`, `workspaceName`, and/or `versionOverride`. The location of the config files are relative to the modules' base path.
 
 A second option to override this configuration is the usage of the environment variable `CDS_PLUGIN_UI5_MODULES`. It contains the JSON string from the configuration above, e.g.:
 

--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -32,7 +32,7 @@ cds.on("bootstrap", async function bootstrap(app) {
 
 	const cwd = process.cwd();
 	const ui5Modules = await findUI5Modules({ cwd });
-	const { localApps, configFiles } = ui5Modules;
+	const { localApps, config } = ui5Modules;
 
 	const links = [];
 
@@ -41,7 +41,7 @@ cds.on("bootstrap", async function bootstrap(app) {
 		const { moduleId, mountPath, modulePath } = ui5Module;
 
 		// mounting the Router for the UI5 application to the CAP server
-		log.info(`Mounting ${mountPath} to UI5 app ${modulePath} (id=${moduleId})${configFiles[moduleId] ? ` using configFile=${configFiles[moduleId]}` : ""}`);
+		log.info(`Mounting ${mountPath} to UI5 app ${modulePath} (id=${moduleId})${config[moduleId] ? ` using config=${JSON.stringify(config[moduleId])}` : ""}`);
 
 		// create a patched router
 		const router = await createPatchedRouter();
@@ -50,8 +50,7 @@ cds.on("bootstrap", async function bootstrap(app) {
 		// retrieve the available HTML pages
 		const appInfo = await applyUI5Middleware(router, {
 			basePath: modulePath,
-			configPath: modulePath,
-			configFile: configFiles[moduleId],
+			...(config[moduleId] || {}),
 		});
 
 		// register the router to the specified mount path

--- a/packages/cds-plugin-ui5/lib/findUI5Modules.js
+++ b/packages/cds-plugin-ui5/lib/findUI5Modules.js
@@ -83,7 +83,7 @@ module.exports = async function findUI5Modules({ cwd, skipLocalApps, skipDeps })
 	// determine module configuration:
 	//   => env variable: CDS_PLUGIN_UI5_MODULES (JSONObject<string, object>)
 	//   => package.json: cds-plugin-ui5 > modules (JSONObject<string, object>)
-	// JSONObject<string, object>: key = moduleId (folder name, npm package name), object={ configFile: string }
+	// JSONObject<string, object>: key = moduleId (folder name, npm package name), object={ configFile: string, ... }
 	let modulesConfig;
 	try {
 		modulesConfig = JSON.parse(process.env.CDS_PLUGIN_UI5_MODULES);
@@ -92,13 +92,13 @@ module.exports = async function findUI5Modules({ cwd, skipLocalApps, skipDeps })
 		modulesConfig = pkgJson.cds?.["cds-plugin-ui5"]?.modules;
 	}
 	if (modulesConfig) {
-		log.debug(JSON.stringify(modulesConfig, undefined, 2));
+		log.debug(`Found modules configuration: ${JSON.stringify(modulesConfig, undefined, 2)}`);
 	}
 
 	// if apps are available, attach the middlewares of the UI5 apps
 	// to the express of the CAP server via a express router
 	const apps = [];
-	apps.configFiles = {};
+	apps.config = {};
 	if (appDirs) {
 		for await (const appDir of appDirs) {
 			// read the ui5.yaml file to extract the configuration
@@ -142,9 +142,9 @@ module.exports = async function findUI5Modules({ cwd, skipLocalApps, skipDeps })
 				}
 				const moduleId = moduleName || path.basename(appDir);
 
-				// store the custom config file
-				if (modulesConfig?.[moduleId]?.configFile) {
-					apps.configFiles[moduleId] = modulesConfig?.[moduleId]?.configFile;
+				// store the custom config in the configuration map
+				if (modulesConfig?.[moduleId]) {
+					apps.config[moduleId] = modulesConfig[moduleId];
 				}
 
 				apps.push({ moduleId, modulePath, mountPath });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       rimraf:
         specifier: ^5.0.1
         version: 5.0.1
+      ui5-middleware-index:
+        specifier: workspace:^
+        version: link:../../../../packages/ui5-middleware-index
       ui5-middleware-livereload:
         specifier: workspace:^
         version: link:../../../../packages/ui5-middleware-livereload

--- a/showcases/cds-bookshop/app/ui5-bookshop/package.json
+++ b/showcases/cds-bookshop/app/ui5-bookshop/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@ui5/cli": "^3.6.0",
     "rimraf": "^5.0.1",
+    "ui5-middleware-index": "workspace:^",
     "ui5-middleware-livereload": "workspace:^",
     "ui5-task-zipper": "workspace:^"
   }

--- a/showcases/cds-bookshop/app/ui5-bookshop/ui5-workspace-test.yaml
+++ b/showcases/cds-bookshop/app/ui5-bookshop/ui5-workspace-test.yaml
@@ -1,0 +1,6 @@
+specVersion: workspace/1.0
+metadata:
+  name: default
+dependencyManagement:
+  resolutions:
+    - path: ../../../../../../git/openui5

--- a/showcases/cds-bookshop/app/ui5-bookshop/ui5.yaml
+++ b/showcases/cds-bookshop/app/ui5-bookshop/ui5.yaml
@@ -19,6 +19,8 @@ builder:
 # https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
 server:
   customMiddleware:
+    - name: ui5-middleware-index
+      afterMiddleware: compression
     # Last middleware (for the same afterMiddleware) comes first!
     - name: ui5-middleware-livereload
       afterMiddleware: compression

--- a/showcases/cds-bookshop/package.json
+++ b/showcases/cds-bookshop/package.json
@@ -46,10 +46,8 @@
     "cds-plugin-ui5": {
       "modules": {
         "ui5-bookshop": {
-          "configFile": "ui5.yaml"
-        },
-        "cds-ui5-bookshopviewer": {
-          "configFile": "ui5-dist.yaml"
+          "configFile": "ui5.yaml",
+          "_workpaceConfigFile": "ui5-workspace-test.yaml"
         }
       }
     }


### PR DESCRIPTION
The plugin can be configured using the `cds-plugin-ui5` section in the `package.json`. To define a custom configFile for any module you can add a configuration object for each module in the `modules` section:

```json
{
  "name": "cds-bookshop",
  [...]
  "cds": {
    [...]
    "cds-plugin-ui5": {
      "modules": {
        "ui5-bookshop": {
          "configFile": "ui5.yaml",
          "workspaceConfigFile": "ui5-workspace.yaml",
          "workspaceName": "default",
          "versionOverride": "1.117.0"
        }
      }
    }
  }
}
```

The key is the `moduleId` which is either the directory name for local apps in the `app` directory of the CAP server or for dependencies the `name` from the `package.json`. As value you can specify an alternative `configFile`, `workspaceConfigFile`, `workspaceName`, and/or `versionOverride`. The location of the config files are relative to the modules' base path.

A second option to override this configuration is the usage of the environment variable `CDS_PLUGIN_UI5_MODULES`. It contains the JSON string from the configuration above, e.g.:

```sh
CDS_PLUGIN_UI5_MODULES="{ \"ui5-bookshop\": { \"configFile\": \"ui5-dist.yaml\" } }" cds-serve
```

Fixes #830

---

feat(cds-plugin-ui5): support browsing in UI5 server file listing

Rewrites the URls of the links in the UI5 server file listing to support browsing when running inside nested routes.