### PR TITLE
fix: make it work without config

### DIFF
--- a/packages/ui5-middleware-ui5/lib/findUI5Modules.js
+++ b/packages/ui5-middleware-ui5/lib/findUI5Modules.js
@@ -32,7 +32,7 @@ module.exports = async function findUI5Modules({ cwd, config, log }) {
 	appDirs.push(
 		...deps.filter((dep) => {
 			try {
-				require.resolve(path.join(dep, config?.modules?.[dep].configFile || "ui5.yaml"), {
+				require.resolve(path.join(dep, config?.modules?.[dep]?.configFile || "ui5.yaml"), {
 					paths: [cwd],
 				});
 				return true;
@@ -49,7 +49,7 @@ module.exports = async function findUI5Modules({ cwd, config, log }) {
 	if (appDirs) {
 		for await (const appDir of appDirs) {
 			// read the ui5.yaml file to extract the configuration
-			const ui5YamlPath = require.resolve(path.join(appDir, config?.modules?.[appDir].configFile || "ui5.yaml"), {
+			const ui5YamlPath = require.resolve(path.join(appDir, config?.modules?.[appDir]?.configFile || "ui5.yaml"), {
 				paths: [cwd],
 			});
 			let ui5Configs;


### PR DESCRIPTION
It doesn't work in case no config is provided because of an error it goes into the catch. This fix will make sure it takes the default value in case no config is provided