### PR TITLE
fix(ui5-tooling-modules): monkey patch mapValueState for older versions of UI5

### DIFF
--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -82,6 +82,7 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 			skipTransform: false,
 			watch: true,
 			watchDebounce: 100,
+			entryPoints: [],
 		},
 		options.configuration,
 	);
@@ -178,6 +179,11 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 	// logic which bundles and watches the modules coming from the
 	// node_modules or dependencies via NPM package names
 	const requestedModules = new Set();
+	// inject the entrypoints from the configuration
+	config.entryPoints?.forEach((entry) => {
+		requestedModules.add(entry);
+	});
+	// start bundling
 	let whenBundled, scanTime, bundleTime;
 	const bundleAndWatch = async ({ moduleName, force }) => {
 		if (moduleName && !requestedModules.has(moduleName)) {

--- a/packages/ui5-tooling-modules/lib/templates/monkey_patches/MapValueState.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/monkey_patches/MapValueState.hbs
@@ -1,0 +1,6 @@
+// Fixed with https://github.com/SAP/openui5/commit/111c4bcd1660f90714ed567fa8cb57fbc448591f in UI5 1.133.0
+
+WebComponent.prototype._mapValueState ??= function(sValueState) {
+	console.warn("ValueState mapping is not implemented for Web Components yet. Please use UI5 version 1.133.0 or higher.");
+	return sValueState;
+};

--- a/packages/ui5-tooling-modules/lib/templates/monkey_patches/RegisterAllEvents.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/monkey_patches/RegisterAllEvents.hbs
@@ -1,6 +1,4 @@
-// Will be fixed with TBD in UI5 1.130
-import hyphenate from "sap/base/strings/hyphenate";
-import WebComponent from "sap/ui/core/webc/WebComponent";
+// Fixed with https://github.com/SAP/openui5/commit/a4b5fe00b49e0e26e5fd845607a2b95db870d55a in UI5 1.133.0
 
 WebComponent.prototype.__attachCustomEventsListeners = function() {
 	// ##### MODIFICATION START #####

--- a/packages/ui5-tooling-modules/lib/templates/monkey_patches/RenderAttributeProperties.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/monkey_patches/RenderAttributeProperties.hbs
@@ -1,8 +1,5 @@
 // Fixed with https://github.com/SAP/openui5/commit/7a4615e3fe55221ae9de9d876d3eed209f71a5b1 in UI5 1.128.0
 
-import hyphenate from "sap/base/strings/hyphenate";
-import WebComponentRenderer from "sap/ui/core/webc/WebComponentRenderer";
-
 WebComponentRenderer.renderAttributeProperties = function (oRm, oWebComponent) {
 	var oAttrProperties = oWebComponent.getMetadata().getPropertiesByMapping("property");
 	// ##### MODIFICATION START #####

--- a/packages/ui5-tooling-modules/lib/templates/monkey_patches/_Preamble.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/monkey_patches/_Preamble.hbs
@@ -1,0 +1,5 @@
+// this file contains all imports which are shared between the Monkey Patch files
+
+import hyphenate from "sap/base/strings/hyphenate";
+import WebComponent from "sap/ui/core/webc/WebComponent";
+import WebComponentRenderer from "sap/ui/core/webc/WebComponentRenderer";

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents-base.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents-base.js
@@ -1,6 +1,9 @@
-sap.ui.define(['sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/base/DataType'], (function (hyphenate, WebComponent, DataType) { 'use strict';
+sap.ui.define(['sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/webc/WebComponentRenderer', 'sap/ui/base/DataType'], (function (hyphenate, WebComponent, WebComponentRenderer, DataType) { 'use strict';
 
-	// Will be fixed with TBD in UI5 1.130
+	// this file contains all imports which are shared between the Monkey Patch files
+
+
+	// Fixed with https://github.com/SAP/openui5/commit/a4b5fe00b49e0e26e5fd845607a2b95db870d55a in UI5 1.133.0
 
 	WebComponent.prototype.__attachCustomEventsListeners = function() {
 		// ##### MODIFICATION START #####
@@ -27,6 +30,13 @@ sap.ui.define(['sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 's
 				oDomRef.removeEventListener(sCustomEventName, this.__handleCustomEventBound);
 			}
 		}
+	};
+
+	// Fixed with https://github.com/SAP/openui5/commit/111c4bcd1660f90714ed567fa8cb57fbc448591f in UI5 1.133.0
+
+	WebComponent.prototype._mapValueState ??= function(sValueState) {
+		console.warn("ValueState mapping is not implemented for Web Components yet. Please use UI5 version 1.133.0 or higher.");
+		return sValueState;
 	};
 
 	const pkg = {

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents.js
@@ -1,4 +1,4 @@
-sap.ui.define(['./webcomponents-base', 'sap/ui/base/DataType', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent'], (function (_ui5_webcomponentsBase, DataType, hyphenate, WebComponent) { 'use strict';
+sap.ui.define(['./webcomponents-base', 'sap/ui/base/DataType', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/webc/WebComponentRenderer'], (function (_ui5_webcomponentsBase, DataType, hyphenate, WebComponent, WebComponentRenderer) { 'use strict';
 
 	const pkg = {
 		"_ui5metadata": {

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
@@ -1,4 +1,4 @@
-sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/EnabledPropagator', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents-base', 'sap/base/strings/hyphenate', 'sap/ui/base/DataType'], (function (_ui5_webcomponents, WebComponent, EnabledPropagator, _ui5_webcomponentsBase, hyphenate, DataType) { 'use strict';
+sap.ui.define(['ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/EnabledPropagator', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents-base', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponentRenderer', 'sap/ui/base/DataType'], (function (_ui5_webcomponents, WebComponent, EnabledPropagator, _ui5_webcomponentsBase, hyphenate, WebComponentRenderer, DataType) { 'use strict';
 
     var class2type = {};
     var hasOwn = class2type.hasOwnProperty;

--- a/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents.js
+++ b/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents.js
@@ -1,4 +1,4 @@
-sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'sap/ui/base/DataType', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent'], (function (_ui5_webcomponentsBase, DataType, hyphenate, WebComponent) { 'use strict';
+sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'sap/ui/base/DataType', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/webc/WebComponentRenderer'], (function (_ui5_webcomponentsBase, DataType, hyphenate, WebComponent, WebComponentRenderer) { 'use strict';
 
 	const pkg = {
 		"_ui5metadata": {

--- a/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
+++ b/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
@@ -1,4 +1,4 @@
-sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/base/strings/hyphenate', 'sap/ui/base/DataType'], (function (_ui5_webcomponentsBase, _ui5_webcomponents, WebComponent, hyphenate, DataType) { 'use strict';
+sap.ui.define(['ui5/ecosystem/demo/app/resources/webcomponents-base', 'ui5/ecosystem/demo/app/resources/@ui5/webcomponents', 'sap/ui/core/webc/WebComponent', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponentRenderer', 'sap/ui/base/DataType'], (function (_ui5_webcomponentsBase, _ui5_webcomponents, WebComponent, hyphenate, WebComponentRenderer, DataType) { 'use strict';
 
     const tasks = new WeakMap();
     class AnimationQueue {

--- a/packages/ui5-tooling-modules/test/__snap__/d726ec84/webcomponents-base.js
+++ b/packages/ui5-tooling-modules/test/__snap__/d726ec84/webcomponents-base.js
@@ -1,4 +1,4 @@
-sap.ui.define(['exports', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/base/DataType'], (function (exports, hyphenate, WebComponent, DataType) { 'use strict';
+sap.ui.define(['exports', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebComponent', 'sap/ui/core/webc/WebComponentRenderer', 'sap/ui/base/DataType'], (function (exports, hyphenate, WebComponent, WebComponentRenderer, DataType) { 'use strict';
 
     var class2type = {};
     var hasOwn = class2type.hasOwnProperty;
@@ -1807,7 +1807,10 @@ sap.ui.define(['exports', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebCom
     }
     registerFeature("OpenUI5Support", OpenUI5Support);
 
-    // Will be fixed with TBD in UI5 1.130
+    // this file contains all imports which are shared between the Monkey Patch files
+
+
+    // Fixed with https://github.com/SAP/openui5/commit/a4b5fe00b49e0e26e5fd845607a2b95db870d55a in UI5 1.133.0
 
     WebComponent.prototype.__attachCustomEventsListeners = function() {
     	// ##### MODIFICATION START #####
@@ -1834,6 +1837,13 @@ sap.ui.define(['exports', 'sap/base/strings/hyphenate', 'sap/ui/core/webc/WebCom
     			oDomRef.removeEventListener(sCustomEventName, this.__handleCustomEventBound);
     		}
     	}
+    };
+
+    // Fixed with https://github.com/SAP/openui5/commit/111c4bcd1660f90714ed567fa8cb57fbc448591f in UI5 1.133.0
+
+    WebComponent.prototype._mapValueState ??= function(sValueState) {
+    	console.warn("ValueState mapping is not implemented for Web Components yet. Please use UI5 version 1.133.0 or higher.");
+    	return sValueState;
     };
     setCustomElementsScopingSuffix("mYsCoPeSuFfIx");
 


### PR DESCRIPTION
The `_mapValueState` function has been introduced with OpenUI5 `1.133.0-SNAPSHOT` and for older versions of UI5 we need to monkey patch it. This change introduces the monkey patch for the older versions. Otherwise this causes runtime issues when the value state is used for older versions.