### PR TITLE
feat(ui5-middleware-serveframework): provide custom ui5 version from env variable

### DIFF
--- a/packages/ui5-middleware-serveframework/README.md
+++ b/packages/ui5-middleware-serveframework/README.md
@@ -20,6 +20,10 @@ npm install ui5-middleware-serveframework --save-dev
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
 - `debug`: *`boolean`*, default: `false`
+- `ui5VersionEnvVariable`: *`string`*
+  Name of environment variable that contains ui5 version (in case you want to override framework version from ui5.yaml)
+- `envFilePath`: *`string`*, default: `./.env`
+  Path to file with environment variables
 
 ## Usage
 
@@ -40,6 +44,9 @@ server:
   customMiddleware:
   - name: ui5-middleware-serveframework
     afterMiddleware: compression
+    configuration:
+      ui5VersionEnvVariable: UI5_VERSION
+      envFilePath: "./.dev.env"
 ```
 
 ## How it works

--- a/packages/ui5-middleware-serveframework/lib/index.js
+++ b/packages/ui5-middleware-serveframework/lib/index.js
@@ -31,7 +31,13 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 	// derive framework from current project
 	const rootProject = middlewareUtil.getProject();
 	const frameworkName = rootProject.getFrameworkName();
-	const frameworkVersion = rootProject.getFrameworkVersion();
+	const envFilePath = options.configuration?.envFilePath || "./.env";
+	require("dotenv").config({
+		path: envFilePath,
+	});
+	const ui5VersionEnvVariable = options.configuration?.ui5VersionEnvVariable;
+	const frameworkVersion = process.env[ui5VersionEnvVariable] || rootProject.getFrameworkVersion();
+	log.info(`Loading sources for ${frameworkName} version ${frameworkVersion}`);
 
 	// check if the framework libraries are loaded from the local cache in the user home
 	// by checking the library version to be the last segment of the folder name of the library path
@@ -48,7 +54,6 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 	if (frameworkName && !isWorkspace) {
 		// derive the npm scope and the version
 		const frameworkScope = `@${frameworkName.toLowerCase()}`;
-		const frameworkVersion = rootProject.getFrameworkVersion(); // TODO: how to determine the versionOverride?
 
 		// all the data is stored in the `.ui5` folder
 		const homeDir = require("os").homedir();

--- a/packages/ui5-middleware-serveframework/package.json
+++ b/packages/ui5-middleware-serveframework/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@ui5/project": "^3.9.0",
+    "dotenv": "^16.3.1",
     "etag": "^1.8.1",
     "fresh": "^0.5.2",
     "https-proxy-agent": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@ui5/project':
         specifier: ^3.9.0
         version: 3.9.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.4.5
       etag:
         specifier: ^1.8.1
         version: 1.8.1
@@ -15320,9 +15323,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0


### PR DESCRIPTION
Allow to override ui5 version coming from `$yourapp/ui5.yaml` file with environment variable. This allows to store ui5 version used by multiple projects in a single place.