### PR TITLE
fix(ui5-tooling-modules): resolve XML namespaces defined inline on elements

### DIFF
--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -735,7 +735,9 @@ module.exports = function (log, projectInfo) {
 									let module = nodeParts[2];
 									if (module !== "#text") {
 										// only add those dependencies whose namespace is known
-										let namespace = ns[nodeParts[1] || ""];
+										//  - in some cases the ns is defined directly at the element
+										//    this is handled by the OR case here to avoid recursive parsing
+										let namespace = ns[nodeParts[1] || ""] || (nodeParts[1] && child[`@_xmlns:${nodeParts[1]}`]);
 										if (typeof namespace === "string") {
 											namespace = namespace.replace(/\./g, "/");
 											addUniqueNamespace(namespace);

--- a/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
+++ b/showcases/ui5-tsapp-webc/webapp/view/Main.view.xml
@@ -8,11 +8,12 @@
   xmlns:ca="http://schemas.sap.com/sapui5/extension/sap.ui.core.CustomData/1"
   xmlns:webc="@ui5/webcomponents/dist"
   xmlns:fiori="@ui5/webcomponents-fiori/dist"
-  xmlns:ai="@ui5/webcomponents-ai/dist"
   core:require="{
     Formatter: 'ui5/ecosystem/demo/webctsapp/model/Formatter',
     iconUI5: '@ui5/webcomponents-icons/dist/sap-ui5',
     iconAI: '@ui5/webcomponents-icons/dist/ai',
+    iconStop: '@ui5/webcomponents-icons/dist/stop',
+    iconNavigationDownArrow: '@ui5/webcomponents-icons/dist/navigation-down-arrow',
     iconBiometric: '@ui5/webcomponents-icons/dist/biometric-face',
     iconBadge: '@ui5/webcomponents-icons/dist/badge',
     iconAccept: '@ui5/webcomponents-icons/dist/accept',
@@ -134,7 +135,7 @@
             </customData>
           </Button>
           <webc:Button text="webc Button" click="onBoo" class="buttonSpacing" />
-          <ai:Button id="myAiButton" state="generate">
+          <ai:Button id="myAiButton" state="generate" xmlns:ai="@ui5/webcomponents-ai/dist">
             <ai:ButtonState name="generate" text="Generate" icon="ai" />
             <ai:ButtonState name="generating" text="Stop Generating" icon="stop" />
             <ai:ButtonState name="revise" text="Revise" icon="ai" endIcon="navigation-down-arrow" />


### PR DESCRIPTION
The XML view parser now handles cases where a namespace prefix is defined directly on the element using it (e.g. xmlns:ai="..." on the ai:Button element itself) rather than only at the root view level.

## Summary
- Fix XML view parser to resolve namespace prefixes defined directly on the element (e.g. `xmlns:ai="..."` on `<ai:Button>`) rather than requiring them at the root view level
- Added inline namespace usage example in the webc TypeScript showcase

## Test plan
- [x] Verify existing tests pass (`npm test` in `packages/ui5-tooling-modules`)
- [x] Confirm the webc showcase app builds and the ai:Button renders correctly
