### PR TITLE
fix: handle case when lessToCompile is provided as a string value

### DIFF
--- a/packages/ui5-tooling-less/lib/task.js
+++ b/packages/ui5-tooling-less/lib/task.js
@@ -29,6 +29,12 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 
 	// determine the less files to compile from the ui5.yaml (config)
 	let lessToCompile = options?.configuration?.lessToCompile || [];
+
+	// handle case when the parameter is a string, e.g. lessToCompile: 'theme/style.less'
+	if (typeof lessToCompile === "string") {
+		lessToCompile = [lessToCompile];
+	}
+
 	if (lessToCompile.length === 0) {
 		// if nothing is specified, we extract the less files to compile from the manifest
 		let manifest = await (await workspace.byPath(`${localPath}/manifest.json`)).getString();


### PR DESCRIPTION
As of now the ui5-tooling-less-task is not working when the configuration parameter `lessToCompile` is provided as a single string value.

```yaml
customTasks:
   - name: ui5-tooling-less-task
     beforeTask: minify
     configuration:
       lessToCompile: 'theme/style.less'
```

A workaround is to use a list style. 

```yaml
customTasks:
   - name: ui5-tooling-less-task
     beforeTask: minify
     configuration:
       lessToCompile: 
         - 'theme/style.less'
```
I stumbled across it when migrating an old project from a colleague to UI5 tooling v3. We used a custom less compile task supporting single values and the switch to the official UI5 tooling task made me struggling. 