### PR TITLE
fix(cds-plugin-ui5): fixes minor condition error for custom webapp path

### DIFF
--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -185,7 +185,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 	};
 
 	const determineWebappPath = (ui5ConfigPath) => {
-		if (ui5ConfigPath) {
+		if (!ui5ConfigPath) {
 			log.warn("Path to config file could not be determined. Using default webapp path to lookup HTML pages");
 			return "webapp";
 		}


### PR DESCRIPTION
@petermuessig I overlooked a minor issue. Not critical for projects with default `webapp` folder location but would result in loading issues when an app has a custom `webapp` path and lazy loading is active.