### PR TITLE
docs: patch jsdoc type of the `configuration` property & adjust `ui5-task-zipper` jsdoc to reflect signature 

### DIFF
--- a/packages/ui5-middleware-approuter/lib/middleware.js
+++ b/packages/ui5-middleware-approuter/lib/middleware.js
@@ -32,7 +32,7 @@ const nextFreePort = async (basePort) => {
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use

--- a/packages/ui5-middleware-cap/lib/middleware.js
+++ b/packages/ui5-middleware-cap/lib/middleware.js
@@ -13,7 +13,7 @@ const hook = require("ui5-utils-express/lib/hook");
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance for use in the custom middleware
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = async ({ log, options }) => {

--- a/packages/ui5-middleware-iasync/lib/iaSync.js
+++ b/packages/ui5-middleware-iasync/lib/iaSync.js
@@ -23,7 +23,7 @@ const customUI5Html = fs.readFileSync(path.join(`${__dirname}`, "ui5mangler.html
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = ({ log, options }) => {

--- a/packages/ui5-middleware-index/lib/index.js
+++ b/packages/ui5-middleware-index/lib/index.js
@@ -7,7 +7,7 @@
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = ({ log, options }) => {

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -71,7 +71,7 @@ const determineSourcePaths = (collection, skipFwkDeps) => {
  * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies Reader or Collection to read resources of
  *                                        the projects dependencies
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a MiddlewareUtil instance
  * @returns {Function} Middleware function to use
  */

--- a/packages/ui5-middleware-onelogin/lib/index.js
+++ b/packages/ui5-middleware-onelogin/lib/index.js
@@ -48,7 +48,7 @@ var firstTime = true;
  *                                        Reader or Collection to read resources of
  *                                        the projects dependencies
  * @param {Object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration
  *                                                      if given in ui5.yaml
  * @returns {function} Middleware function to use
  */

--- a/packages/ui5-middleware-onelogin/src/index.ts
+++ b/packages/ui5-middleware-onelogin/src/index.ts
@@ -39,7 +39,7 @@ var firstTime: boolean = true;
  *                                        Reader or Collection to read resources of
  *                                        the projects dependencies
  * @param {Object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration
  *                                                      if given in ui5.yaml
  * @returns {function} Middleware function to use
  */

--- a/packages/ui5-middleware-serveframework/lib/index.js
+++ b/packages/ui5-middleware-serveframework/lib/index.js
@@ -13,7 +13,7 @@ const fresh = require("fresh");
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use

--- a/packages/ui5-middleware-servestatic/lib/serveStatic.js
+++ b/packages/ui5-middleware-servestatic/lib/serveStatic.js
@@ -32,7 +32,7 @@ const parseConfigOption = (optionValue) => {
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = function ({ log, options }) {

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -57,7 +57,7 @@ function sanitizeObject(o) {
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use

--- a/packages/ui5-middleware-ui5/lib/ui5.js
+++ b/packages/ui5-middleware-ui5/lib/ui5.js
@@ -11,7 +11,7 @@ const createPatchedRouter = require("./createPatchedRouter");
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a MiddlewareUtil instance
  * @returns {Function} Middleware function to use
  */

--- a/packages/ui5-middleware-webjars/lib/index.js
+++ b/packages/ui5-middleware-webjars/lib/index.js
@@ -15,7 +15,7 @@ const JSZip = require("jszip");
  * @param {object} parameters Parameters
  * @param {@ui5/logger/Logger} parameters.log Logger instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use

--- a/packages/ui5-task-cachebuster/lib/cachebuster.js
+++ b/packages/ui5-task-cachebuster/lib/cachebuster.js
@@ -9,7 +9,7 @@
  *                [TaskUtil]{@link module:@ui5/builder.tasks.TaskUtil} instance
  * @param {object} parameters.options Options
  * @param {string} [parameters.options.projectNamespace] Project namespace
- * @param {string} [parameters.options.configuration] Task configuration if given in ui5.yaml; possible is debug : true|false
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml; possible is debug : true|false
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written or rejecting in case of an error
  */
 module.exports = async function ({ workspace, /* dependencies,*/ taskUtil, options }) {

--- a/packages/ui5-task-i18ncheck/lib/i18ncheck.js
+++ b/packages/ui5-task-i18ncheck/lib/i18ncheck.js
@@ -8,7 +8,7 @@ const utils = require("./utils");
  * @param {module:@ui5/logger/Logger} parameters.log Logger instance
  * @param {module:@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
  * @param {object} parameters.options Options
- * @param {string} parameters.options.configuration Configuration object
+ * @param {object} parameters.options.configuration Configuration object
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
 module.exports = async function ({ log, workspace, options }) {

--- a/packages/ui5-task-minify-xml/lib/minifyXml.js
+++ b/packages/ui5-task-minify-xml/lib/minifyXml.js
@@ -13,7 +13,7 @@ const attrValueRegExp = /(?<=<\/?[^\s\/>]+\b(?:\s+[^=\s>]+\s*=\s*(?:"[^"]*"|'[^'
  * @param {module:@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
- * @param {string} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
 module.exports = async ({ log, workspace, options }) => {

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -31,8 +31,9 @@ const determineProjectName = (collection) => {
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {string} parameters.options.projectNamespace Project namespace
- * @param {string} [parameters.options.archiveName] ZIP archive name (defaults to project namespace)
- * @param {string} [parameters.options.additionalFiles] List of additional files to be included
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {string} [parameters.options.configuration.archiveName] ZIP archive name (defaults to project namespace)
+ * @param {string} [parameters.options.configuration.additionalFiles] List of additional files to be included
  * @param {object} parameters.taskUtil the task utilities
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */

--- a/packages/ui5-tooling-less/lib/middleware.js
+++ b/packages/ui5-tooling-less/lib/middleware.js
@@ -12,7 +12,7 @@ const LessBuilder = require("./LessBuilder");
  * @param {module:@ui5/fs.AbstractReader} parameters.resources.dependencies Reader or Collection to read resources of
  *                                        the projects dependencies
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use

--- a/packages/ui5-tooling-less/lib/task.js
+++ b/packages/ui5-tooling-less/lib/task.js
@@ -10,7 +10,7 @@ const LessBuilder = require("./LessBuilder");
  * @param {module:@ui5/fs.AbstractReader} parameters.dependencies Reader or Collection to read dependency files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
- * @param {string} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
  * @param {module:@ui5/builder.tasks.TaskUtil} [parameters.taskUtil] TaskUtil
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -17,7 +17,7 @@ const minimatch = require("minimatch");
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {string} [parameters.options.projectNamespace] Project namespace if available
- * @param {string} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
  * @param {boolean} [parameters.options.configuration.prependPathMappings] Prepend the path mappings for the UI5 loader to Component.js
  * @param {boolean} [parameters.options.configuration.addToNamespace] Adds modules into the sub-namespace thirdparty of the Component
  * @param {boolean} [parameters.options.configuration.removeScopePrefix] Remove the @ prefix for the scope in the namespace/path

--- a/packages/ui5-tooling-stringreplace/lib/middleware.js
+++ b/packages/ui5-tooling-stringreplace/lib/middleware.js
@@ -20,7 +20,7 @@ const intercept = require("ui5-utils-express/lib/intercept");
  * @param {module:@ui5/server.middleware.MiddlewareUtil} parameters.middlewareUtil Specification version dependent
  *                                                       interface to a MiddlewareUtil instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = function createMiddleware({ log, resources, options, middlewareUtil }) {

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -18,7 +18,7 @@ const path = require("path");
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @param {object} parameters.options Options
- * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {Function} Middleware function to use
  */
 module.exports = async function ({ log, resources, options, middlewareUtil }) {

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -15,7 +15,7 @@ const JSONC = require("comment-json");
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {string} [parameters.options.projectNamespace] Project namespace if available
- * @param {string} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, options }) {


### PR DESCRIPTION
Hello,

I had to write a custom task recently and decided to take a look at the community packages to serve me as examples. 

Specifically, I noticed that the properties of the `configuration` object were annotated as properties of `options` itself in `ui5-task-zipper`. This is the first commit and the thing that I initially noticed & wanted to fix

Additionally, `configuration` was annotated as being of type `string` throughout the monorepo. I took the freedom of patching all such occurrences. That's the second commit - please tell me if that's too much, I'd be happy even if one of those commits does something helpful.


@petermuessig - sorry for the ping - do you think this can get through?