### PR TITLE
feat(ui5-middleware-serveframework): respect defined libraries in local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ ui5-workspace.yaml
 
 # local markdown files
 TODO.md
+
+# UI5 preload resources
+.ui5-middleware-serveframework

--- a/packages/ui5-middleware-serveframework/README.md
+++ b/packages/ui5-middleware-serveframework/README.md
@@ -28,8 +28,6 @@ npm install ui5-middleware-serveframework --save-dev
   Ignore strict SSL checks. Default value `true`.
 - `saveLibsLocal`: `boolean`, default: `false`
   When enabled, libraries are saved in the project directory (.ui5-middleware-serveframework) instead of the user home directory. While this isolates the libraries per project, it requires additional disk space and compilation time compared to sharing compiled libraries across projects.
-- `configPath`: `string`, default: `ui5.yaml`
-  Can only be used together with `saveLibsLocal` being set to `true` in order specify which libraries should be set up. Instead saving all libraries to the project directly, it will check for the libraries defined in the specified config. This can save time in the install step.
 - `cachePath`: `string`
   Custom path to store cached framework files. By default, files are stored in the user home directory (~/.ui5/ui5-middleware-serveframework) or project directory depending on saveLibsLocal setting.
 

--- a/packages/ui5-middleware-serveframework/README.md
+++ b/packages/ui5-middleware-serveframework/README.md
@@ -28,6 +28,8 @@ npm install ui5-middleware-serveframework --save-dev
   Ignore strict SSL checks. Default value `true`.
 - `saveLibsLocal`: `boolean`, default: `false`
   When enabled, libraries are saved in the project directory (.ui5-middleware-serveframework) instead of the user home directory. While this isolates the libraries per project, it requires additional disk space and compilation time compared to sharing compiled libraries across projects.
+- `configPath`: `string`, default: `ui5.yaml`
+  Can only be used together with `saveLibsLocal` being set to `true` in order specify which libraries should be set up. Instead saving all libraries to the project directly, it will check for the libraries defined in the specified config. This can save time in the install step.
 - `cachePath`: `string`
   Custom path to store cached framework files. By default, files are stored in the user home directory (~/.ui5/ui5-middleware-serveframework) or project directory depending on saveLibsLocal setting.
 

--- a/packages/ui5-middleware-serveframework/lib/index.js
+++ b/packages/ui5-middleware-serveframework/lib/index.js
@@ -9,6 +9,23 @@ const fresh = require("fresh");
 const { Agent: HttpsAgent } = require("https");
 
 /**
+ * Loads the yaml file from the given path and returns the libraries defined in the framework section.
+ *
+ * @param {string} pathToUI5Config Absolute path to the ui5-x.yaml file
+ * @returns {Array<{ name: string }>} Array of libraries defined in the framework section
+ */
+async function getLibrariesDefinedInYaml(pathToUI5Config) {
+	if (!existsSync(pathToUI5Config)) {
+		return [];
+	}
+
+	const file = await readFile(pathToUI5Config, { encoding: "utf-8" });
+	const ui5Config = yaml.load(file);
+
+	return ui5Config?.framework?.libraries || [];
+}
+
+/**
  * Serves the built variant of the current framework
  *
  * @param {object} parameters Parameters
@@ -17,6 +34,7 @@ const { Agent: HttpsAgent } = require("https");
  * @param {object} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @param {boolean} [parameters.options.configuration.saveLibsLocal] Whether to save libraries in the project directory instead of user home
  * @param {string} [parameters.options.configuration.cachePath] Custom path to store cached framework files
+ * @param {string} [parameters.options.configuration.configPath] Custom path to a local ui5.yaml file that shall be used to identify the framework libraries if saveLibsLocal is set to true
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
  * @returns {Function} Middleware function to use
@@ -28,6 +46,7 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 		strictSSL: true,
 		saveLibsLocal: false, // New parameter to save libraries locally
 		cachePath: undefined,
+		config: "ui5.yaml", // New parameter to specify the local UI5 config file, only works in combination with saveLibsLocal true
 	};
 	// config-time options from ui5.yaml for cfdestination take precedence
 	if (options.configuration) {
@@ -117,7 +136,40 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 		const existsFramework = [frameworkPkgJson, frameworkUI5Yaml, frameworkManifest, frameworkDestDir, frameworkReadyMarker].reduce((prev, cur) => {
 			return prev && existsSync(cur);
 		}, true);
-		if (!existsFramework) {
+
+		// check if the framework was build with the setting saveLibsLocal and if the depdencies changed which would require a rebuild
+		let localLibsRequiredRebuild = false;
+		const pathTolocalUI5Config = path.join(process.cwd(), effectiveOptions.configPath);
+
+		const shouldUseLocalUI5Config = effectiveOptions.saveLibsLocal && effectiveOptions.configPath;
+
+		if (shouldUseLocalUI5Config && effectiveOptions.debug) {
+			log.info(`[DEBUG] Checking ${pathTolocalUI5Config} for local UI5 config ...`);
+		}
+
+		const localUI5ConfigExists = shouldUseLocalUI5Config && existsSync(pathTolocalUI5Config);
+
+		if (shouldUseLocalUI5Config && effectiveOptions.debug) {
+			log.info(`[DEBUG] ${localUI5ConfigExists ? "Found" : "Did not find"} UI5 config at ${pathTolocalUI5Config}`);
+		}
+
+		if (localUI5ConfigExists) {
+			const localUI5Depdendencies = await getLibrariesDefinedInYaml(pathTolocalUI5Config);
+			const frameworkUI5Dependencies = await getLibrariesDefinedInYaml(frameworkUI5Yaml);
+
+			// if the two yaml files do not have the same dependencies listed, a rebuild is required
+			localLibsRequiredRebuild = localUI5Depdendencies.map((lib) => lib.name).join(",") !== frameworkUI5Dependencies.map((lib) => lib.name).join(",");
+		}
+
+		if (shouldUseLocalUI5Config && !existsSync(pathTolocalUI5Config)) {
+			log.warn(`\n\n\n[WARN] The local UI5 config file ${pathTolocalUI5Config} does not exist! The framework will be build with all UI5 libraries! \n\n`);
+		}
+
+		if (localLibsRequiredRebuild && effectiveOptions.debug) {
+			log.info(`[DEBUG] UI5 libraries of ${pathTolocalUI5Config} and ${frameworkUI5Yaml} do not match! Rebuilding framework libraries ...`);
+		}
+
+		if (!existsFramework || localLibsRequiredRebuild) {
 			existsSync(frameworkWebappDir) && (await rm(frameworkWebappDir, { recursive: true }));
 			existsSync(frameworkDestDir) && (await rm(frameworkDestDir, { recursive: true }));
 			await mkdir(frameworkWebappDir, { recursive: true });
@@ -138,6 +190,31 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 				},
 			);
 
+			let libraries = [];
+
+			if (localUI5ConfigExists) {
+				libraries = (await getLibrariesDefinedInYaml(pathTolocalUI5Config)).map((library) => {
+					return { name: library.name };
+				});
+			} else {
+				libraries = versionInfo.libraries
+					.filter((library) => {
+						const npmPackageName = library.npmPackageName;
+						if (npmPackageName) {
+							if (frameworkScope === "@openui5") {
+								return npmPackageName.startsWith("@openui5/");
+							} else {
+								return true;
+							}
+						} else {
+							return false;
+						}
+					})
+					.map((library) => {
+						return { name: library.name };
+					});
+			}
+
 			// create ui5.yaml to list all libraries
 			let ui5YamlContent = yaml.dump({
 				specVersion: "3.0",
@@ -148,22 +225,7 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 				framework: {
 					name: frameworkName,
 					version: frameworkVersion,
-					libraries: versionInfo.libraries
-						.filter((library) => {
-							const npmPackageName = library.npmPackageName;
-							if (npmPackageName) {
-								if (frameworkScope === "@openui5") {
-									return npmPackageName.startsWith("@openui5/");
-								} else {
-									return true;
-								}
-							} else {
-								return false;
-							}
-						})
-						.map((library) => {
-							return { name: library.name };
-						}),
+					libraries: libraries,
 				},
 			});
 

--- a/packages/ui5-middleware-serveframework/lib/index.js
+++ b/packages/ui5-middleware-serveframework/lib/index.js
@@ -17,12 +17,12 @@ const { Agent: HttpsAgent } = require("https");
  * @returns {Array<{ name: string }>} Array of libraries defined in the framework section
  */
 async function getLibrariesDefinedInResources(resources) {
-	const projetcReader = resources.rootProject._readers.find((reader) => {
+	const projectReader = resources.rootProject._readers.find((reader) => {
 		return !!reader._reader?._project?._config?.framework?.libraries;
 	});
 
-	if (projetcReader) {
-		return projetcReader._reader._project._config.framework.libraries;
+	if (projectReader) {
+		return projectReader._reader._project._config.framework.libraries;
 	}
 
 	return [];

--- a/packages/ui5-middleware-serveframework/lib/index.js
+++ b/packages/ui5-middleware-serveframework/lib/index.js
@@ -9,6 +9,26 @@ const fresh = require("fresh");
 const { Agent: HttpsAgent } = require("https");
 
 /**
+ * Loads the yaml file framework libraries configuration
+ *
+ * @param {object} resources Resource collections
+ * @param {module:@ui5/fs.AbstractReader} resources.rootProject Reader or Collection to read resources of
+ *                                        the project the server is started in
+ * @returns {Array<{ name: string }>} Array of libraries defined in the framework section
+ */
+async function getLibrariesDefinedInResources(resources) {
+	const projetcReader = resources.rootProject._readers.find((reader) => {
+		return !!reader._reader?._project?._config?.framework?.libraries;
+	});
+
+	if (projetcReader) {
+		return projetcReader._reader._project._config.framework.libraries;
+	}
+
+	return [];
+}
+
+/**
  * Loads the yaml file from the given path and returns the libraries defined in the framework section.
  *
  * @param {string} pathToUI5Config Absolute path to the ui5-x.yaml file
@@ -37,16 +57,18 @@ async function getLibrariesDefinedInYaml(pathToUI5Config) {
  * @param {string} [parameters.options.configuration.configPath] Custom path to a local ui5.yaml file that shall be used to identify the framework libraries if saveLibsLocal is set to true
  * @param {object} parameters.middlewareUtil Specification version dependent interface to a
  *                                        [MiddlewareUtil]{@link module:@ui5/server.middleware.MiddlewareUtil} instance
+ * @param {object} parameters.resources Resource collections
+ * @param {module:@ui5/fs.AbstractReader} parameters.resources.rootProject Reader or Collection to read resources of
+ *                                        the project the server is started in
  * @returns {Function} Middleware function to use
  */
-module.exports = async ({ log, options, middlewareUtil }) => {
+module.exports = async ({ log, options, middlewareUtil, resources }) => {
 	// provide a set of default runtime options
 	const effectiveOptions = {
 		debug: false,
 		strictSSL: true,
 		saveLibsLocal: false, // New parameter to save libraries locally
 		cachePath: undefined,
-		config: "ui5.yaml", // New parameter to specify the local UI5 config file, only works in combination with saveLibsLocal true
 	};
 	// config-time options from ui5.yaml for cfdestination take precedence
 	if (options.configuration) {
@@ -139,34 +161,36 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 
 		// check if the framework was build with the setting saveLibsLocal and if the depdencies changed which would require a rebuild
 		let localLibsRequiredRebuild = false;
-		const pathTolocalUI5Config = path.join(process.cwd(), effectiveOptions.configPath);
 
-		const shouldUseLocalUI5Config = effectiveOptions.saveLibsLocal && effectiveOptions.configPath;
-
-		if (shouldUseLocalUI5Config && effectiveOptions.debug) {
-			log.info(`[DEBUG] Checking ${pathTolocalUI5Config} for local UI5 config ...`);
-		}
-
-		const localUI5ConfigExists = shouldUseLocalUI5Config && existsSync(pathTolocalUI5Config);
+		const shouldUseLocalUI5Config = !!effectiveOptions.saveLibsLocal;
 
 		if (shouldUseLocalUI5Config && effectiveOptions.debug) {
-			log.info(`[DEBUG] ${localUI5ConfigExists ? "Found" : "Did not find"} UI5 config at ${pathTolocalUI5Config}`);
+			log.info(`[DEBUG] Checking for local UI5 depdendencies ...`);
 		}
 
-		if (localUI5ConfigExists) {
-			const localUI5Depdendencies = await getLibrariesDefinedInYaml(pathTolocalUI5Config);
+		const localUI5Depdendencies = await getLibrariesDefinedInResources(resources);
+
+		if (shouldUseLocalUI5Config && effectiveOptions.debug) {
+			log.info(`[DEBUG] Found ${localUI5Depdendencies.length} local UI5 depdendencies ...`);
+		}
+
+		if (shouldUseLocalUI5Config && localUI5Depdendencies.length > 0) {
 			const frameworkUI5Dependencies = await getLibrariesDefinedInYaml(frameworkUI5Yaml);
 
 			// if the two yaml files do not have the same dependencies listed, a rebuild is required
 			localLibsRequiredRebuild = localUI5Depdendencies.map((lib) => lib.name).join(",") !== frameworkUI5Dependencies.map((lib) => lib.name).join(",");
 		}
 
-		if (shouldUseLocalUI5Config && !existsSync(pathTolocalUI5Config)) {
-			log.warn(`\n\n\n[WARN] The local UI5 config file ${pathTolocalUI5Config} does not exist! The framework will be build with all UI5 libraries! \n\n`);
+		if (shouldUseLocalUI5Config && localUI5Depdendencies.length === 0) {
+			log.warn(`\n\n\n[WARN] Could not find localUI5Dependencies. The framework will be build with all UI5 libraries! \n\n`);
 		}
 
-		if (localLibsRequiredRebuild && effectiveOptions.debug) {
-			log.info(`[DEBUG] UI5 libraries of ${pathTolocalUI5Config} and ${frameworkUI5Yaml} do not match! Rebuilding framework libraries ...`);
+		if (effectiveOptions.debug) {
+			if (localLibsRequiredRebuild) {
+				log.info(`[DEBUG] UI5 libraries of config and ${frameworkUI5Yaml} do not match! Rebuilding framework libraries ...`);
+			} else {
+				log.info(`[DEBUG] UI5 libraries of config and ${frameworkUI5Yaml} match! No rebuild required ...`);
+			}
 		}
 
 		if (!existsFramework || localLibsRequiredRebuild) {
@@ -192,8 +216,8 @@ module.exports = async ({ log, options, middlewareUtil }) => {
 
 			let libraries = [];
 
-			if (localUI5ConfigExists) {
-				libraries = (await getLibrariesDefinedInYaml(pathTolocalUI5Config)).map((library) => {
+			if (shouldUseLocalUI5Config && localUI5Depdendencies.length > 0) {
+				libraries = localUI5Depdendencies.map((library) => {
 					return { name: library.name };
 				});
 			} else {

--- a/showcases/ui5-app-simple/ui5.yaml
+++ b/showcases/ui5-app-simple/ui5.yaml
@@ -34,6 +34,7 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
+        saveLibsLocal: true
     - name: ui5-tooling-transpile-middleware
       afterMiddleware: compression
       configuration:


### PR DESCRIPTION
## Why this is useful / needed

We would like to use serveframework also as part of our pull request voting. However, the installation takes quite some time if it installs all the libraries.

I understand that we cannot simply respect the ui5.yaml, as the data is stored for the user (in default behaviour), not for the project. 

However, when the project is used, it should consider the ui5.yaml.

## Content
~~This change introduces a new config setting that allows to specify the ui5.yaml that shall be used (defaults to ui5.yaml) in case a different one is used for testing for example.~~

UPDATE: Instead of making the config configurable I found a way to get the current config dependencies via the resources passed into the middleware function.

In case `saveLibsLocal` is set to true, it will filter the libraries to only match the ones that are defined in the current config.

If no library is found, all will be loaded.

It also compares the defined libraries to ensure the data is refetched once the libraries list changes.