### PR TITLE
feat(cds-plugin-ui5): add lazy module loading (#WIP)

### DIFF
--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -28,7 +28,7 @@ const fs = require("fs");
  * root directory to the given router.
  * @param {import("express").Router} router Express Router instance
  * @param {applyUI5MiddlewareOptions} options configuration options
- * @returns {UI5AppInfo} UI5 application information object
+ * @returns {Promise<UI5AppInfo>} UI5 application information object
  */
 module.exports = async function applyUI5Middleware(router, options) {
 	const { graphFromPackageDependencies } = await import("@ui5/project/graph");
@@ -117,6 +117,9 @@ module.exports = async function applyUI5Middleware(router, options) {
 		},
 	});
 	await middlewareManager.applyMiddleware(router);
+
+	// REVISIT: everything that follows has no effect if lazy loading is active.
+	//          just live with it???
 
 	// for Fiori elements based applications we need to invalidate the view cache
 	const isFioriElementsBased = rootProject.getFrameworkDependencies().find((lib) => lib.name.startsWith("sap.fe"));

--- a/showcases/cds-bookshop/package.json
+++ b/showcases/cds-bookshop/package.json
@@ -35,6 +35,7 @@
     "build": "cds build",
     "lint": "eslint .",
     "watch": "cds watch",
+    "watch:lazy": "CDS_PLUGIN_UI5_LAZY_LOADING=true cds w",
     "start": "cds-serve",
     "start:dist": "CDS_PLUGIN_UI5_MODULES=\"{ \"ui5-bookshop\": { \"configFile\": \"ui5-dist.yaml\" } }\" cds-serve"
   },


### PR DESCRIPTION
Hi @petermuessig,

hopefully you didn't have time yet to build a solution for #1028 😅. I was playing around with the lazy middleware loading approach, that you described as possible solution.
It is not finished yet, I just wanted to get your opinion if this goes in the direction you imagined. Generally the lazy loading works. The routers are mounted for the module paths at startup - which I guess we can't get rid off?? -  but the middlewares are only loaded once the first HTTP call goes to a certain module path.

Possible fix for #1028.