### PR TITLE
fix(ui5-tooling-modules): ensure full rebuild after change of modules

### DIFF
--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -10,9 +10,9 @@ const camelize = (str) => {
 // corresponds to the "sap.ui.core.webc.WebComponent" class at runtime.
 const UI5_ELEMENT_CLASS_NAME = "UI5Element";
 
-const _registry = {};
+let _registry = {};
 
-const _classAliases = {};
+let _classAliases = {};
 
 // TODO: Make "classes" into... a class :)
 //       Get's rid of passing the "classDef" and the "ui5metadata" around.
@@ -642,6 +642,11 @@ const WebComponentRegistry = {
 		if (!_classAliases[alias]) {
 			_classAliases[alias] = obj;
 		}
+	},
+
+	clear() {
+		_registry = {};
+		_classAliases = {};
 	},
 };
 


### PR DESCRIPTION
The mechanism in the rollup plugin to generate the package wrappers relies on the lookup of the WebComponentsRegistry. When the packages and classes are known to the registry the packages will not be emitted anymore. In any case we nevertheless need to rebuild the web components metadata in case of changes to them. So the clear function now triggers a complete reload.