### PR TITLE
fix(ui5-tooling-modules): ignore unkown modules for bundling

### DIFF
--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -144,6 +144,9 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 
 			// if the resource is a bundled resource, we need to wait for it
 			const bundleInfo = whenBundled && (await whenBundled);
+			if (bundleInfo.error) {
+				log.error(bundleInfo.error);
+			}
 			const bundledResource = bundleInfo?.getEntry(moduleName);
 			if (bundledResource) {
 				resource = bundledResource;

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -218,6 +218,10 @@ module.exports = async function ({ log, workspace, taskUtil, options }) {
 
 	// every unique dependency will be bundled (entry points will be kept, rest is chunked)
 	const bundleInfo = await getBundleInfo(Array.from(uniqueModules), config, { cwd, depPaths });
+	if (bundleInfo.error) {
+		log.error(bundleInfo.error);
+		process.exit(1);
+	}
 	const bundledResources = bundleInfo.getBundledResources().map((entry) => entry.name);
 	await Promise.all(
 		bundleInfo.getEntries().map(async (entry) => {

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -249,9 +249,9 @@ module.exports = function (log) {
 					// here if they also require to be transpiled by the task
 					try {
 						const depPath = that.resolveModule(dep, { cwd, depPaths });
-						if (existsSyncWithCase(depPath)) {
-							addUniqueModule(dep);
+						if (depPath && existsSyncWithCase(depPath)) {
 							const depContent = readFileSync(depPath, { encoding: "utf8" });
+							addUniqueModule(dep);
 							findUniqueJSDeps(depContent, depPath);
 						}
 					} catch (ex) {
@@ -438,8 +438,7 @@ module.exports = function (log) {
 				for (const tsResource of allTsResources) {
 					const imports = parse(await tsResource.getString(), "module", true);
 					imports?.resolutions?.forEach((res) => {
-						addUniqueDep(res.input);
-						addUniqueModule(res.input);
+						addDep(res.input);
 					});
 				}
 			}


### PR DESCRIPTION
When modules have dependencies to unknown or native modules (e.g. "fs") then the tooling extension tries to include them but cannot find and open them during the build process which leads to an empty bundle.

In addition, added a proper error logging in case of bundling errors to see the stack trace for the build and the middleware. The build will stop but the middleware just prints the issue without stopping the server.

Fixes #977