### PR TITLE
fix(cds-plugin-ui5): wait for middlewares if not lazy

### DIFF
--- a/packages/cds-plugin-ui5/cds-plugin.js
+++ b/packages/cds-plugin-ui5/cds-plugin.js
@@ -188,7 +188,7 @@ if (!skip) {
 					const router = createPatchedRouter();
 
 					// determine the application info and apply the UI5 middlewares (maybe lazy)
-					applyUI5Middleware(router, {
+					const promiseApply = applyUI5Middleware(router, {
 						cwd,
 						basePath: modulePath,
 						...(config[moduleId] || {}),
@@ -202,6 +202,11 @@ if (!skip) {
 							links.push(`${prefix}${page}`);
 						});
 					});
+
+					// if lazy loading is not enabled, we wait for the middlewares to be applied
+					if (!isLazyLoadingEnabled) {
+						await promiseApply; // wait for the middlewares to be applied
+					}
 
 					// register the router to the specified mount path
 					app.use(mountPath, router);


### PR DESCRIPTION
Karma testing showed an "AggregateError" when the middlewares aren't fully applied to the router before the Karma test runs. Therefore, in non-lazy scenarios we need to wait until all middlewares have been properly applied.

Relates: https://github.com/ui5-community/ui5-ecosystem-showcase/pull/1224 (Solution proposal)

Relates: https://github.com/SAP-samples/cap-sflight/pull/1468 (Karma issue)