### PR TITLE
feat(ui5-tooling-modules): support special UI5 settings for web components

### DIFF
--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -305,6 +305,7 @@ module.exports = function ({ log, resolveModule, getPackageJson, framework, opti
 				});
 				const metadata = JSON.stringify(metadataObject, undefined, 2);
 				const webcClass = moduleInfo.attributes.absModulePath.replace(/\\/g, "/"); // is the absolute path of the original Web Component class
+				const needsLabelEnablement = clazz._ui5NeedsLabelEnablement;
 
 				// Determine the superclass UI5 module name and import it
 				let webcBaseClass = "sap/ui/core/webc/WebComponent";
@@ -321,6 +322,7 @@ module.exports = function ({ log, resolveModule, getPackageJson, framework, opti
 					metadata,
 					webcClass,
 					webcBaseClass,
+					needsLabelEnablement,
 				});
 				return code;
 			}

--- a/packages/ui5-tooling-modules/lib/templates/WrapperControl.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/WrapperControl.hbs
@@ -1,8 +1,11 @@
 import WebComponentClass from "{{webcClass}}";
 import "{{namespace}}";
 import WebComponentBaseClass from "{{webcBaseClass}}";
+{{#if needsLabelEnablement}}
+import LabelEnablement from "sap/ui/core/LabelEnablement";
+{{/if}}
 
-export default WebComponentBaseClass.extend("{{ui5Class}}", {
+const WrapperClass = WebComponentBaseClass.extend("{{ui5Class}}", {
   metadata: {{{metadata}}},
   // TODO: Quick solution to fix a conversion between "number" and "core.CSSSize".
   //       WebC attribute is a number and is written back to the Control wrapper via core.WebComponent base class.
@@ -16,3 +19,9 @@ export default WebComponentBaseClass.extend("{{ui5Class}}", {
     return WebComponentBaseClass.prototype.setProperty.apply(this, [sPropName, v, bSupressInvalidate]);
   }
 });
+
+{{#if needsLabelEnablement}}
+LabelEnablement.enrich(WrapperClass.prototype);
+{{/if}}
+
+export default WrapperClass;

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -375,18 +375,6 @@ class RegistryEntry {
 			};
 		}
 
-		// TODO: Discuss if this is still needed.
-		//       Aren't we wrongfully introducing aggregations to controls that shouldn't have any.
-		//       e.g. the "@ui5/webcomponents.Switch" does not have a default slot and thus shouldn't have "content" aggregation.
-		// mandatory default aggregation, named "content" in UI5
-		// if (!ui5metadata.defaultAggregation) {
-		// 	ui5metadata.aggregations["content"] ??= {
-		// 		type: "sap.ui.core.Control",
-		// 		multiple: true,
-		// 	};
-		// 	ui5metadata.defaultAggregation = "content";
-		// }
-
 		// cssProperties: [ "width", "height", "display" ]
 		if (!ui5metadata.properties["width"]) {
 			ui5metadata.properties["width"] = {

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -411,13 +411,10 @@ class RegistryEntry {
 	 *
 	 * @param {object} ui5metadata the UI5 metadata object
 	 */
-	#patchUI5Specifics(ui5metadata) {
+	#patchUI5Specifics(classDef, ui5metadata) {
 		const { tag } = ui5metadata;
 
 		// The label has a couple of specifics that are not fully reflected in the custom elements.
-		// This code harmonizes the Label with the original retrofit control wrapper.
-		// TODO: How to generalize this?
-		//       Is harmonizing with the retrofit library really correct?
 		if (tag === "ui5-label") {
 			// the ui5-label has as default slot, but no aggregations on the retrofit layer...
 			ui5metadata.aggregations = [];
@@ -433,9 +430,9 @@ class RegistryEntry {
 			delete ui5metadata.properties["for"];
 
 			// Any "Label" control needs a special UI5-only interface
-			// Additionally, all controls implementing this interface must apply the "sap/ui/core/LabelEnablement" mixin on their class
-			// refer to "../templates/WrapperControl.hbs"
 			ui5metadata.interfaces.push("sap.ui.core.Label");
+			// Additionally, all such controls must apply the "sap/ui/core/LabelEnablement" (see "../templates/WrapperControl.hbs")
+			classDef._ui5NeedsLabelEnablement = true;
 		} else if (tag === "ui5-multi-input") {
 			// TODO: Multi Input needs to implement the functions defined in "sap.ui.core.ISemanticFormContent"...
 			ui5metadata.interfaces.push("sap.ui.core.ISemanticFormContent");
@@ -472,7 +469,7 @@ class RegistryEntry {
 
 		this.#ensureDefaults(ui5metadata);
 
-		this.#patchUI5Specifics(ui5metadata);
+		this.#patchUI5Specifics(classDef, ui5metadata);
 	}
 }
 

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
@@ -3962,7 +3962,7 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
     var CheckBox_1;
     let isGlobalHandlerAttached = false;
     let activeCb;
-    let CheckBox$1 = CheckBox_1 = class CheckBox extends UI5Element {
+    let CheckBox = CheckBox_1 = class CheckBox extends UI5Element {
       get formValidityMessage() {
         return CheckBox_1.i18nBundle.getText(FORM_CHECKABLE_REQUIRED);
       }
@@ -4127,34 +4127,34 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
         CheckBox_1.i18nBundle = await getI18nBundle("@ui5/webcomponents");
       }
     };
-    __decorate([property()], CheckBox$1.prototype, "accessibleNameRef", void 0);
-    __decorate([property()], CheckBox$1.prototype, "accessibleName", void 0);
+    __decorate([property()], CheckBox.prototype, "accessibleNameRef", void 0);
+    __decorate([property()], CheckBox.prototype, "accessibleName", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "disabled", void 0);
+    })], CheckBox.prototype, "disabled", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "readonly", void 0);
+    })], CheckBox.prototype, "readonly", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "displayOnly", void 0);
+    })], CheckBox.prototype, "displayOnly", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "required", void 0);
+    })], CheckBox.prototype, "required", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "indeterminate", void 0);
+    })], CheckBox.prototype, "indeterminate", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "checked", void 0);
-    __decorate([property()], CheckBox$1.prototype, "text", void 0);
-    __decorate([property()], CheckBox$1.prototype, "valueState", void 0);
-    __decorate([property()], CheckBox$1.prototype, "wrappingType", void 0);
-    __decorate([property()], CheckBox$1.prototype, "name", void 0);
+    })], CheckBox.prototype, "checked", void 0);
+    __decorate([property()], CheckBox.prototype, "text", void 0);
+    __decorate([property()], CheckBox.prototype, "valueState", void 0);
+    __decorate([property()], CheckBox.prototype, "wrappingType", void 0);
+    __decorate([property()], CheckBox.prototype, "name", void 0);
     __decorate([property({
       type: Boolean
-    })], CheckBox$1.prototype, "active", void 0);
-    CheckBox$1 = CheckBox_1 = __decorate([customElement({
+    })], CheckBox.prototype, "active", void 0);
+    CheckBox = CheckBox_1 = __decorate([customElement({
       tag: "ui5-checkbox",
       languageAware: true,
       formAssociated: true,
@@ -4162,23 +4162,29 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
       template: block0,
       styles: styleData,
       dependencies: [Label$1, Icon$1]
-    }), event("change")], CheckBox$1);
-    CheckBox$1.define();
+    }), event("change")], CheckBox);
+    CheckBox.define();
 
-    var CheckBox = WebComponentBaseClass.extend("@ui5/webcomponents.CheckBox", {
+    const WrapperClass = WebComponentBaseClass.extend("@ui5/webcomponents.CheckBox", {
       metadata: {
       "namespace": "@ui5/webcomponents",
       "tag": "ui5-checkbox",
-      "interfaces": [],
+      "interfaces": [
+        "sap.ui.core.IFormContent"
+      ],
       "properties": {
         "accessibleName": {
           "type": "string",
           "mapping": "property"
         },
-        "disabled": {
+        "enabled": {
           "type": "boolean",
-          "mapping": "property",
-          "defaultValue": false
+          "defaultValue": "true",
+          "mapping": {
+            "type": "property",
+            "to": "disabled",
+            "formatter": "_mapEnabled"
+          }
         },
         "readonly": {
           "type": "boolean",
@@ -4232,12 +4238,7 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
           "mapping": "style"
         }
       },
-      "aggregations": {
-        "default": {
-          "type": "sap.ui.core.Control",
-          "multiple": true
-        }
-      },
+      "aggregations": {},
       "associations": {
         "ariaLabelledBy": {
           "type": "sap.ui.core.Control",
@@ -4254,7 +4255,6 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
       },
       "getters": [],
       "methods": [],
-      "defaultAggregation": "default",
       "library": "@ui5/webcomponents.library",
       "designtime": "@ui5/webcomponents/designtime/CheckBox.designtime"
     },
@@ -4271,6 +4271,6 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
       }
     });
 
-    return CheckBox;
+    return WrapperClass;
 
 }));

--- a/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
+++ b/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
@@ -3204,7 +3204,7 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosy
       return (c > 3 && r && Object.defineProperty(target, key, r), r);
     });
     var Panel_1;
-    let Panel$1 = Panel_1 = class Panel extends UI5Element {
+    let Panel = Panel_1 = class Panel extends UI5Element {
       constructor() {
         super(...arguments);
         this.fixed = false;
@@ -3370,38 +3370,38 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosy
         Panel_1.i18nBundle = await getI18nBundle("@ui5/webcomponents");
       }
     };
-    __decorate([property()], Panel$1.prototype, "headerText", void 0);
+    __decorate([property()], Panel.prototype, "headerText", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "fixed", void 0);
+    })], Panel.prototype, "fixed", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "collapsed", void 0);
+    })], Panel.prototype, "collapsed", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "noAnimation", void 0);
-    __decorate([property()], Panel$1.prototype, "accessibleRole", void 0);
-    __decorate([property()], Panel$1.prototype, "headerLevel", void 0);
-    __decorate([property()], Panel$1.prototype, "accessibleName", void 0);
+    })], Panel.prototype, "noAnimation", void 0);
+    __decorate([property()], Panel.prototype, "accessibleRole", void 0);
+    __decorate([property()], Panel.prototype, "headerLevel", void 0);
+    __decorate([property()], Panel.prototype, "accessibleName", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "stickyHeader", void 0);
+    })], Panel.prototype, "stickyHeader", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "useAccessibleNameForToggleButton", void 0);
+    })], Panel.prototype, "useAccessibleNameForToggleButton", void 0);
     __decorate([property({
       type: Boolean
-    })], Panel$1.prototype, "_hasHeader", void 0);
+    })], Panel.prototype, "_hasHeader", void 0);
     __decorate([property({
       type: Boolean,
       noAttribute: true
-    })], Panel$1.prototype, "_contentExpanded", void 0);
+    })], Panel.prototype, "_contentExpanded", void 0);
     __decorate([property({
       type: Boolean,
       noAttribute: true
-    })], Panel$1.prototype, "_animationRunning", void 0);
-    __decorate([slot()], Panel$1.prototype, "header", void 0);
-    Panel$1 = Panel_1 = __decorate([customElement({
+    })], Panel.prototype, "_animationRunning", void 0);
+    __decorate([slot()], Panel.prototype, "header", void 0);
+    Panel = Panel_1 = __decorate([customElement({
       tag: "ui5-panel",
       fastNavigation: true,
       languageAware: true,
@@ -3409,10 +3409,10 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosy
       template: block0,
       styles: styleData,
       dependencies: [Button$1, Icon$1]
-    }), event("toggle")], Panel$1);
-    Panel$1.define();
+    }), event("toggle")], Panel);
+    Panel.define();
 
-    var Panel = WebComponentBaseClass.extend("@ui5/webcomponents.Panel", {
+    const WrapperClass = WebComponentBaseClass.extend("@ui5/webcomponents.Panel", {
       metadata: {
       "namespace": "@ui5/webcomponents",
       "tag": "ui5-panel-mYsCoPeSuFfIx",
@@ -3503,6 +3503,6 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosy
       }
     });
 
-    return Panel;
+    return WrapperClass;
 
 }));

--- a/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
+++ b/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
@@ -10,6 +10,7 @@ import Button from "@ui5/webcomponents/Button";
 import DatePicker from "@ui5/webcomponents/DatePicker";
 import Input from "@ui5/webcomponents/Input";
 import { AvatarSize } from "@ui5/webcomponents";
+import Token from "@ui5/webcomponents/Token";
 
 // import icons
 import "@ui5/webcomponents-icons/dist/Assets.js";
@@ -70,6 +71,17 @@ export default class Main extends Controller {
 
 	public onLiveChange(e: Event): void {
 		MessageToast.show(`🛠️ liveChange: ${e.getParameter("selectedOption").getText()}`, { at: Popup.Dock.CenterCenter });
+	}
+
+	/**
+	 * Deletes a token from the MultiInput's "token" aggregation.
+	 */
+	public deleteToken(e: Event): void {
+		const deletedTokens: Token[] = e.getParameter("tokens");
+		deletedTokens.forEach((t: Token) => {
+			const multiInput = t.getParent();
+			multiInput.removeToken(t);
+		});
 	}
 
 	// wire popover opener buttons

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -59,6 +59,16 @@
             <webc:Option text="Biometric" icon="biometric-face" />
             <webc:Option text="Security" icon="badge" />
           </webc:Select>
+          <!-- Sample for aggregation modification via event handler -->
+          <webc:MultiInput id="multi-input" tokenDelete=".deleteToken">
+            <webc:tokens>
+              <webc:Token text="Argentina" />
+              <webc:Token text="Mexico" />
+              <webc:Token text="Philippines" />
+              <webc:Token text="Sweden" />
+              <webc:Token text="USA" />
+            </webc:tokens>
+          </webc:MultiInput>
         </VBox>
       </webc:Panel>
 

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -73,7 +73,7 @@
 
           <webc:Popover id="popover1" opener="popoverOpenerButton1" headerText="Newsletter subscription" placement="Bottom">
             <c:HTMLElement tag="div" class="popover-content">
-              <webc:Label for="emailInput" required="true" showColon="true" text="Email" />
+              <webc:Label labelFor="emailInput" required="true" showColon="true" text="Email" />
               <webc:Input id="emailInput1" placeholder="Enter Email" />
               <!-- TODO: support for inline styles  =  style="min-width: 150px;" -->
               <webc:Label text="The popover is associated with the Button. Calling getOpener() returns the ID of the Button." />
@@ -87,7 +87,7 @@
 
           <webc:Popover id="popover2" opener="popoverOpenerButton2" headerText="Newsletter subscription" placement="Start">
             <c:HTMLElement tag="div" class="popover-content">
-              <webc:Label for="emailInput" required="true" showColon="true" text="Email" />
+              <webc:Label labelFor="emailInput" required="true" showColon="true" text="Email" />
               <webc:Input id="emailInput2" placeholder="Enter Email" />
               <!-- TODO: support for inline styles  =  style="min-width: 150px;" -->
               <webc:Label text="The popover is associated with the Button. Calling getOpener() returns the ID of the Button." />

--- a/showcases/ui5-tsapp-webc/webapp/view/form/FormPage.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/form/FormPage.view.xml
@@ -20,14 +20,14 @@
           <webc:Form id="testForm2" headerText="Form Title Text" layout="S1 M2 L2 XL3" labelSpan="S12 M12 L12 XL12">
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label for="nameInp" text="Name:" />
+                <webc:Label labelFor="nameInp" text="Name:" />
               </webc:labelContent>
               <webc:Input value="Red Point Stores" id="nameInp" />
             </webc:FormItem>
 
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label id="cityLbl" for="cityInp" text="ZIP Code/City:" />
+                <webc:Label id="cityLbl" labelFor="cityInp" text="ZIP Code/City:" />
               </webc:labelContent>
               <webc:Input id="cityInp" value="411" ariaLabelledBy="cityLbl" />
               <webc:Input value="Maintown" ariaLabelledBy="cityLbl" />
@@ -35,7 +35,7 @@
 
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label id="streetLbl" for="streetInp" text="Street:" />
+                <webc:Label id="streetLbl" labelFor="streetInp" text="Street:" />
               </webc:labelContent>
               <webc:Input id="streetInp" value="Main St" ariaLabelledBy="streetLbl" />
               <webc:Input id="streetNumberInp" value="1618" ariaLabelledBy="streetLbl" />
@@ -43,7 +43,7 @@
 
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label id="countryLbl" for="countrySel" text="Country:" />
+                <webc:Label id="countryLbl" labelFor="countrySel" text="Country:" />
               </webc:labelContent>
               <webc:Select id="countrySel" ariaLabelledBy="countryLbl">
                 <webc:Option text="Australia" />
@@ -54,14 +54,14 @@
 
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label for="wsInp" text="WebSite:" />
+                <webc:Label labelFor="wsInp" text="WebSite:" />
               </webc:labelContent>
               <webc:Input value="sap.com" id="wsInp" />
             </webc:FormItem>
 
             <webc:FormItem>
               <webc:labelContent>
-                <webc:Label for="delInp" text="Delivery address:" />
+                <webc:Label labelFor="delInp" text="Delivery address:" />
               </webc:labelContent>
               <webc:Input value="Newtown" id="delInp" />
             </webc:FormItem>


### PR DESCRIPTION
#### TODO:
* [x] Import of LabelEnablement mixin for the webc that implement `sap.ui.core.Label`
* [x] Introduce Mapping for
  * [x] enabled/diabled
  * [x] textDirection/dir

#### Next Steps:
* Test how custom data (or a variation) could be used to handle native properties (see below, _Open special properties/events_)
* Investigate how to implement `sap.ui.core.ISemanticFormContent` for the Multi Input?
  * Is this even needed?
  * What does the semantic form content do in UI5 anyway?

#### Questions:
* ~~Should the `for` property of `@ui5/webcomponents/Label` be renamed to `labelFor` like in the original retrofits?~~
  * **Answer**: No we will not align with the deprecated retrofit components. The custom elements metadata will be leading.
* ~~Is `InputElementsFormSupport` still needed for the latest WebC versions?~~
  * ~~Seems to be replaced by an actual interface...~~
  * **Answer**: No it is not needed anymore. The current web components implementation uses a newer internal interface approach, refer to [OpenUI5Enablement.ts](https://github.com/SAP/ui5-webcomponents/blob/f3fd7c0139ca4672138917b26d5b0a6ec902f761/packages/base/src/features/OpenUI5Enablement.ts)
