### PR TITLE
[ui5-tooling-transpile] fix for loading replaceVersion

### DIFF
--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -83,7 +83,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 			await import(
 				pathToFileURL(
 					require.resolve("@ui5/builder/tasks/replaceVersion", {
-						paths: [cwd, `node_modules${path.sep}@ui5${path.sep}cli`]
+						paths: [cwd, require.resolve("@ui5/cli/package.json")]
 					})
 				)
 			)

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -83,7 +83,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 			await import(
 				pathToFileURL(
 					require.resolve("@ui5/builder/tasks/replaceVersion", {
-						paths: [cwd, require.resolve("@ui5/cli/package.json")]
+						paths: [cwd, path.dirname(require.resolve("@ui5/cli/package.json"))]
 					})
 				)
 			)

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -74,12 +74,20 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 
 	// replace the version in all files handled by this task because this plugin handles additional file types
 	// which are not supported by the replaceVersion task of the UI5 Tooling (hardcoded some selected file types)
-	// (HINT: do this a bit loosly coupled for now to avoid tight dependencies to UI5 Tooling)
+	// (HINT: do this a bit loosely coupled for now to avoid tight dependencies to UI5 Tooling)
+	// Also check for @ui5/builder under @ui5/cli to avoid issues with the module resolution
 	try {
 		// dynamically require the replaceVersion task
 		// (using the absolute path to the module to avoid issues with the module resolution)
-		const replaceVersion = (await import(pathToFileURL(require.resolve("@ui5/builder/tasks/replaceVersion"))))
-			.default;
+		const replaceVersion = (
+			await import(
+				pathToFileURL(
+					require.resolve("@ui5/builder/tasks/replaceVersion", {
+						paths: [cwd, `node_modules${path.sep}@ui5${path.sep}cli`]
+					})
+				)
+			)
+		).default;
 		// replace the versions for all supported file types
 		// using the central replaceVersion task of the UI5 Tooling
 		await replaceVersion({


### PR DESCRIPTION
Fixes #1062 

and issues like the following:

```
> ui5 build --config=ui5.yaml --clean-dest --dest dist

info ProjectBuilder Preparing build for project zbasicrel
info ProjectBuilder   Target directory: dist
info ProjectBuilder Cleaning target directory...
info Project 1 of 1: ❯ Building application project zbasicrel...
info zbasicrel › Running task escapeNonAsciiCharacters...
info zbasicrel › Running task replaceCopyright...
info zbasicrel › Running task replaceVersion...
info zbasicrel › Running task ui5-tooling-transpile-task...
info builder:custom-task:ui5-tooling-transpile-task Create Babel configuration based on ui5.yaml configuration options...
info builder:custom-task:ui5-tooling-transpile-task Using browserslist configuration from ui5.yaml...
error builder:custom-task:ui5-tooling-transpile-task Failed to replace the version in the TypeScript files!
Reason: Error: Cannot find module '@ui5/builder/tasks/replaceVersion'
Require stack:
- C:\SAPDevelop\Java\zbasicrel\node_modules\ui5-tooling-transpile\lib\task.js
```