### PR TITLE
feat(ui5-middleware-serverframework): custom path to save libs

### DIFF
--- a/packages/ui5-middleware-serveframework/README.md
+++ b/packages/ui5-middleware-serveframework/README.md
@@ -26,6 +26,10 @@ npm install ui5-middleware-serveframework --save-dev
   Path to file with environment variables
 - `strictSSL`: `boolean`
   Ignore strict SSL checks. Default value `true`.
+- `saveLibsLocal`: `boolean`, default: `false`
+  When enabled, libraries are saved in the project directory (.ui5-middleware-serveframework) instead of the user home directory. While this isolates the libraries per project, it requires additional disk space and compilation time compared to sharing compiled libraries across projects.
+- `cachePath`: `string`
+  Custom path to store cached framework files. By default, files are stored in the user home directory (~/.ui5/ui5-middleware-serveframework) or project directory depending on saveLibsLocal setting.
 
 ## Usage
 


### PR DESCRIPTION
In some environments (e.g. Citrix 😖), the specified path is deleted daily and requires a new compilation every day.
To prevent this, new configuration options are added to store the libraries either in the project or in a separate custom path.