### PR TITLE
Adjusted ui5-tooling-stringreplace to work with .ts files

### DIFF
--- a/packages/ui5-tooling-stringreplace/lib/util.js
+++ b/packages/ui5-tooling-stringreplace/lib/util.js
@@ -78,7 +78,7 @@ const _self = (module.exports = {
 	 * @public
 	 */
 	getMimeInfo: function getMimeInfo(resourcePath) {
-		const type = mime.lookup(resourcePath) || "application/octet-stream";
+		const type = resourcePath.endsWith(".ts") ? "application/javascript" : mime.lookup(resourcePath) || "application/octet-stream";
 		const charset = mime.charset(type);
 		return {
 			type,


### PR DESCRIPTION
I adjusted fetching the MimeInfo fetching as currently the type for all .ts files will result in "video/mp2t" and therefore will be ignored by the stringreplace-task. 
With this change the stringreplace-task can also detect and replace strings in any TypeScript files.

Please also refer to this issue: https://github.com/ui5-community/ui5-ecosystem-showcase/issues/979