### PR TITLE
feat: make tooling extension self-registering 

### DIFF
--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -35,6 +35,12 @@ Once the UI5 application is finally built, the Chart.js dependency will be copie
 npm install ui5-tooling-modules --save-dev
 ```
 
+If you want the `ui5-tooling-modules` to add it's configuration to the `ui5.yaml`, just add the command line argument `-rte` or `--register-tooling-extension`:
+
+```bash
+npm install ui5-tooling-modules --save-dev -rte
+```
+
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
 The following configuration options are relevant for the `task` and the `middleware`:

--- a/packages/ui5-tooling-modules/lib/postinstall.js
+++ b/packages/ui5-tooling-modules/lib/postinstall.js
@@ -1,0 +1,101 @@
+const path = require("path");
+const fs = require("fs");
+
+// only register if the current working directory is set
+// and the npm config variable "rte" or "register_tooling_extension" is set
+// or the environment variable "ui5eco_rte" or "ui5eco_register_tooling_extension" is set
+const cwd = process.env["INIT_CWD"];
+const shouldRegister =
+	(cwd && process.env["npm_config_rte"] === "true") ||
+	process.env["npm_config_register_tooling_extension"] === "true" ||
+	process.env["ui5eco_rte"] === "true" ||
+	process.env["ui5eco_register_tooling_extension"] === "true";
+
+// and the ui5.yaml file exists in the current working directory
+if (shouldRegister && fs.existsSync(path.join(cwd, "ui5.yaml"))) {
+	// load the YAML parser
+	const yaml = require("js-yaml");
+
+	// read the ui5.yaml file with all documents
+	const doc = yaml.loadAll(fs.readFileSync(path.join(cwd, "ui5.yaml"), "utf8"));
+
+	// no documents found => no creation
+	if (doc && doc.length > 0) {
+		// only write the ui5.yaml if it has been changed
+		let changed = false;
+
+		// if there are multiple documents, we only take the first one
+		const builder = (doc[0].builder ??= {});
+		const ct = (builder.customTasks ??= []);
+		if (!ct.find((t) => t.name === "ui5-tooling-modules-task")) {
+			// push after ui5-tooling-transpile-middleware
+			const index = ct.findIndex((t) => t.name === "ui5-tooling-transpile-task");
+			if (index === -1) {
+				// or if not found, just add it at the beginning
+				ct.unshift({
+					name: "ui5-tooling-modules-task",
+					afterTask: "replaceVersion",
+				});
+			} else {
+				ct.splice(index + 1, 0, {
+					name: "ui5-tooling-modules-task",
+					afterTask: "ui5-tooling-transpile-task",
+				});
+			}
+			changed = true;
+		}
+
+		// if there are multiple documents, we only take the first one
+		const server = (doc[0].server ??= {});
+		const cmw = (server.customMiddleware ??= []);
+		if (!cmw.find((mw) => mw.name === "ui5-tooling-modules-middleware")) {
+			// push after ui5-tooling-transpile-middleware
+			const index = cmw.findIndex((mw) => mw.name === "ui5-tooling-transpile-middleware");
+			if (index === -1) {
+				// or if not found, just add it at the beginning
+				cmw.unshift({
+					name: "ui5-tooling-modules-middleware",
+					afterMiddleware: "compression",
+				});
+			} else {
+				cmw.splice(index + 1, 0, {
+					name: "ui5-tooling-modules-middleware",
+					afterMiddleware: "ui5-tooling-transpile-middleware",
+				});
+			}
+			changed = true;
+		}
+
+		// Write back to YAML file
+		if (changed) {
+			fs.writeFileSync(path.join(cwd, "ui5.yaml"), doc.length > 1 ? yaml.dumpAll(doc) : yaml.dump(doc[0]), "utf8");
+		}
+	}
+}
+
+// and the ui5.yaml file exists in the current working directory
+if (shouldRegister && fs.existsSync(path.join(cwd, "tsconfig.json"))) {
+	// load the JSONC parser
+	const JSONC = require("comment-json");
+
+	// read the ui5.yaml file with all documents
+	const tsconfig = JSONC.parse(fs.readFileSync(path.join(cwd, "tsconfig.json"), "utf8"));
+
+	// no documents found => no creation
+	if (tsconfig) {
+		// only write the ui5.yaml if it has been changed
+		let changed = false;
+
+		// if there are multiple documents, we only take the first one
+		tsconfig.include ??= [];
+		if (!tsconfig.include.includes("./.ui5-tooling-modules/types/**/*")) {
+			tsconfig.include.push("./.ui5-tooling-modules/types/**/*");
+			changed = true;
+		}
+
+		// Write back to JSONC file
+		if (changed) {
+			fs.writeFileSync(path.join(cwd, "tsconfig.json"), JSONC.stringify(tsconfig, undefined, 2), "utf8");
+		}
+	}
+}

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/ui5-tooling-modules"
   },
   "scripts": {
+    "postinstall": "node ./lib/postinstall.js",
     "lint": "eslint lib",
     "test": "ava --no-worker-threads",
     "test:snapshots": "ava --no-worker-threads -- --generateSnapshots --generateFixtures"
@@ -33,10 +34,12 @@
     "@rollup/pluginutils": "^5.2.0",
     "@typescript-eslint/typescript-estree": "^8.35.1",
     "chokidar": "^4.0.3",
+    "comment-json": "^4.2.5",
     "estree-walker": "^3.0.3",
     "fast-xml-parser": "^5.2.5",
     "handlebars": "^4.7.8",
     "ignore-walk": "^7.0.0",
+    "js-yaml": "^4.1.0",
     "minimatch": "^7.4.6",
     "rollup": "^4.44.2",
     "rollup-plugin-polyfill-node": "^0.13.0",

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -21,6 +21,12 @@ The task finally transpiles the relevant source files during the UI5 Tooling bui
 npm install ui5-tooling-transpile --save-dev
 ```
 
+If you want the `ui5-tooling-transpile` to add it's configuration to the `ui5.yaml`, just add the command line argument `-rte` or `--register-tooling-extension`:
+
+```bash
+npm install ui5-tooling-transpile --save-dev -rte
+```
+
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
 - debug: `boolean`  

--- a/packages/ui5-tooling-transpile/lib/postinstall.js
+++ b/packages/ui5-tooling-transpile/lib/postinstall.js
@@ -1,0 +1,58 @@
+const path = require("path");
+const fs = require("fs");
+
+// only register if the current working directory is set
+// and the npm config variable "rte" or "register_tooling_extension" is set
+// or the environment variable "ui5eco_rte" or "ui5eco_register_tooling_extension" is set
+const cwd = process.env["INIT_CWD"];
+const shouldRegister =
+	(cwd && process.env["npm_config_rte"] === "true") ||
+	process.env["npm_config_register_tooling_extension"] === "true" ||
+	process.env["ui5eco_rte"] === "true" ||
+	process.env["ui5eco_register_tooling_extension"] === "true";
+
+// and the ui5.yaml file exists in the current working directory
+if (shouldRegister && fs.existsSync(path.join(cwd, "ui5.yaml"))) {
+	// load the YAML parser
+	const yaml = require("js-yaml");
+
+	// read the ui5.yaml file with all documents
+	const doc = yaml.loadAll(fs.readFileSync(path.join(cwd, "ui5.yaml"), "utf8"));
+
+	// no documents found => no creation
+	if (doc && doc.length > 0) {
+		// only write the ui5.yaml if it has been changed
+		let changed = false;
+
+		// if there are multiple documents, we only take the first one
+		const builder = (doc[0].builder ??= {});
+		const ct = (builder.customTasks ??= []);
+		if (!ct.find((t) => t.name === "ui5-tooling-transpile-task")) {
+			ct.unshift({
+				name: "ui5-tooling-transpile-task",
+				afterTask: "replaceVersion"
+			});
+			changed = true;
+		}
+
+		// if there are multiple documents, we only take the first one
+		const server = (doc[0].server ??= {});
+		const cmw = (server.customMiddleware ??= []);
+		if (!cmw.find((mw) => mw.name === "ui5-tooling-transpile-middleware")) {
+			cmw.unshift({
+				name: "ui5-tooling-transpile-middleware",
+				afterMiddleware: "compression"
+			});
+			changed = true;
+		}
+
+		// Write back to YAML file
+		if (changed) {
+			fs.writeFileSync(
+				path.join(cwd, "ui5.yaml"),
+				doc.length > 1 ? yaml.dumpAll(doc) : yaml.dump(doc[0]),
+				"utf8"
+			);
+		}
+	}
+}

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -18,7 +18,8 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-preset-transform-ui5": "^7.7.1",
     "browserslist": "^4.25.1",
-    "comment-json": "^4.2.5"
+    "comment-json": "^4.2.5",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "ava": "^6.4.0"
@@ -32,6 +33,7 @@
     }
   },
   "scripts": {
+    "postinstall": "node ./lib/postinstall.js",
     "lint": "eslint lib",
     "test": "ava --no-worker-threads"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      comment-json:
+        specifier: ^4.2.5
+        version: 4.2.5
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
@@ -514,6 +517,9 @@ importers:
       ignore-walk:
         specifier: ^7.0.0
         version: 7.0.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       minimatch:
         specifier: ^7.4.6
         version: 7.4.6
@@ -587,6 +593,9 @@ importers:
       comment-json:
         specifier: ^4.2.5
         version: 4.2.5
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       ava:
         specifier: ^6.4.0


### PR DESCRIPTION
By using the command line argument `-rte` or `--register-tooling-extension`
the `ui5-tooling-transpile` and `ui5-tooling-modules` tooling extensions
add their configuration into the `ui5.yaml` of the project and in case
of the modules, it also modifies the `tsconfig.json` to add the
`include` configuration for the generated type definitions.