### PR TITLE
feat(ui5-tooling-modules): support HTMLElement as base class for webcomponents

### DIFF
--- a/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
@@ -38,7 +38,7 @@ sap.ui.define([
   pkg["{{this.name}}"] = {
   {{#each this.values}}
     {{this._jsDoc}}
-    "{{this.name}}": "{{this.name}}",
+    "{{this.name}}": "{{{this.value}}}",
   {{/each}}
   };
   registerEnum("{{this._ui5QualifiedName}}", pkg["{{this.name}}"]);

--- a/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
@@ -2,12 +2,12 @@
  * ${copyright}
  */
 sap.ui.define([
-  "{{webcPackage}}",{{#if isBaseLib}}
+  {{#if webcPackage}}"{{webcPackage}}",{{/if}}{{#if isBaseLib}}
   "sap/ui/core/webc/WebComponent",{{/if}}{{#if hasEnums}}
   "sap/ui/base/DataType",{{/if}}{{#each dependencies}}
   "{{this}}",{{/each}}
 ], function(
-  WebCPackage,{{#if isBaseLib}}
+  {{#if webcPackage}}WebCPackage,{{/if}}{{#if isBaseLib}}
   WebComponent,{{/if}}{{#if hasEnums}}
   DataType,{{/if}}
 ) {
@@ -20,7 +20,7 @@ sap.ui.define([
     "_ui5metadata":
 {{{metadata}}}
   };
-
+  {{#if webcPackage}}
   if (WebCPackage) {
     Object.keys(WebCPackage).forEach((key) => {
       if (key !== "default") {
@@ -31,7 +31,7 @@ sap.ui.define([
         }
       }
     });
-  }
+  }{{/if}}
 
   {{#each enums}}
   {{{this._jsDoc}}}

--- a/packages/ui5-tooling-modules/lib/templates/dts/Class.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/dts/Class.hbs
@@ -11,11 +11,6 @@
 
 {{/each}}
 
-/**
- * Default imports
- */
-import type { default as WebComponentMetadata } from "sap/ui/core/webc/WebComponentMetadata";
-
 {{#each clazz._dts.imports}}
 	{{#if @first}}
 
@@ -162,7 +157,12 @@ declare module "{{{clazz._ui5QualifiedNameSlashes}}}" {
 			 *
 			 * @returns Metadata object describing this class
 			 */
+<<<<<<< HEAD
 			static getMetadata(): WebComponentMetadata;
+=======
+			static getMetadata(): {{{clazz._dts.metadataClass}}};
+
+>>>>>>> 601145da (feat(ui5-tooling-modules): improve d.ts generation for web components)
 			{{#each clazz._dts.methods}}
 
 				{{#if this.description}}

--- a/packages/ui5-tooling-modules/lib/templates/dts/Class.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/dts/Class.hbs
@@ -157,12 +157,8 @@ declare module "{{{clazz._ui5QualifiedNameSlashes}}}" {
 			 *
 			 * @returns Metadata object describing this class
 			 */
-<<<<<<< HEAD
-			static getMetadata(): WebComponentMetadata;
-=======
 			static getMetadata(): {{{clazz._dts.metadataClass}}};
 
->>>>>>> 601145da (feat(ui5-tooling-modules): improve d.ts generation for web components)
 			{{#each clazz._dts.methods}}
 
 				{{#if this.description}}

--- a/packages/ui5-tooling-modules/lib/templates/dts/Module.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/dts/Module.hbs
@@ -10,7 +10,7 @@ declare module "{{registryEntry.namespace}}" {
 		export enum {{@key}} {
 			{{#each this.values}}
 				{{{generateApiDocumentation this.description}}}
-				{{{this.name}}} = "{{{this.name}}}",
+				{{{this.name}}} = "{{{this.value}}}",
 			{{/each}}
 		}
 	{{/each}}

--- a/packages/ui5-tooling-modules/lib/utils/DTSSerializer.js
+++ b/packages/ui5-tooling-modules/lib/utils/DTSSerializer.js
@@ -887,6 +887,11 @@ const DTSSerializer = {
 					class: "WebComponent",
 					module: "sap/ui/core/webc/WebComponent",
 				};
+			} else if (WebComponentRegistryHelper.isUi5CoreHTMLElement(classDef.superclass)) {
+				superclassSettings = {
+					class: "HTMLElement",
+					module: "sap/ui/core/html/HTMLElement",
+				};
 			} else {
 				superclassSettings = {
 					class: classDef.superclass.name,
@@ -913,6 +918,15 @@ const DTSSerializer = {
 			// Add superclass imports
 			writeImports(superclassSettings.module, superclassSettings.class, { default: true });
 			writeImports(superclassSettings.module, `$${superclassSettings.class}Settings`);
+
+			if (WebComponentRegistryHelper.isSubclassOf(classDef, "sap.ui.core.html", "HTMLElement")) {
+				classDef._dts.metadataClass = "HTMLElementMetadata";
+				writeImports("sap/ui/core/html/HTMLElementMetadata", "HTMLElementMetadata", { default: true });
+			} else if (WebComponentRegistryHelper.isSubclassOf(classDef, "@ui5/webcomponents-base", "UI5Element")) {
+				classDef._dts.metadataClass = "WebComponentMetadata";
+				writeImports("sap/ui/core/webc/WebComponentMetadata", "WebComponentMetadata", { default: true });
+			}
+
 			classDef._dts.extends = superclassSettings.class;
 
 			// Process all entity types

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -184,12 +184,21 @@ class RegistryEntry {
 
 			let superclassRef = (refPackage || this).classes[superclassName];
 			if (!superclassRef) {
-				logger.error(
-					`The class '${this.namespace}/${classDef.name}' has an unknown superclass '${classDef.superclass.package}/${superclassName}' using default '@ui5/webcomponents-base/UI5Element'!`,
-				);
-				const refPackage = WebComponentRegistry.getPackage(WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE);
-				let superclassRef = (refPackage || this).classes[WebComponentRegistryHelper.UI5_ELEMENT_CLASS_NAME];
-				classDef.superclass = superclassRef;
+				if (classDef.namespace === "@ui5/html") {
+					classDef.superclass = {
+						name: "HTMLElement",
+						package: "sap.ui.core",
+						namespace: "sap.ui.core.html",
+						module: "sap/ui/core/html/HTMLElement.js",
+					};
+				} else {
+					logger.error(
+						`The class '${this.namespace}/${classDef.name}' has an unknown superclass '${classDef.superclass.package}/${superclassName}' using default '@ui5/webcomponents-base/UI5Element'!`,
+					);
+					const refPackage = WebComponentRegistry.getPackage(WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE);
+					let superclassRef = (refPackage || this).classes[WebComponentRegistryHelper.UI5_ELEMENT_CLASS_NAME];
+					classDef.superclass = superclassRef;
+				}
 			} else {
 				this.#connectSuperclass(superclassRef);
 				classDef.superclass = superclassRef;
@@ -1205,6 +1214,9 @@ const WebComponentRegistry = {
 			skipDtsGeneration,
 			skipJSDoc,
 		});
+
+		// TODO: no scoping for html tags, otherwise invalid
+		scopeSuffix = namespace === "@ui5/html" ? undefined : scopeSuffix;
 
 		let entry = _registry[namespace];
 		if (!entry) {

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -1143,7 +1143,11 @@ class RegistryEntry {
 			const enumMembers = this.enums[enumName].members;
 			enumMembers.forEach((member) => {
 				// Key<>Value must be identical!
-				enumValues.push({ name: member.name, description: member.description || "" });
+				enumValues.push({
+					name: member.name,
+					value: member.value || member.name,
+					description: member.description || "",
+				});
 			});
 
 			// prepare enum info object for HBS template later

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -222,7 +222,7 @@ class RegistryEntry {
 
 	#calculateScopedTagName(classDef) {
 		// only scope UI5Element subclasses
-		if (this.scopeSuffix && WebComponentRegistryHelper.isUI5ElementSubclass(classDef)) {
+		if (this.scopeSuffix && WebComponentRegistryHelper.isSubclassOf(classDef, WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE, WebComponentRegistryHelper.UI5_ELEMENT_CLASS_NAME)) {
 			if (classDef.tagName) {
 				classDef.scopedTagName = `${classDef.tagName}-${this.scopeSuffix}`;
 			}

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
@@ -8,6 +8,8 @@ const WebComponentRegistryHelper = {
 	 * Helper function to check whether the given class inherits from the provided class name.
 	 *
 	 * @param {object} classDef a class definition from a WebComponentRegistry entry
+	 * @param {string} namespace the class namespace
+	 * @param {string} className the class name
 	 * @returns {boolean} whether the class inherits from the provided class name
 	 */
 	isSubclassOf(classDef, namespace, className) {

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
@@ -5,23 +5,22 @@ const WebComponentRegistryHelper = {
 	UI5_ELEMENT_NAMESPACE: "@ui5/webcomponents-base",
 
 	/**
-	 * Helper function to check whether the given class inherits from UI5Element, the base class for all
-	 * UI5 web components.
+	 * Helper function to check whether the given class inherits from the provided class name.
 	 *
 	 * @param {object} classDef a class definition from a WebComponentRegistry entry
-	 * @returns {boolean} whether the class inherits from UI5Element
+	 * @returns {boolean} whether the class inherits from the provided class name
 	 */
-	isUI5ElementSubclass(classDef) {
+	isSubclassOf(classDef, namespace, className) {
 		let superclass = classDef.superclass,
-			isUI5ElementSubclass = false;
+			isSubclass = false;
 		while (superclass) {
-			if (superclass?.namespace === this.UI5_ELEMENT_NAMESPACE && superclass?.name === this.UI5_ELEMENT_CLASS_NAME) {
-				isUI5ElementSubclass = true;
+			if (superclass?.namespace === namespace && superclass?.name === className) {
+				isSubclass = true;
 				break;
 			}
 			superclass = superclass.superclass;
 		}
-		return isUI5ElementSubclass;
+		return isSubclass;
 	},
 
 	isUI5Element(ui5Superclass) {
@@ -30,10 +29,6 @@ const WebComponentRegistryHelper = {
 
 	isUi5CoreHTMLElement(ui5Superclass) {
 		return ui5Superclass?.namespace === "sap.ui.core.html" && ui5Superclass?.name === "HTMLElement";
-	},
-
-	isHTMLElementBase(ui5Superclass) {
-		return ui5Superclass?.namespace === "sap.ui.core.html" && ui5Superclass.name !== "HTMLElementBase";
 	},
 };
 

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
@@ -27,6 +27,14 @@ const WebComponentRegistryHelper = {
 	isUI5Element(ui5Superclass) {
 		return ui5Superclass.namespace === this.UI5_ELEMENT_NAMESPACE && ui5Superclass.name === this.UI5_ELEMENT_CLASS_NAME;
 	},
+
+	isUi5CoreHTMLElement(ui5Superclass) {
+		return ui5Superclass?.namespace === "sap.ui.core.html" && ui5Superclass?.name === "HTMLElement";
+	},
+
+	isHTMLElementBase(ui5Superclass) {
+		return ui5Superclass?.namespace === "sap.ui.core.html" && ui5Superclass.name !== "HTMLElementBase";
+	},
 };
 
 module.exports = WebComponentRegistryHelper;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,7 +736,7 @@ importers:
         version: 2.12.0
       axios:
         specifier: ^1.11.0
-        version: 1.11.0
+        version: 1.11.0(debug@4.4.1)
       cmis:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1138,6 +1138,9 @@ importers:
 
   showcases/ui5-tsapp-webc:
     dependencies:
+      '@ui5/html':
+        specifier: file:../../../ui5-html
+        version: file:../ui5-html
       '@ui5/webcomponents':
         specifier: ^2.12.0
         version: 2.12.0
@@ -3396,6 +3399,9 @@ packages:
     resolution: {integrity: sha512-vVphxHk0yywJ0eseBNQ2rd1JdUZSUUZ0CAjZ3ghttqD8hx8elJjc7UllpOduysDcdaH3+Km2oLw9yumz14+lgg==}
     engines: {node: ^20.11.0 || >=22.0.0, npm: '>= 8'}
 
+  '@ui5/html@file:../ui5-html':
+    resolution: {directory: ../ui5-html, type: directory}
+
   '@ui5/logger@3.0.0':
     resolution: {integrity: sha512-Np9pHhr+dnyL2gDFwIx6c6Xy0yhtpBIqUQM9An8uLX/wIcRjIjBSQ/r16o3YgS9roY59I/uj5ZEbIa1cdS3Dzg==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
@@ -3504,6 +3510,9 @@ packages:
 
   '@vitest/snapshot@2.0.5':
     resolution: {integrity: sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==}
+
+  '@vscode/web-custom-data@0.6.0':
+    resolution: {integrity: sha512-ZcDarMVk4SquxEtgVcFQc+9DoWTyT3s+lUjreNQz1fmcoCB21DF+wSgy4H9BGcicPUInmiJnGDxRJ9U7LjOmGw==}
 
   '@wdio/cli@8.40.3':
     resolution: {integrity: sha512-woB6RQj3upBOaytL/Ru3QPErJa80Ct2E/jHvQMSTC0xBTAOqpL/Q/vgMriyNTdvwkFwLi8Z3Jpoi9FnAhX0Lfg==}
@@ -5249,10 +5258,6 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  es-set-tostringtag@2.0.3:
-    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
-    engines: {node: '>= 0.4'}
-
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
@@ -5700,10 +5705,6 @@ packages:
   form-data@2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
-
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
@@ -10315,7 +10316,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -10935,7 +10936,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/types': 7.28.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11158,7 +11159,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11176,7 +11177,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -12573,7 +12574,7 @@ snapshots:
   '@sap/xssec@3.6.1':
     dependencies:
       axios: 1.11.0(debug@4.4.1)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       jsonwebtoken: 9.0.2
       node-rsa: 1.1.1
     transitivePeerDependencies:
@@ -12581,7 +12582,7 @@ snapshots:
 
   '@sap/xssec@4.7.0':
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       jwt-decode: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -12884,7 +12885,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 22.14.1
-      form-data: 4.0.0
+      form-data: 4.0.4
 
   '@types/supertest@6.0.2':
     dependencies:
@@ -12939,7 +12940,7 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 9.30.1(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -12949,7 +12950,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -12967,7 +12968,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 9.30.1(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -13157,6 +13158,10 @@ snapshots:
       minimatch: 10.0.1
       pretty-hrtime: 1.0.3
       random-int: 3.0.0
+
+  '@ui5/html@file:../ui5-html':
+    dependencies:
+      '@vscode/web-custom-data': 0.6.0
 
   '@ui5/logger@3.0.0':
     dependencies:
@@ -13532,6 +13537,8 @@ snapshots:
       magic-string: 0.30.11
       pathe: 1.1.2
 
+  '@vscode/web-custom-data@0.6.0': {}
+
   '@wdio/cli@8.40.3(devtools@8.40.2(encoding@0.1.13))(encoding@0.1.13)':
     dependencies:
       '@types/node': 22.5.0
@@ -13821,13 +13828,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14036,7 +14043,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       emittery: 1.2.0
       figures: 6.1.0
       globby: 14.1.0
@@ -14087,14 +14094,6 @@ snapshots:
       axios: 1.8.3(debug@4.3.2)
       is-retry-allowed: 2.2.0
 
-  axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.3.2)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.11.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.6(debug@4.4.1)
@@ -14106,7 +14105,7 @@ snapshots:
   axios@1.8.3(debug@4.3.2):
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.2)
-      form-data: 4.0.0
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -15638,7 +15637,7 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
-      es-set-tostringtag: 2.0.3
+      es-set-tostringtag: 2.1.0
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.6
       get-intrinsic: 1.3.0
@@ -15682,12 +15681,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.0.3:
-    dependencies:
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   es-set-tostringtag@2.1.0:
     dependencies:
@@ -15750,7 +15743,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 9.30.1(jiti@2.4.2)
       espree: 10.4.0
@@ -16090,7 +16083,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -16365,7 +16358,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.4.1):
     optionalDependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
 
   for-each@0.3.3:
     dependencies:
@@ -16393,12 +16386,6 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
     optional: true
-
-  form-data@4.0.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.4:
     dependencies:
@@ -16575,7 +16562,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16927,7 +16914,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16952,7 +16939,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6(debug@4.3.2)
+      follow-redirects: 1.15.6(debug@4.4.1)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -16980,14 +16967,14 @@ snapshots:
   https-proxy-agent@5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17169,7 +17156,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -17440,7 +17427,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -17969,7 +17956,7 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       commander: 14.0.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       lilconfig: 3.1.3
       listr2: 8.3.3
       micromatch: 4.0.8
@@ -18125,7 +18112,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       flatted: 3.3.1
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -18537,7 +18524,7 @@ snapshots:
 
   nock@13.5.6:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -18817,7 +18804,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.11.0
+      axios: 1.11.0(debug@4.4.1)
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -19054,7 +19041,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -19454,7 +19441,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -19969,7 +19956,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -20091,7 +20078,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -20354,7 +20341,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -20398,7 +20385,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -20409,7 +20396,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -20486,7 +20473,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -20595,9 +20582,9 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.0
+      form-data: 4.0.4
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -20845,7 +20832,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -20853,7 +20840,7 @@ snapshots:
   tuf-js@3.0.1:
     dependencies:
       '@tufjs/models': 3.0.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       make-fetch-happen: 14.0.3
     transitivePeerDependencies:
       - supports-color
@@ -21191,7 +21178,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/showcases/ui5-tsapp-webc/package.json
+++ b/showcases/ui5-tsapp-webc/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@ui5/webcomponents": "^2.12.0",
     "@ui5/webcomponents-ai": "^2.12.0",
-    "@ui5/webcomponents-fiori": "^2.12.0"
+    "@ui5/webcomponents-fiori": "^2.12.0",
+    "@ui5/html": "file:../../../ui5-html"
   },
   "devDependencies": {
     "@types/openui5": "1.136.0",

--- a/showcases/ui5-tsapp-webc/ui5.yaml
+++ b/showcases/ui5-tsapp-webc/ui5.yaml
@@ -39,7 +39,7 @@ builder:
           webcomponents:
             #namespace: false
             skipJSDoc: false # enable the JSDoc generation
-            skipDtsGeneration: false
+            skipDtsGeneration: true
 server:
   customMiddleware:
     - name: ui5-tooling-transpile-middleware
@@ -57,7 +57,7 @@ server:
           webcomponents:
             force: true
             skipJSDoc: false # enable the JSDoc generation
-            skipDtsGeneration: false
+            skipDtsGeneration: true
     - name: ui5-middleware-livereload
       afterMiddleware: compression
       configuration:

--- a/showcases/ui5-tsapp-webc/ui5.yaml
+++ b/showcases/ui5-tsapp-webc/ui5.yaml
@@ -39,7 +39,7 @@ builder:
           webcomponents:
             #namespace: false
             skipJSDoc: false # enable the JSDoc generation
-            skipDtsGeneration: true
+            skipDtsGeneration: false
 server:
   customMiddleware:
     - name: ui5-tooling-transpile-middleware
@@ -57,7 +57,7 @@ server:
           webcomponents:
             force: true
             skipJSDoc: false # enable the JSDoc generation
-            skipDtsGeneration: true
+            skipDtsGeneration: false
     - name: ui5-middleware-livereload
       afterMiddleware: compression
       configuration:

--- a/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
+++ b/showcases/ui5-tsapp-webc/webapp/controller/Main.controller.ts
@@ -21,7 +21,8 @@ import { Select$LiveChangeEvent } from "@ui5/webcomponents/dist/Select";
 import Option from "@ui5/webcomponents/dist/Option";
 import MultiInput, { MultiInput$TokenDeleteEvent } from "@ui5/webcomponents/dist/MultiInput";
 
-console.log(AvatarSize);
+// HTML Elements
+import Progress from "@ui5/html/dist/Progress";
 
 function injectStyle() {
 	const sheet = new CSSStyleSheet();
@@ -45,27 +46,49 @@ function injectStyle() {
  * @namespace ui5.ecosystem.demo.webctsapp.controller
  */
 export default class Main extends Controller {
+	private animationId: number = 0;
+	private isAnimating: boolean = false;
+
 	public onInit(): void {
 		injectStyle();
 
 		const button = new Button({ text: "👻", click: this.onBoo });
-		if (button instanceof Control) {
-			(this.getView()?.byId("contentArea") as VBox).addItem(button);
-		}
+		(this.byId("contentArea") as VBox).addItem(button);
 		console.log(`Button is a sap.ui.core.WebComponent: ${button.isA("sap.ui.core.WebComponent")}`);
 		console.log(`Button is a @ui5.webcomponents.dist.Button: ${button.isA("@ui5.webcomponents.dist.Button")}`);
 		console.log(`Button is not a @ui5.webcomponents.Button: ${button.isA("@ui5.webcomponents.Button")}`);
+
 		const datePicker = new DatePicker({ placeholder: "📅" });
-		if (datePicker instanceof Control) {
-			(this.getView()?.byId("contentArea") as VBox).addItem(datePicker);
-		}
+		(this.byId("contentArea") as VBox).addItem(datePicker);
+
 		console.log(`DatePicker is a @ui5.webcomponents.dist.DatePicker: ${datePicker.isA("@ui5.webcomponents.dist.DatePicker")}`);
 		const input = new Input({ value: "🚀🚀🚀" });
-		if (input instanceof Control) {
-			(this.getView()?.byId("contentArea") as VBox).addItem(input);
-		}
+		(this.byId("contentArea") as VBox).addItem(input);
+
 		console.log(`Input is a @ui5.webcomponents.dist.Input: ${input.isA("@ui5.webcomponents.dist.Input")}`);
 		console.log(`Input is a @ui5.webcomponents.Input: ${input.isA("@ui5.webcomponents.Input")}`);
+	}
+
+	public onNativeClick(): void {
+		this.isAnimating = !this.isAnimating;
+
+		if (!this.isAnimating) {
+			cancelAnimationFrame(this.animationId);
+		}
+
+		this.animate();
+	}
+
+	public animate() {
+		if (!this.isAnimating) return;
+		const progressBar = this.byId("myProgressBar") as unknown as Progress;
+
+		let v = parseInt(progressBar.getValue(), 10) + 1;
+		v %= 100;
+		progressBar.setValue(`${v}`);
+
+		// Continue animation
+		this.animationId = requestAnimationFrame(this.animate.bind(this));
 	}
 
 	public onNavToDynamicPage(): void {

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -287,7 +287,8 @@
           <h:P text="This is a checkbox:" />
           <webc:CheckBox text="inside Div" />
           <h:P>
-            <h:A href="https://ui5.sap.com" data-sap-ui-test="12" enabled="true" text="link to demokit" />
+            <h:A href="https://ui5.sap.com" text="link to demokit" />
+            <!-- <h:Input disabled="false" /> -->
           </h:P>
         </h:Div>
       </h:Div>

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -272,7 +272,7 @@
         </webc:Tree>
       </webc:Panel>
 
-      <!-- Not supported as of now, but would be nice to have -->
+      <!-- HTML sample -->
       <h:Div
         style="
         background: #FAFAFA;
@@ -282,14 +282,15 @@
         padding: 10px;
         margin: 10px"
       >
-        <h:Div style="border-bottom: 1px solid #D0D0D0; padding: 2px;" text="I'm a self made card :)" />
-        <h:Div>
-          <h:P text="This is a checkbox:" />
-          <webc:CheckBox text="inside Div" />
-          <h:P>
-            <h:A href="https://ui5.sap.com" text="link to demokit" />
-            <!-- <h:Input disabled="false" /> -->
-          </h:P>
+        <h:Div style="border-bottom: 1px solid #D0D0D0; padding: 2px;" text="Pure HTML in a custom card" />
+        <h:Div style="display: flex; flex-direction: column; gap: 1rem; padding: 0.5rem;">
+          <h:P text="I'm a paragraph §" />
+          <h:A href="https://ui5.sap.com" text="link to UI5 demo kit" />
+          <h:Button text="Native Button with Event Handler in Controller" value="hello world" click=".onNativeClick" />
+          <h:Progress id="myProgressBar" max="100" value="70" />
+          <h:Input type="Text" placeholder="I'm a placeholder text..." />
+          <!-- public domain audio from wikimedia commons: https://commons.wikimedia.org/wiki/File:The_Entertainer_-_Scott_Joplin.ogg -->
+          <h:Audio id="myAudioPlayer" controls="true" src="https://upload.wikimedia.org/wikipedia/commons/1/1b/The_Entertainer_-_Scott_Joplin.ogg" />
         </h:Div>
       </h:Div>
     </content>

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -9,6 +9,7 @@
   xmlns:webc="@ui5/webcomponents/dist"
   xmlns:fiori="@ui5/webcomponents-fiori/dist"
   xmlns:ai="@ui5/webcomponents-ai/dist"
+  xmlns:h="@ui5/html"
   core:require="{
     Formatter: 'ui5/ecosystem/demo/webctsapp/model/Formatter',
     iconUI5: '@ui5/webcomponents-icons/dist/sap-ui5',
@@ -272,29 +273,24 @@
       </webc:Panel>
 
       <!-- Not supported as of now, but would be nice to have -->
-      <!-- <h:div style="
+      <h:Div
+        style="
         background: #FAFAFA;
         border-bottom: 2px solid #777777;
         border-radius: 5px;
         box-shadow: 0px 5px 10px #999999;
         padding: 10px;
-        margin: 10px">
-        <h:div style="border-bottom: 1px solid #D0D0D0; padding: 2px;">
-          I'm a self made card :)
-        </h:div>
-        <h:div>
-          <h:p>This is a checkbox:</h:p>
-          <webc:CheckBox text="inside div" />
-          <h:p>
-            <h:a href="https://ui5.sap.com" data-sap-ui-test="12" enabled="true">link to demokit</h:a>
-          </h:p>
-          <h:p>
-            text content before the &lt;hr&gt;...
-            <h:hr />
-            ... and text content after the &lt;hr&gt;.
-          </h:p>
-        </h:div>
-      </h:div> -->
+        margin: 10px"
+      >
+        <h:Div style="border-bottom: 1px solid #D0D0D0; padding: 2px;" text="I'm a self made card :)" />
+        <h:Div>
+          <h:P text="This is a checkbox:" />
+          <webc:CheckBox text="inside Div" />
+          <h:P>
+            <h:A href="https://ui5.sap.com" data-sap-ui-test="12" enabled="true" text="link to demokit" />
+          </h:P>
+        </h:Div>
+      </h:Div>
     </content>
   </Page>
 </mvc:View>

--- a/showcases/ui5-tsapp-webc/webapp/view/fiori/DynamicPage.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/fiori/DynamicPage.view.xml
@@ -2,6 +2,7 @@
   controllerName="ui5.ecosystem.demo.webctsapp.controller.DynamicPage"
   displayBlock="true"
   xmlns:m="sap.m"
+  xmlns="@ui5/html/dist"
   xmlns:core="sap.ui.core"
   xmlns:mvc="sap.ui.core.mvc"
   xmlns:webc="@ui5/webcomponents/dist"
@@ -88,7 +89,7 @@
       </fiori:DynamicPageHeader>
     </fiori:headerArea>
 
-    <webc:List items="{dpModel>/items}" headerText="Products" selectionMode="None">
+    <!-- <webc:List items="{dpModel>/items}" headerText="Products" selectionMode="None">
       <webc:ListItemStandard icon="slim-arrow-right" iconEnd="true" description="{dpModel>productID}" additionalText="{dpModel>price}" text="{dpModel>productName}">
         <webc:image>
           <webc:Avatar size="S" shape="Square" colorScheme="Accent10">
@@ -96,19 +97,19 @@
           </webc:Avatar>
         </webc:image>
       </webc:ListItemStandard>
-    </webc:List>
+    </webc:List> -->
 
     <!-- pure HTML sample, not supported as of now... but would be nice to have in the future -->
-    <!-- <h:div children="{dpModel>/items}">
-        <h:div>
-            <h:span>
-                <webc:Avatar size="S" shape="Square" colorScheme="Accent10">
-                    <m:Image src="{dpModel>imageSrc}" />
-                </webc:Avatar>
-            </h:span>
-            <h:span>{dpModel&gt;productID}<h:span/>
-        </h:div>
-    </h:div> -->
+    <Ul children="{dpModel>/items}">
+      <Li>
+        <Span>
+          <webc:Avatar size="S" shape="Square" colorScheme="Accent10">
+            <Img src="{dpModel>imageSrc}" />
+          </webc:Avatar>
+        </Span>
+        <Span text="{dpModel>productID}" />
+      </Li>
+    </Ul>
 
     <fiori:footerArea>
       <webc:Bar design="FloatingFooter">


### PR DESCRIPTION
The rollup plugin for webcomponents now properly handles sap/ui/core/html/HTMLElement as a base class. This allows webcomponents to extend from it and be properly integrated into the UI5 rendering.

The WebComponentRegistry is now able to resolve the superclass for webcomponents in the @ui5/html namespace to sap.ui.core.html.HTMLElement.

Helper functions isUi5CoreHTMLElement and isHTMLElementBase have been added to WebComponentRegistryHelper.js to facilitate this change.