### PR TITLE
feat(ui5-tooling-modules): entry point modules must be project dependencies

### DIFF
--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -97,6 +97,9 @@ The following configuration options are relevant for the `task` and the `middlew
 - *chunksPath*: `boolean|string`
   Relative path for the chunks to be stored into (if value is `true`, chunks are put into the closest modules folder which was the default behavior in the `3.5.x` release of the tooling extension)
 
+- *legacyDependencyResolution*: `boolean`
+  Re-enables the legacy dependency resolution of the tooling extension which allows to use entry points from `devDependencies` of the project. By default, only the `dependencies` maintained in the projects' `package.json` and the transitive dependencies are considered for the entry points and all other entry points are ignored. (available since new minor version `3.7.0` which introduces a new dependency resolution for `dependencies` only)
+
 - *minify*: `boolean` *experimental feature*
   Flag to indicate that the generated code should be minified (in case of excluding thirdparty resources from minification in general, this option can be used to minify just the generated code)
 


### PR DESCRIPTION
Starting with `ui5-tooling-modules` version `3.7.0` every entry point must be resolved from a `dependency`. Entry points used from `devDependencies` or other dependencies are not included anymore for the generation of the modules bundles. 

This ensures that the used entry points are properly declared and scan tools can identify the NPM packages for the used thirdparty modules. It also ensures that if a dependency is used the proper thirdparty modules are also available as transitive dependencies.