### PR TITLE
fix: prefere cds.env._home over just current process.cwd

### DIFF
--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -68,7 +68,7 @@ if (!skip) {
 	cds.on("bootstrap", async function bootstrap(app) {
 		log.debug("bootstrap");
 
-		const cwd = process.cwd();
+		const cwd = cds?.env?._home || process.cwd();
 		const ui5Modules = await findUI5Modules({ cwd, cds });
 		const { localApps, config } = ui5Modules;
 


### PR DESCRIPTION
fixes: #946

maybe there is a better option like ```cds.env._home```?