### PR TITLE
feat(ui5-tooling-modules): performance opt + persistent bundle info cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 package-lock.json
 yarn.lock
 
+# ignore ui5-tooling-modules cache
+showcases/*/.ui5-tooling-modules
+
 # wdi5 screenshots
 packages/ui5-app/webapp/test/e2e/report/*
 

--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -43,8 +43,12 @@ The following configuration options are relevant for the `task` and the `middlew
   Enables debug logging (defaults to `false`), by setting value to `"verbose"` the extension will log even more detailed
   &nbsp;
 
-- *skipCache*: `boolean` *experimental feature*
+- *skipCache*: `boolean`
   For development scenarios, the module cache can be disabled by setting this option to true. Normally, if a module changes (e.g. bundledefs), this change is detected and the bundle is recreated. This just forces the regeneration always (defaults to `false`)
+  &nbsp;
+
+- *persistentCache*: `boolean` *experimental feature*
+  With this option, the bundle information will be persistent and will be available again after the restart of the development server or for the next execution of your build task. The bundle information is stored in the working directory in the folder `.ui5-tooling-modules` folder. It's recommended to put this folder into `.gitignore` (defaults to `false`)
   &nbsp;
 
 - *keepDynamicImports*: `boolean|String[]` *experimental feature*


### PR DESCRIPTION
* only scan the dependencies which are UI5 packages (either having a ui5.yaml or .ui5pkg marker file)
* avoid recursive scanning of packages
* add verbose logging information
* introduced persistent cache for middleware to store bundle info in `.ui5-tooling-modules` folder in the cwd with a hash to reduce the overhead of regenerating the bundle info without changes

Fixes #1052