### PR TITLE
fix(cds-plugin-ui5): package name in logs

### DIFF
--- a/packages/cds-plugin-ui5/lib/log.js
+++ b/packages/cds-plugin-ui5/lib/log.js
@@ -15,7 +15,7 @@ function log(type, ...message) {
 	if (!console[type]) {
 		type = "log";
 	}
-	const args = [`\x1b[36m[cds-ui5-plugin]\x1b[0m %s[%s]\x1b[0m %s`, colors[type], type];
+	const args = [`\x1b[36m[cds-plugin-ui5]\x1b[0m %s[%s]\x1b[0m %s`, colors[type], type];
 	message && args.push(...message);
 	console[type].apply(console[type], args);
 }


### PR DESCRIPTION
`cds-ui5-plugin` was logged into the console when using the package instead of `cds-plugin-ui5`.