### PR TITLE
fix(ui5-tooling-transpile): create absolute path for the replaceVersion import

### DIFF
--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -2,7 +2,7 @@
 const path = require("path");
 const fs = require("fs");
 const JSONC = require("comment-json");
-const { pathToFileURL } = require("node:url");
+const { pathToFileURL } = require("url");
 
 /**
  * Custom task to transpile resources to JavaScript modules.
@@ -78,7 +78,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 	try {
 		// dynamically require the replaceVersion task
 		// (using the absolute path to the module to avoid issues with the module resolution)
-		const replaceVersion = (await import(pathToFileURL(require.resolve("@ui5/builder/tasks/replaceVersion")).href))
+		const replaceVersion = (await import(pathToFileURL(require.resolve("@ui5/builder/tasks/replaceVersion"))))
 			.default;
 		// replace the versions for all supported file types
 		// using the central replaceVersion task of the UI5 Tooling

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const fs = require("fs");
 const JSONC = require("comment-json");
+const { pathToFileURL } = require("node:url");
 
 /**
  * Custom task to transpile resources to JavaScript modules.
@@ -77,7 +78,8 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 	try {
 		// dynamically require the replaceVersion task
 		// (using the absolute path to the module to avoid issues with the module resolution)
-		const replaceVersion = (await import(require.resolve("@ui5/builder/tasks/replaceVersion"))).default;
+		const replaceVersion = (await import(pathToFileURL(require.resolve("@ui5/builder/tasks/replaceVersion")).href))
+			.default;
 		// replace the versions for all supported file types
 		// using the central replaceVersion task of the UI5 Tooling
 		await replaceVersion({


### PR DESCRIPTION
This uses https://nodejs.org/api/url.html#urlpathtofileurlpath-options to make the path an absolute `file://` path that should be suitable for using with `import` on all platforms.

`require.resolve()` alone results in an absolute path on Windows which cannot be used.