### PR TITLE
feat(ui5-task-zipper): optional  parameter to turn absolute data sour…

### DIFF
--- a/packages/ui5-task-zipper/README.md
+++ b/packages/ui5-task-zipper/README.md
@@ -35,6 +35,9 @@ Set this to `true` if you also want to generate the unzipped resources in the `d
 - includeDependencies: `true|false` or `String<Array>`
 Set this to `true` if you also want to include the dependencies (UI5 libraries) in the zip archive. Otherwise, it will only include the workspace files (controller, views, etc). In order to select only specific dependencies to be included in the final zip you just need to specify the list of dependencies (value of `ui5.yaml`: `metadata > name`).
 
+- relativePaths `true|false`
+Set this to `true` if you want to turn absolute data source paths in the `manifest.json` into relative paths, e.g. `"uri": "/backend/"` will be turned into `"uri": "backend/"` upon ZIP creation. This is useful when deploying the ZIP to the HTML Application Repository on SAP BTP, Cloud Foundry environment to later consume it in SAP Build Work Zone, standard edition, which only supports relative paths.
+
 **NOTE:** Starting with release `3.0.5`, the `ui5-task-zipper` includes the generated workspace resources such as the self-contained bundles (`sap-ui-custom.*` files). To do so, it is important that the `ui5-task-zipper` is running as last task in the build.
 
 ## Usage

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -1,7 +1,5 @@
 const path = require("path");
 const yazl = require("yazl");
-const { Buffer } = require("node:buffer");
-const fs = require("fs");
 
 /**
  * Determines the project name from the given resource collection.
@@ -25,7 +23,6 @@ const determineProjectName = (collection) => {
 
 /**
   * Turn absolute data source paths in the manifest.json into relative paths
-  * Only works if manifest.json is located in the `webapp/` directory
   *
   * @param {Buffer} buffer Buffer of the manifest.json file
   * @param {object} zip ZipFile instance

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -1,5 +1,7 @@
 const path = require("path");
 const yazl = require("yazl");
+const { Buffer } = require("node:buffer");
+const fs = require("fs");
 
 /**
  * Determines the project name from the given resource collection.
@@ -22,6 +24,25 @@ const determineProjectName = (collection) => {
 };
 
 /**
+  * Turn absolute data source paths in the manifest.json into relative paths
+  * Only works if manifest.json is located in the `webapp/` directory
+  *
+  * @param {Buffer} buffer Buffer of the manifest.json file
+  * @param {object} zip ZipFile instance
+  * returns {void}
+*/
+const absoluteToRelativePaths = (buffer, zip) => {
+	const manifest = JSON.parse(buffer.toString("utf-8"));
+	if (!manifest["sap.app"]["dataSources"]) return;
+	for (const [dataSourceName, dataSource] of Object.entries(manifest["sap.app"]["dataSources"])) {
+		if (dataSource.uri?.substring(0, 1) === "/") {
+			manifest["sap.app"]["dataSources"][dataSourceName].uri = dataSource.uri.substring(1);
+		}
+	}
+	zip.addBuffer(Buffer.from(JSON.stringify(manifest, null, 4), "utf-8"), "manifest.json");
+}
+
+/**
  * Zips the application content of the output folder
  *
  * @param {object} parameters Parameters
@@ -37,11 +58,14 @@ const determineProjectName = (collection) => {
  * @param {object} parameters.taskUtil the task utilities
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
-module.exports = async function ({ log, workspace, dependencies, options, taskUtil }) {
+module.exports = async function({ log, workspace, dependencies, options, taskUtil }) {
 	const { OmitFromBuildResult } = taskUtil.STANDARD_TAGS;
 
 	// debug mode?
 	const isDebug = options?.configuration?.debug;
+
+	// turn absolute paths into relative paths?
+	const relativePaths = options?.configuration?.relativePaths;
 
 	// determine the name of the ZIP archive (either from config or from project namespace)
 	const defaultName = options && options.configuration && options.configuration.archiveName;
@@ -54,14 +78,14 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 		includeDependencies === true
 			? dependencies
 			: taskUtil.resourceFactory.createReaderCollection({
-					readers: !includeDependencies
-						? []
-						: dependencies._readers.filter((reader) => {
-								const projectName = determineProjectName(reader);
-								return includeDependencies.indexOf(projectName) !== -1;
-						  }),
-					name: "Filtered reader collection of ui5-task-zipper",
-			  });
+				readers: !includeDependencies
+					? []
+					: dependencies._readers.filter((reader) => {
+						const projectName = determineProjectName(reader);
+						return includeDependencies.indexOf(projectName) !== -1;
+					}),
+				name: "Filtered reader collection of ui5-task-zipper",
+			});
 
 	// retrieve the resource path prefix (to get all application resources)
 	const prefixPath = `/resources/${options.projectNamespace}/`;
@@ -95,7 +119,11 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 					zipEntries.push(resourcePath);
 					return resource.getBuffer().then((buffer) => {
 						isDebug && log.info(`Adding ${resource.getPath()} to archive.`);
-						zip.addBuffer(buffer, resourcePath); // Replace first forward slash at the start of the path
+						if (relativePaths && resourcePath.includes("manifest.json")) {
+							absoluteToRelativePaths(buffer, zip);
+						} else {
+							zip.addBuffer(buffer, resourcePath); // Replace first forward slash at the start of the path
+						}
 					});
 				} else {
 					log.warn(`Duplicate resource path found: ${resourcePath}! Skipping...`);
@@ -147,7 +175,7 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
  *      UI5 Tooling will ensure that those dependencies have been
  *      built before executing the task.
  */
-module.exports.determineRequiredDependencies = async function ({ availableDependencies, options }) {
+module.exports.determineRequiredDependencies = async function({ availableDependencies, options }) {
 	const includeDependencies = options?.configuration?.includeDependencies;
 	if (includeDependencies) {
 		if (Array.isArray(includeDependencies)) {

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -116,7 +116,7 @@ module.exports = async function({ log, workspace, dependencies, options, taskUti
 					zipEntries.push(resourcePath);
 					return resource.getBuffer().then((buffer) => {
 						isDebug && log.info(`Adding ${resource.getPath()} to archive.`);
-						if (relativePaths && resourcePath.includes("manifest.json")) {
+						if (relativePaths && resourcePath === "manifest.json") {
 							absoluteToRelativePaths(buffer, zip);
 						} else {
 							zip.addBuffer(buffer, resourcePath); // Replace first forward slash at the start of the path

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.relativePaths.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.relativePaths.yaml
@@ -1,0 +1,20 @@
+specVersion: "3.0"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.126.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateVersionInfo
+      configuration:
+        debug: true
+        onlyZip: true
+        relativePaths: true

--- a/packages/ui5-task-zipper/test/zipper.test.js
+++ b/packages/ui5-task-zipper/test/zipper.test.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { rmSync, existsSync, readdirSync, readFile } = require("fs");
+const { rmSync, existsSync, readdirSync } = require("fs");
 const { spawnSync } = require("child_process");
 const crypto = require("crypto");
 const yauzl = require("yauzl");


### PR DESCRIPTION
…ce paths into relative ones

I stumpled across this while working on the [generator-ui5-project](/ui5-community/generator-ui5-project), where we want to turn absolute data sources paths into relative ones, to be able to deploy them to SAP Build Work Zone, standard edition. Currently the [open-ux-tools](https://github.com/SAP/open-ux-tools) (which both the generator-ui5-project and the Fiori Tools Application Generator rely on) only add absolute paths to the manifest, which is why this transformation is necessary.

I thought it makes sense to implement this here in a reusable manner instead of building a custom script for it.

This has been mentioned/requested before, see here: https://github.com/SAP/ui5-tooling/issues/625