### PR TITLE
fix(cds-plugin-ui5): fixes issue in lazy loading feature

### DIFF
--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -192,7 +192,7 @@ if (!skip) {
 						cwd,
 						basePath: modulePath,
 						...(config[moduleId] || {}),
-						LOG,
+						log: LOG,
 						lazy: isLazyLoadingEnabled,
 						//logPerformance: true,
 					});

--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -188,7 +188,7 @@ if (!skip) {
 					const router = createPatchedRouter();
 
 					// determine the application info and apply the UI5 middlewares (maybe lazy)
-					const { pages } = applyUI5Middleware(router, {
+					const { pages } = await applyUI5Middleware(router, {
 						cwd,
 						basePath: modulePath,
 						...(config[moduleId] || {}),

--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -188,25 +188,20 @@ if (!skip) {
 					const router = createPatchedRouter();
 
 					// determine the application info and apply the UI5 middlewares (maybe lazy)
-					const promiseApply = applyUI5Middleware(router, {
+					const { pages } = applyUI5Middleware(router, {
 						cwd,
 						basePath: modulePath,
 						...(config[moduleId] || {}),
 						LOG,
 						lazy: isLazyLoadingEnabled,
 						//logPerformance: true,
-					}).then(({ pages }) => {
-						// append the HTML pages to the links
-						pages.forEach((page) => {
-							const prefix = mountPath !== "/" ? mountPath : "";
-							links.push(`${prefix}${page}`);
-						});
 					});
 
-					// if lazy loading is not enabled, we wait for the middlewares to be applied
-					if (!isLazyLoadingEnabled) {
-						await promiseApply; // wait for the middlewares to be applied
-					}
+					// append the HTML pages to the links
+					pages.forEach((page) => {
+						const prefix = mountPath !== "/" ? mountPath : "";
+						links.push(`${prefix}${page}`);
+					});
 
 					// register the router to the specified mount path
 					app.use(mountPath, router);

--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -183,7 +183,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 		}
 	};
 
-	const getCustomWebappPath = (ui5ConfigPath) => {
+	const determineWebappPath = (ui5ConfigPath) => {
 		/** @type {{resources: {configuration: {paths: {webapp: string}}}}[]} */
 		let ui5Configs;
 		try {
@@ -215,10 +215,10 @@ module.exports = async function applyUI5Middleware(router, options) {
 			}
 			next();
 		});
-		const appWebappFolder = getCustomWebappPath(determineConfigPath(configPath, configFile));
+		const webappPath = determineWebappPath(determineConfigPath(configPath, configFile));
 		// collect pages via glob pattern
 		return {
-			pages: (await glob(PAGE_GLOB_PATTERN, { cwd: path.join(configPath, appWebappFolder) })).map((p) => (!p.startsWith("/") ? `/${p}` : p)),
+			pages: (await glob(PAGE_GLOB_PATTERN, { cwd: path.join(configPath, webappPath) })).map((p) => (!p.startsWith("/") ? `/${p}` : p)),
 		};
 	} else {
 		const { graph, rootProject, rootReader } = await loadAppInfo();

--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -98,7 +98,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 		return { rootProject, rootReader, graph };
 	};
 
-	const loadPages = async (rootProject, rootReader) => {
+	const loadPages = async ({ rootProject, rootReader }) => {
 		// for Fiori elements based applications we need to invalidate the view cache
 		// so we need to append the query parameter to the HTML files (sap-ui-xx-viewCache=false)
 		const isFioriElementsBased = rootProject.getFrameworkDependencies().find((lib) => lib.name.startsWith("sap.fe"));

--- a/packages/cds-plugin-ui5/lib/findUI5Modules.js
+++ b/packages/cds-plugin-ui5/lib/findUI5Modules.js
@@ -18,7 +18,7 @@ const yaml = require("js-yaml");
  * @param {string} options.skipLocalApps skip local apps
  * @param {string} options.skipDeps skip dependencies
  * @param {string} options.log the logger (defaults to console)
- * @returns {Array<UI5Module>} array of UI5 module
+ * @returns {Promise<Array<UI5Module>>} array of UI5 module
  */
 module.exports = async function findUI5Modules({ cwd, cds, skipLocalApps, skipDeps, log = console }) {
 	// extract the modules configuration from the package.json

--- a/packages/cds-plugin-ui5/package.json
+++ b/packages/cds-plugin-ui5/package.json
@@ -14,6 +14,7 @@
     "@ui5/fs": "^4",
     "@ui5/project": "^4",
     "@ui5/server": "^4",
+    "glob": "^11.0.2",
     "js-yaml": "^4.1.0",
     "node-html-parser": "^7.0.1",
     "semver": "^7.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@ui5/server':
         specifier: ^4
         version: 4.0.4
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.2
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5907,6 +5910,11 @@ packages:
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -16631,6 +16639,15 @@ snapshots:
       path-scurry: 1.11.1
 
   glob@11.0.0:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 4.0.1
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 2.0.0
+
+  glob@11.0.2:
     dependencies:
       foreground-child: 3.3.0
       jackspeak: 4.0.1


### PR DESCRIPTION
## Problem

The current implementation of `CDS_PLUGIN_UI5_LAZY_LOADING` allows for a very fast bootstrapping, but gives no indication to the user, when the loading/mounting of the UI5 applications is actually done.

Because of the asynchronicity, a restart of the cds runtime also breaks the app reload for the UI5 applications, as the apps are not available yet.

## Solution

If _lazy loading_ is active, all the heavy stuff like graph loading, finding ui5 project dependencies, etc. is moved into the first request, that is being made to the custom router of the specific app module.

## Remarks

As the `Reader` is not yet loaded when lazy mode is active, `glob` is used to determine all relevant `htm[l]` pages. Furthermore it is assumed that the main application folder is called `webapp`. 
