### PR TITLE
fix(ui5-tooling-transpile): support JS-based babel config files

### DIFF
--- a/packages/ui5-tooling-transpile/test/__assets__/external-js/.babelrc
+++ b/packages/ui5-tooling-transpile/test/__assets__/external-js/.babelrc
@@ -1,0 +1,5 @@
+{
+	// comments are allowed
+	"presets": ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"],
+	"sourceMaps": true
+}

--- a/packages/ui5-tooling-transpile/test/__assets__/external-js/.browserslistrc
+++ b/packages/ui5-tooling-transpile/test/__assets__/external-js/.browserslistrc
@@ -1,0 +1,1 @@
+>0.5% and not dead

--- a/packages/ui5-tooling-transpile/test/__assets__/external-js/babel.config.js
+++ b/packages/ui5-tooling-transpile/test/__assets__/external-js/babel.config.js
@@ -1,0 +1,18 @@
+module.exports = function (api) {
+	api.cache(true);
+
+	const presets = ["transform-ui5", "@babel/preset-typescript", "@babel/preset-env"];
+	const plugins = [
+		[
+			"transform-async-to-promises",
+			{
+				inlineHelpers: true
+			}
+		]
+	];
+
+	return {
+		presets,
+		plugins
+	};
+};

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -71,6 +71,27 @@ test("usage of external babel config", async (t) => {
 		cwd
 	);
 	t.true(config !== undefined);
+	t.deepEqual(config.presets[0].file.request, "transform-ui5");
+	t.deepEqual(config.presets[1].file.request, "@babel/preset-typescript");
+	t.deepEqual(config.presets[2].file.request, "@babel/preset-env");
+});
+
+test("usage of external js babel config", async (t) => {
+	const cwd = path.join(__dirname, "__assets__/external-js");
+	const config = await t.context.util.createBabelConfig(
+		{
+			configuration: {
+				debug: true,
+				skipBabelPresetPluginResolve: true
+			}
+		},
+		cwd
+	);
+	t.true(config !== undefined);
+	t.deepEqual(config.presets[0].file.request, "transform-ui5");
+	t.deepEqual(config.presets[1].file.request, "@babel/preset-typescript");
+	t.deepEqual(config.presets[2].file.request, "@babel/preset-env");
+	t.deepEqual(config.plugins[0].file.request, "transform-async-to-promises");
 });
 
 test("inject configuration options", async (t) => {


### PR DESCRIPTION
Fixes #966