### PR TITLE
fix(ui5-tooling-modules): fixed some dependencies falsely assumed to be located in project root

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -191,7 +191,7 @@ module.exports = function (log) {
 			}
 		};
 		// try to resolve the module with different file extensions
-		for (const ext of ["", ".js", ".cjs", ".mjs"]) {
+		for (const ext of [".js", ".cjs", ".mjs", ""]) {
 			// 1.) use default lookup
 			modulePath = resolve(`${moduleName}${ext}`);
 			if (modulePath) break;


### PR DESCRIPTION
When using ui5-tooling-modules in combination with signalr packages the dependency for "punycode" was assumed to be located in the project root and not inside node_modules subfolders. By changing the search order of file extensions in util.js this bug will not occur.