### PR TITLE
feat: add custom /my-jwt route for debugging auth(n,z)

### DIFF
--- a/packages/dev-approuter/README.md
+++ b/packages/dev-approuter/README.md
@@ -55,6 +55,9 @@ The `dev-approuter` is a wrapper for the SAP Application Router, meaning your cu
         ...
     }
     ```
+  ...or by passing a port as environment variable: `PORT=5001 npm run dev`
+  
+4. Upon start, the `dev-approuter` exposes a custom endpoint `http://localhost:$port/my-jwt`. It echos the current JWT of the current (authenticated and authorized) user (or `none`) - this helps debugging auth(n,z) issues at dev time. 
 
 ## Adding and serving apps
 

--- a/packages/dev-approuter/lib/devApprouter.js
+++ b/packages/dev-approuter/lib/devApprouter.js
@@ -159,7 +159,14 @@ class DevApprouter {
 
 		// create and start the SAP Approuter
 		// https://help.sap.com/docs/btp/sap-business-technology-platform/extension-api-of-application-router
-		approuter().start({
+		const _approuter = approuter();
+		// helper: if used in a hybrid setup w/ xsuaa,
+		// this endpoint helps to debug auth(n,z) issues
+		// DANGER, WILL SMITH: you must not use this in production envs!
+		_approuter.beforeRequestHandler.use("/my-jwt", (req, res) => {
+			res.end(req.session.user.token.accessToken)
+		})
+		_approuter.start({
 			port: arPort,
 			xsappConfig: applyDependencyConfig(config),
 			extensions: [

--- a/packages/dev-approuter/lib/devApprouter.js
+++ b/packages/dev-approuter/lib/devApprouter.js
@@ -164,7 +164,7 @@ class DevApprouter {
 		// this endpoint helps to debug auth(n,z) issues
 		// DANGER, WILL SMITH: you must not use this in production envs!
 		_approuter.beforeRequestHandler.use("/my-jwt", (req, res) => {
-			res.end(req.session.user.token.accessToken)
+			res.end(req.session?.user?.token?.accessToken || "none")
 		})
 		_approuter.start({
 			port: arPort,


### PR DESCRIPTION
subject pretty much says it all: when the `dev-approuter` is used in hybrid scenarios (👋  CAP), 
then the `/my-jwt` route logs the current JWT/access token 
&rarr; helps in debugging auth(n,z) issues at dev time

docs are also in.