### PR TITLE
feat(ui5-tooling-transpile): properly lookup the babel config

### DIFF
--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -27,6 +27,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 		determineResourceFSPath,
 		transformAsync
 	} = require("./util")(log);
+	const { OmitFromBuildResult } = taskUtil.STANDARD_TAGS;
 
 	const cwd = taskUtil.getProject().getRootPath() || process.cwd();
 	const config = createConfiguration({ configuration: options?.configuration || {}, isMiddleware: false }, cwd);
@@ -162,7 +163,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 			if (omitFromBuildResult) {
 				config.debug && log.verbose(`Omitting resource ${resourcePath}`);
 				const resource = await workspace.byPath(resourcePath);
-				taskUtil.setTag(resource, taskUtil.STANDARD_TAGS.OmitFromBuildResult, true);
+				taskUtil.setTag(resource, OmitFromBuildResult, true);
 			}
 		}
 

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -88,7 +88,13 @@ async function findBabelConfigOptions(cwd) {
 
 	const findConfigFile = function (cfgFiles, dir) {
 		const configFile = cfgFiles.find((cfgFile) => {
-			return fs.existsSync(path.join(dir, cfgFile));
+			let exists = fs.existsSync(path.join(dir, cfgFile));
+			// for the package.json we need to check if the babel property exists
+			if (exists && cfgFile === "package.json") {
+				const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, cfgFile), { encoding: "utf8" }));
+				exists = pkgJson.babel !== undefined;
+			}
+			return exists;
 		});
 		return configFile && path.join(dir, configFile);
 	};
@@ -103,7 +109,7 @@ async function findBabelConfigOptions(cwd) {
 	}
 
 	let babelConfigOptions;
-	if (path.basename(configFile) === "package.json") {
+	if (configFile && path.basename(configFile) === "package.json") {
 		// for the package.json, we need to extract the babel config
 		const pkgJson = JSON.parse(fs.readFileSync(configFile, { encoding: "utf8" }));
 		if (pkgJson.babel) {


### PR DESCRIPTION
This fix checks the package.json to contain a babel config object and only in this case interprets the package.json as source of the configuration.

This fix is marked as feature because it may change the lookup of the configuration and detects now properly the babel config file in parent folders like babel itself does...