### PR TITLE
fix(ui5-task-cachebuster): update docu for afterTask configuration

### DIFF
--- a/packages/ui5-task-cachebuster/README.md
+++ b/packages/ui5-task-cachebuster/README.md
@@ -47,7 +47,7 @@ What is possible:
 builder:
   customTasks:
   - name: ui5-task-cachebuster
-    afterTask: uglify
+    afterTask: generateResourcesJson
     configuration:
       debug: true | false
       moveResources: true | false
@@ -58,7 +58,7 @@ For app in SAP BTP in Cloud Foundry environment with managed approuter:
 builder:
   customTasks:
   - name: ui5-task-cachebuster
-    afterTask: uglify
+    afterTask: generateResourcesJson
     configuration:
       moveResources: false
 ```


### PR DESCRIPTION
The `uglify` task has been removed with the UI5 Tooling v3 and mentions thereof lead to a build error.