### PR TITLE
fix(cds-plugin-ui5): remove activation hook since it's not needed

### DIFF
--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -160,12 +160,3 @@ if (!skip) {
 		bootstrapped();
 	});
 }
-
-// return callback for plugin activation
-module.exports = {
-	activate: function activate(conf) {
-		if (!skip) {
-			log.debug("activate", conf);
-		}
-	},
-};


### PR DESCRIPTION
Instead of supporting both variants, activate hook in object vs. Promise, the activate hook has been completely removed to avoid a switch statement based on version. This ensures simplicity of code and it wasn't needed at all...

Fixes #899