### PR TITLE
feat(ui5-tooling-transpile): allow aliasing for request paths for the middleware

### DIFF
--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -74,6 +74,9 @@ npm install ui5-tooling-transpile --save-dev
 - generateBabelConfig: `boolean|string` (*experimental feature*)
   this option allows to generate the babel config file for the current project when the babel config file doesn't exist - this option is useful when you are using babel generation within a different tooling (like a native babel execution inside e.g. jest) to use the same configuration like when running the task or middleware; if the value is a string the tooling extension will assume to generate a file with the provided name
 
+- aliasPatterns: `Map<string,string` (*experimental feature*)
+  allows to define alias patterns to convert a request urls into target urls, e.g. converting `/__alias/ui5.ecosystem.demo.tslib.util/capitalize.js` into `/resources/ui5/ecosystem/demo/tslib/util/capitalize.js`. This can be done by providing the following mapping: `^/__alias/([^.]+)\\.([^.]+)\\.([^.]+)\\.([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3/$4/$5/$6"` as an entry of this configuration option.
+
 The following configuration options will only be taken into account if no inline babel configuration is maintained in the `ui5.yaml` as `babelConfig` or no external babel configuration exists in any configuration file as described in [Babels configuration section](https://babeljs.io/docs/configuration):
 
 - targetBrowsers: `String` (default: [`"defaults"`](https://browsersl.ist/#q=defaults))

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -343,6 +343,7 @@ module.exports = function (log) {
 				includes,
 				excludes,
 				filePattern,
+				aliasPatterns: config.aliasPatterns,
 				omitTSFromBuildResult: config.omitTSFromBuildResult,
 				omitSourceMaps: config.omitSourceMaps,
 				generateTsInterfaces,

--- a/showcases/ui5-tsapp/ui5.yaml
+++ b/showcases/ui5-tsapp/ui5.yaml
@@ -10,6 +10,11 @@ customConfiguration:
   config-ui5-tooling-transpile: &cfgTranspile
     debug: true
     filePattern: .+(ts|tsx)
+    aliasPatterns:
+      "^/__alias/([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3"
+      "^/__alias/([^.]+)\\.([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3/$4"
+      "^/__alias/([^.]+)\\.([^.]+)\\.([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3/$4/$5"
+      "^/__alias/([^.]+)\\.([^.]+)\\.([^.]+)\\.([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3/$4/$5/$6"
     generateDts: true
     omitTSFromBuildResult: true
   config-ui5-tooling-modules: &cfgModules


### PR DESCRIPTION
The configuration has been extended to allow to specify `aliasPatterns` like that:

```yaml
  config:
    aliasPatterns:
      "^/__alias/([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3"
      "^/__alias/([^.]+)\\.([^.]+)\\.([^.]+)/(.*)$": "/resources/$1/$2/$3/$4"
```

The key is a regex and the value the replacement. This can be used to convert the request url.

Fixes #1209