### PR TITLE
fix(ui5-tooling-modules): add @implements tag to wrapper JSDoc

### DIFF
--- a/packages/ui5-tooling-modules/lib/templates/jsdoc/ClassHeader.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/jsdoc/ClassHeader.hbs
@@ -1,9 +1,7 @@
 /**
  * @class
- * {{{description}}}
-{{#if interfacesSlashed}}
- * @implements {{{interfacesSlashed}}}
-{{/if}}
+ * {{{description}}}{{#if interfacesSlashed}}
+ * @implements {{{interfacesSlashed}}}{{/if}}
  * {{{implementsTag}}}
  * @extends {{{extendsTag}}}
  * @constructor

--- a/packages/ui5-tooling-modules/lib/templates/jsdoc/ClassHeader.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/jsdoc/ClassHeader.hbs
@@ -1,6 +1,10 @@
 /**
  * @class
  * {{{description}}}
+{{#if interfacesSlashed}}
+ * @implements {{{interfacesSlashed}}}
+{{/if}}
+ * {{{implementsTag}}}
  * @extends {{{extendsTag}}}
  * @constructor
  * @public

--- a/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
+++ b/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
@@ -90,6 +90,9 @@ function _serializeClassHeader(classDef) {
 	//       and not by their class names.
 	const description = classDef.description;
 
+	// @implements
+	const interfacesSlashed = classDef._ui5QualifiedInterfaceNamesSlashes ? classDef._ui5QualifiedInterfaceNamesSlashes.join(", ") : "";
+
 	// @extends
 	const extendsTag = superclassName ? superclassName : "";
 
@@ -99,6 +102,7 @@ function _serializeClassHeader(classDef) {
 	// and finally we template the class header preamble
 	classDef._jsDoc.classHeader = Templates.classHeader({
 		description,
+		interfacesSlashed,
 		extendsTag,
 		aliasSlashed: classDef._ui5QualifiedNameSlashes,
 	});

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -584,10 +584,15 @@ class RegistryEntry {
 	}
 
 	#processUI5Interfaces(classDef, ui5metadata) {
+		let jsdocInterfaces;
 		if (Array.isArray(classDef._ui5implements)) {
+			jsdocInterfaces ??= [];
 			classDef._ui5implements.forEach((interfaceDef) => {
 				if (this.interfaces[interfaceDef.name]) {
 					ui5metadata.interfaces.push(this.prefixns(interfaceDef.name));
+					jsdocInterfaces.push(`module:${this.namespace}.${interfaceDef.name}`);
+				} else {
+					jsdocInterfaces.push(this.prefixns(interfaceDef.name));
 				}
 			});
 		}
@@ -595,7 +600,10 @@ class RegistryEntry {
 		// classes with properties marked as "_ui5formProperty" need to implement IFormContent
 		if (classDef._ui5implementsFormContent) {
 			ui5metadata.interfaces.push("sap.ui.core.IFormContent");
+			jsdocInterfaces ??= [];
+			jsdocInterfaces.push("sap.ui.core.IFormContent");
 		}
+		classDef._ui5QualifiedInterfaceNamesSlashes = jsdocInterfaces;
 	}
 
 	/**


### PR DESCRIPTION
The @implements tag in the class header documentation for a wrapper class should list the JSDoc names of the implemented interfaces. In contrast, runtime metadata contains the runtime metadata names of the interfaces.