### PR TITLE
feat(ui5-tooling-stringreplace): allow combination with other middlewares

### DIFF
--- a/packages/ui5-tooling-stringreplace/package.json
+++ b/packages/ui5-tooling-stringreplace/package.json
@@ -12,11 +12,10 @@
   },
   "dependencies": {
     "dotenv": "^16.3.1",
-    "etag": "^1.8.1",
-    "fresh": "^0.5.2",
     "lodash.escaperegexp": "^4.1.2",
     "mime-types": "^2.1.35",
     "minimatch": "^7.4.6",
-    "replacestream": "^4.0.3"
+    "replacestream": "^4.0.3",
+    "ui5-utils-express": "workspace:^"
   }
 }

--- a/packages/ui5-utils-express/lib/intercept.js
+++ b/packages/ui5-utils-express/lib/intercept.js
@@ -1,0 +1,96 @@
+const http = require("http");
+
+/**
+ * Async callback function to determine whether the response should be intercepted
+ *
+ * @callback ConditionCallback
+ * @param {http.OutgoingMessage} req http request object
+ * @returns {Promise<boolean>} true, if the response should be intercepted and the `intercept` callback called
+ */
+
+/**
+ * Async callback function to allow intercepting the response body and rewrite it
+ *
+ * @callback InterceptCallback
+ * @param {string} body the reponse body
+ * @param {string} encoding rthe response body encoding
+ * @param {http.OutgoingMessage} req http request object
+ * @returns {Promise<string|undefined>}
+ */
+
+/**
+ * This function installs an express app-like middleware function
+ * to get access to the express app and intercepts the listen function
+ * to get access to the server instance.
+ *
+ * @param {string} name Name of the middleware function
+ * @param {ConditionCallback} condition Async callback function to determine whether the response should be intercepted
+ * @param {InterceptCallback} intercept Async callback function to allow intercepting the response body and rewrite it
+ * @returns {Function} Middleware function to use
+ */
+module.exports = function intercept(name, condition, intercept) {
+	// default the name
+	name = name || "<anonymous_interceptor>";
+	const fn = async function (req, res, next) {
+		if (typeof condition === "function" && (await condition(req))) {
+			// store the references to the origin response methods
+			const { writeHead, write, end } = res;
+
+			// disable compression to allow proper rewrite of the content
+			req.headers["accept-encoding"] = "identity";
+
+			// only 2xx responses should be handled
+			const shouldHandleResponse = function shouldHandleResponse(res) {
+				return res.statusCode >= 200 && res.statusCode < 300;
+			};
+
+			// disable the response headers for the content-length which will change
+			// anyhow when modifying the content and disable caching...
+			res.writeHead = function interceptWriteHead() {
+				if (!shouldHandleResponse(res)) return writeHead.apply(this, arguments);
+				res.removeHeader("content-length");
+				res.removeHeader("etag");
+				res.setHeader("cache-control", "no-cache");
+				return writeHead.apply(this, arguments);
+			};
+
+			// the content will be put into a body array
+			const body = [];
+			let bodyEncoding;
+			const appendToBody = function appendToBody(content, encoding) {
+				if (shouldHandleResponse(res)) {
+					if (content !== undefined) {
+						body.push(content instanceof Buffer ? content.toString(encoding) : content);
+					}
+					bodyEncoding = bodyEncoding || encoding;
+					return true;
+				} else {
+					return false;
+				}
+			};
+
+			// when buffered, chunks of data may be written which need to be intercepted
+			res.write = function interceptWrite(content, encoding) {
+				if (!appendToBody(content, encoding)) return write.apply(this, arguments);
+				return true;
+			};
+
+			res.end = async function interceptEnd(content, encoding) {
+				if (!appendToBody(content, encoding)) return end.apply(this, arguments);
+				// modify the content of the body
+				end.call(res, await intercept(body.join(""), bodyEncoding, req), bodyEncoding);
+			};
+		}
+		next();
+	};
+
+	// apply a name to the function to allow a better lookup
+	// in the express middleware stack when debugging
+	Object.defineProperty(fn, "name", {
+		value: name,
+		writable: false,
+	});
+
+	// that's it!
+	return fn;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,12 +497,6 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
-      etag:
-        specifier: ^1.8.1
-        version: 1.8.1
-      fresh:
-        specifier: ^0.5.2
-        version: 0.5.2
       lodash.escaperegexp:
         specifier: ^4.1.2
         version: 4.1.2
@@ -515,6 +509,9 @@ importers:
       replacestream:
         specifier: ^4.0.3
         version: 4.0.3
+      ui5-utils-express:
+        specifier: workspace:^
+        version: link:../ui5-utils-express
 
   packages/ui5-tooling-transpile:
     dependencies:

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -195,7 +195,7 @@ server:
         debug: true
         jarRootPath: "META-INF/"
     - name: ui5-tooling-transpile-middleware
-      afterMiddleware: compression
+      afterMiddleware: ui5-tooling-stringreplace-middleware
       configuration:
         <<: *cfgTranspile
     - name: ui5-tooling-modules-middleware

--- a/showcases/ui5-app/webapp/includes/iWillBeTranspiled.js
+++ b/showcases/ui5-app/webapp/includes/iWillBeTranspiled.js
@@ -1,6 +1,7 @@
 // nothing to see here, just for demo purposes
 
 const [a, ...b] = ["will", "be", "transpiled!"];
+const version = "${project.version}";
 
 const o = {
 	async value() {


### PR DESCRIPTION
The stringreplace middleware must not be the last middleware in the chain and therefore should only intercept the response rather than sending the response. This allows other middlewares such as the transpiling to run afterwards.

The middleware must be executed before any other middleware which finally sends the response (like the transpile or modules middleware). When called, it hooks into the functions of the server response and collects the content to finally rewrite it. The final send will be left to the UI5 tooling development server or other middlewares.

Fixes #665