### PR TITLE
fix(ui5-tooling-modules): apply sap/ui/core/EnabledPropagator mixin

### DIFF
--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -163,7 +163,14 @@ module.exports = function ({ log, resolveModule, getPackageJson, framework, opti
 	};
 
 	// list of external dependencies that are needed for the Web Components transformation
-	const externalDeps = ["sap/ui/core/webc/WebComponent", "sap/ui/core/webc/WebComponentRenderer", "sap/ui/base/DataType", "sap/base/strings/hyphenate", "sap/ui/core/LabelEnablement"];
+	const externalDeps = [
+		"sap/ui/core/webc/WebComponent",
+		"sap/ui/core/webc/WebComponentRenderer",
+		"sap/ui/base/DataType",
+		"sap/base/strings/hyphenate",
+		"sap/ui/core/LabelEnablement",
+		"sap/ui/core/EnabledPropagator",
+	];
 
 	return {
 		name: "webcomponents",
@@ -306,6 +313,7 @@ module.exports = function ({ log, resolveModule, getPackageJson, framework, opti
 				const metadata = JSON.stringify(metadataObject, undefined, 2);
 				const webcClass = moduleInfo.attributes.absModulePath.replace(/\\/g, "/"); // is the absolute path of the original Web Component class
 				const needsLabelEnablement = clazz._ui5NeedsLabelEnablement;
+				const needsEnabledPropagator = clazz._ui5NeedsEnabledPropagator;
 
 				// Determine the superclass UI5 module name and import it
 				let webcBaseClass = "sap/ui/core/webc/WebComponent";
@@ -323,6 +331,7 @@ module.exports = function ({ log, resolveModule, getPackageJson, framework, opti
 					webcClass,
 					webcBaseClass,
 					needsLabelEnablement,
+					needsEnabledPropagator,
 				});
 				return code;
 			}

--- a/packages/ui5-tooling-modules/lib/templates/WrapperControl.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/WrapperControl.hbs
@@ -4,6 +4,9 @@ import WebComponentBaseClass from "{{webcBaseClass}}";
 {{#if needsLabelEnablement}}
 import LabelEnablement from "sap/ui/core/LabelEnablement";
 {{/if}}
+{{#if needsEnabledPropagator}}
+import EnabledPropagator from "sap/ui/core/EnabledPropagator";
+{{/if}}
 
 const WrapperClass = WebComponentBaseClass.extend("{{ui5Class}}", {
   metadata: {{{metadata}}},
@@ -22,6 +25,9 @@ const WrapperClass = WebComponentBaseClass.extend("{{ui5Class}}", {
 
 {{#if needsLabelEnablement}}
 LabelEnablement.enrich(WrapperClass.prototype);
+{{/if}}
+{{#if needsEnabledPropagator}}
+EnabledPropagator.call(WrapperClass.prototype);
 {{/if}}
 
 export default WrapperClass;

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -236,7 +236,7 @@ class RegistryEntry {
 	 * @param {object} ui5metadata the UI5 metadata object
 	 * @returns {boolean} whether the property needs a special mapping
 	 */
-	#checkForSpecialMapping(propDef, ui5metadata) {
+	#checkForSpecialMapping(classDef, propDef, ui5metadata) {
 		if (propDef.name === "accessibleNameRef") {
 			ui5metadata.associations["ariaLabelledBy"] = {
 				type: "sap.ui.core.Control",
@@ -250,6 +250,8 @@ class RegistryEntry {
 			return true;
 		} else if (propDef.name === "disabled") {
 			// "disabled" maps to "enabled" in UI5
+			// we also need the UI5 EnabledPropagator
+			classDef._ui5NeedsEnabledPropagator = true;
 			ui5metadata.properties["enabled"] = {
 				type: "boolean",
 				defaultValue: "true",
@@ -289,7 +291,7 @@ class RegistryEntry {
 			}
 
 			// Some properties might need a special UI5 mapping, e.g. "accesibleNameRef"
-			const hasSpecialMapping = this.#checkForSpecialMapping(propDef, ui5metadata);
+			const hasSpecialMapping = this.#checkForSpecialMapping(classDef, propDef, ui5metadata);
 			if (hasSpecialMapping) {
 				return;
 			}

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
@@ -1,4 +1,4 @@
-sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/ui/base/DataType', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents-base'], (function (_ui5_webcomponents, WebComponentBaseClass, DataType, _ui5_webcomponentsBase) { 'use strict';
+sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/EnabledPropagator', 'sap/ui/base/DataType', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents-base'], (function (_ui5_webcomponents, WebComponentBaseClass, EnabledPropagator, DataType, _ui5_webcomponentsBase) { 'use strict';
 
     const isSSR$3 = typeof document === "undefined";
     const internals$1 = {
@@ -4525,6 +4525,8 @@ sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/co
         return WebComponentBaseClass.prototype.setProperty.apply(this, [sPropName, v, bSupressInvalidate]);
       }
     });
+
+    EnabledPropagator.call(WrapperClass.prototype);
 
     return WrapperClass;
 

--- a/packages/ui5-tooling-modules/test/util.test.js
+++ b/packages/ui5-tooling-modules/test/util.test.js
@@ -675,6 +675,7 @@ test.serial("Verify generation of @ui5/webcomponents/dist/Panel Wrapper UI5 Cont
 						return { name, def };
 					},
 				},
+				"sap/ui/core/EnabledPropagator": function () {},
 			},
 		},
 		{
@@ -740,6 +741,7 @@ test.serial("Verify generation of @ui5/webcomponents/dist/CheckBox Wrapper UI5 C
 						return { name, def };
 					},
 				},
+				"sap/ui/core/EnabledPropagator": function () {},
 			},
 		},
 		{

--- a/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
+++ b/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import Controller from "sap/ui/core/mvc/Controller";
 import MessageToast from "sap/m/MessageToast";
+import OverflowToolbar from "sap/m/OverflowToolbar";
 import Control from "sap/ui/core/Control";
 import VBox from "sap/m/VBox";
 import Popup from "sap/ui/core/Popup";
@@ -92,5 +93,14 @@ export default class Main extends Controller {
 	public onPopoverOpener2Click(e: Event): void {
 		const poppy2 = this.byId("popover2");
 		poppy2?.setOpen(!poppy2?.getOpen());
+	}
+
+	/**
+	 * Toggles the 'enabled' state of the OverflowToolbar to test the
+	 * propagation of the 'enabled' state to child controls.
+	 */
+	public toggleOverflowToolbarEnabled(e: Event): void {
+		const ovt: OverflowToolbar = this.byId("overflowToolbar") as OverflowToolbar;
+		ovt.setEnabled(!ovt.getEnabled());
 	}
 }

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -43,6 +43,14 @@
             <webc:Avatar icon="ai" colorScheme="Accent7" />
           </webc:AvatarGroup>
           <webc:CheckBox text="Hello World 123" />
+
+          <!-- Enabled propagation test -->
+          <webc:Label text="'enabled' poperty of Buttons is propagated from OverflowToolbar:" />
+          <webc:Button click=".toggleOverflowToolbarEnabled" text="toggle enabled state" />
+          <OverflowToolbar id="overflowToolbar" enabled="false">
+            <Button text="enabled='false'" press="onBoo" class="buttonSpacing" enabled="false" />
+            <webc:Button text="enabled='true'" class="buttonSpacing" enabled="true" />
+          </OverflowToolbar>
         </VBox>
       </webc:Panel>
 


### PR DESCRIPTION
When the `enabled` (resp. `disabled`) property exists, we need to also apply the `sap/ui/core/EnabledPropagator` mixin to the control wrapper.
This way the `enabled` state is propagated along the control tree.