### PR TITLE
feat(ui5-tooling-transpile): support generation of interfaces in task

### DIFF
--- a/packages/karma-ui5-transpile/lib/index.js
+++ b/packages/karma-ui5-transpile/lib/index.js
@@ -62,7 +62,7 @@ function createPreprocessor(config, logger) {
 	// determine the ui5-tooling-transpile-task configuration
 	const customTasks = configs?.[0]?.builder?.customTasks;
 	const transpileTask = customTasks?.find((customTask) => customTask.name === "ui5-tooling-transpile-task");
-	const configuration = createConfiguration(transpileTask?.configuration);
+	const configuration = createConfiguration({ configuration: transpileTask?.configuration });
 
 	// create the Babel configuration using the ui5-tooling-tranpile-task util
 	const babelConfigCreated = createBabelConfig({

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -33,7 +33,7 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 	} = require("./util")(log);
 
 	const cwd = middlewareUtil.getProject().getRootPath() || process.cwd();
-	const config = createConfiguration(options?.configuration || {}, cwd);
+	const config = createConfiguration({ configuration: options?.configuration || {}, isMiddleware: true }, cwd);
 	const babelConfig = await createBabelConfig({ configuration: config, isMiddleware: true }, cwd);
 
 	// in case of local development of framework dependencies, they are not listed as

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -228,11 +228,13 @@ module.exports = function (log) {
 		/**
 		 * Build the configuration for the task and the middleware.
 		 *
-		 * @param {object} configuration task/middleware configuration
+		 * @param {object} cfg configuration object
+		 * @param {object} cfg.configuration task/middleware configuration
+		 * @param {boolean} cfg.isMiddleware true, if the function is called from the middleware
 		 * @param {string} [cwd] the cwd to lookup the configuration (defaults to process.cwd())
 		 * @returns {object} the translated task/middleware configuration
 		 */
-		createConfiguration: function createConfiguration(configuration, cwd = process.cwd()) {
+		createConfiguration: function createConfiguration({ configuration, isMiddleware }, cwd = process.cwd()) {
 			// extract the configuration
 			const config = configuration || {};
 
@@ -265,9 +267,15 @@ module.exports = function (log) {
 
 			// load the pkgJson to determine the existence of the @ui5/ts-interface-generator
 			// to automatically set the config option generateTsInterfaces (if this is a ts project)
+			// in case of running the code inside a middleware
 			let generateTsInterfaces = config.generateTsInterfaces;
 			const pkgJsonPath = path.join(cwd, "package.json");
-			if (transformTypeScript && generateTsInterfaces === undefined && fs.existsSync(pkgJsonPath)) {
+			if (
+				isMiddleware &&
+				transformTypeScript &&
+				generateTsInterfaces === undefined &&
+				fs.existsSync(pkgJsonPath)
+			) {
 				const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, { encoding: "utf8" }));
 				const deps = [
 					...Object.keys(pkgJson?.dependencies || {}),

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -79,8 +79,10 @@ test("inject configuration options", async (t) => {
 	// typescript, default config
 	let configuration = t.context.util.createConfiguration(
 		{
-			debug: true,
-			skipBabelPresetPluginResolve: true
+			configuration: {
+				debug: true,
+				skipBabelPresetPluginResolve: true
+			}
 		},
 		cwd
 	);
@@ -112,11 +114,13 @@ test("inject configuration options", async (t) => {
 	// typescript, custom transform-ui5 config
 	configuration = t.context.util.createConfiguration(
 		{
-			debug: true,
-			transformModulesToUI5: {
-				overridesToOverride: true
-			},
-			skipBabelPresetPluginResolve: true
+			configuration: {
+				debug: true,
+				transformModulesToUI5: {
+					overridesToOverride: true
+				},
+				skipBabelPresetPluginResolve: true
+			}
 		},
 		cwd
 	);
@@ -153,14 +157,16 @@ test("inject configuration options", async (t) => {
 	// typescript, custom typescript and transform-ui5 config
 	configuration = t.context.util.createConfiguration(
 		{
-			debug: true,
-			transformTypeScript: {
-				optimizeConstEnums: true
-			},
-			transformModulesToUI5: {
-				overridesToOverride: true
-			},
-			skipBabelPresetPluginResolve: true
+			configuration: {
+				debug: true,
+				transformTypeScript: {
+					optimizeConstEnums: true
+				},
+				transformModulesToUI5: {
+					overridesToOverride: true
+				},
+				skipBabelPresetPluginResolve: true
+			}
 		},
 		cwd
 	);

--- a/showcases/ui5-tsapp/ui5.yaml
+++ b/showcases/ui5-tsapp/ui5.yaml
@@ -32,6 +32,7 @@ builder:
       afterTask: replaceVersion
       configuration:
         <<: *cfgTranspile
+        generateTsInterfaces: true
     - name: ui5-tooling-modules-task
       afterTask: ui5-tooling-transpile-task
       configuration:

--- a/showcases/ui5-tsapp/webapp/Component.ts
+++ b/showcases/ui5-tsapp/webapp/Component.ts
@@ -1,5 +1,5 @@
 import UIComponent from "sap/ui/core/UIComponent";
-import { support } from "sap/ui/Device";
+import Device from "sap/ui/Device";
 
 /**
  * @namespace ui5.ecosystem.demo.tsapp
@@ -30,7 +30,7 @@ export default class Component extends UIComponent {
 			// check whether FLP has already set the content density class; do nothing in this case
 			if (document.body.classList.contains("sapUiSizeCozy") || document.body.classList.contains("sapUiSizeCompact")) {
 				this.contentDensityClass = "";
-			} else if (!support.touch) {
+			} else if (!Device.support.touch) {
 				// apply "compact" mode if touch is not supported
 				this.contentDensityClass = "sapUiSizeCompact";
 			} else {


### PR DESCRIPTION
With this feature the task of `ui5-tooling-transpile` supports the generation of the control interfaces if the option `generateTsInterfaces` is set to `true`.

Fixes #919