### PR TITLE
fix(ui5-tooling-modules): only consider js, cjs or mjs files as bundle entry points

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -843,7 +843,7 @@ module.exports = function (log) {
 					//   3) should not be skipped from transformation
 					//   4) is no UI5 module
 					if (modulePath) {
-						if (/\.(m|c)?js/.test(path.extname(modulePath).toLowerCase()) && !shouldSkipTransform(moduleName) && !(await shouldSkipModule(modulePath))) {
+						if (/\.(m|c)?js$/.test(path.extname(modulePath).toLowerCase()) && !shouldSkipTransform(moduleName) && !(await shouldSkipModule(modulePath))) {
 							const module = bundleInfo.addModule({
 								name: moduleName,
 								path: modulePath,


### PR DESCRIPTION
The regex to decide which file extensions are considered as entry points for the bundle was to vague and needs to be more precise to not match json file extensions with it as json files should be considered as resources.