### PR TITLE
fix(ui5-tooling-less): resolve globs relative to app namespace

### DIFF
--- a/packages/ui5-tooling-less/lib/task.js
+++ b/packages/ui5-tooling-less/lib/task.js
@@ -49,7 +49,11 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 	// find the less files in the workspace
 	const lessResources = [];
 	for (const glob of lessToCompile) {
-		lessResources.push(...((await workspace.byGlobSource(glob)) || []));
+		if (!path.isAbsolute(glob)) {
+			lessResources.push(...((await workspace.byGlobSource(path.join(localPath, glob))) || []));
+		} else {
+			lessResources.push(...((await workspace.byGlobSource(glob)) || []));
+		}
 	}
 
 	// create a new resource collection including the workspance and the dependencies

--- a/showcases/ui5-app/ui5.yaml
+++ b/showcases/ui5-app/ui5.yaml
@@ -94,8 +94,8 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        # lessToCompile: (Optional by default css from manifest will be used)
-        #   - "css/style.less"
+        lessToCompile: # (Optional by default css from manifest will be used)
+          - "css/**/style.less"
 # https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
 server:
   customMiddleware:

--- a/showcases/ui5-app/webapp/css/sap_horizon/style.less
+++ b/showcases/ui5-app/webapp/css/sap_horizon/style.less
@@ -1,0 +1,12 @@
+@import "../base/base.less";
+
+@import "/resources/ui5/ecosystem/demo/lib/css/variables.less";
+
+@import "/resources/sap/ui/core/themes/sap_horizon/base.less";
+@backgroundColor: @sapHighlightColor;
+
+.styledWithLess {
+	color: @var1;
+	background-color: @backgroundColor;
+	border: 1px solid @libvar;
+}

--- a/showcases/ui5-app/webapp/css/sap_horizon_dark/style.less
+++ b/showcases/ui5-app/webapp/css/sap_horizon_dark/style.less
@@ -1,0 +1,12 @@
+@import "../base/base.less";
+
+@import "/resources/ui5/ecosystem/demo/lib/css/variables.less";
+
+@import "/resources/sap/ui/core/themes/sap_horizon_dark/base.less";
+@backgroundColor: @sapHighlightColor;
+
+.styledWithLess {
+	color: @var1;
+	background-color: @backgroundColor;
+	border: 1px solid @libvar;
+}


### PR DESCRIPTION
To ensure that resources can be found with the specified globs in the lessToInclude configuration parameter, they have to be resolved relative to the app namespace.

Fixes #896