### PR TITLE
[FIX] ui5-tooling-less: Make compatible with UI5 Tooling v4

### DIFF
--- a/packages/ui5-tooling-less/lib/task.js
+++ b/packages/ui5-tooling-less/lib/task.js
@@ -56,9 +56,9 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 	const lessResources = [];
 	for (const glob of lessToCompile) {
 		if (!path.isAbsolute(glob)) {
-			lessResources.push(...((await workspace.byGlobSource(path.posix.join(localPath, glob))) || []));
+			lessResources.push(...((await workspace.byGlob(path.posix.join(localPath, glob))) || []));
 		} else {
-			lessResources.push(...((await workspace.byGlobSource(glob)) || []));
+			lessResources.push(...((await workspace.byGlob(glob)) || []));
 		}
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/SAP/ui5-tooling/issues/1007

`DuplexCollection#byGlobSource` has been removed in UI5 Tooling v4: https://sap.github.io/ui5-tooling/v4/updates/migrate-v4/#changes-to-ui5fs