### PR TITLE
chore: simplify LICENSE and standardize README license sections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,3 @@
-/*
- * ----------------------------------------------------------------------------
- * "THE DERIVED BEER-WARE LICENSE" (Revision 1):
- * You can do whatever you want with this stuff. When you like it, just buy
- * Volker Buzek (@vobu) a beer or buy Peter Muessig (@pmuessig) a coke when
- * you see one of them.
- *
- * Inspired by the official: https://fedoraproject.org/wiki/Licensing/Beerware
- *
- * "THE BEER-WARE LICENSE" (Revision 42):
- * <phk@FreeBSD.ORG> wrote this file. As long as you retain this notice you
- * can do whatever you want with this stuff. If we meet some day, and you think
- * this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp
- * ----------------------------------------------------------------------------
- */
-
----
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -223,31 +204,5 @@
 APIs
 
 This project may include APIs to SAP or third party products or services. The use of these APIs, products and services may be subject to additional agreements. In no event shall the application of the Apache Software License, v.2 to this project grant any rights in or to these APIs, products or services that would alter, expand, be inconsistent with, or supersede any terms of these additional agreements. “API” means application programming interfaces, as well as their respective specifications and implementing code that allows other software products to communicate with or call on SAP or third party products or services (for example, SAP Enterprise Services, BAPIs, Idocs, RFCs and ABAP calls or other user exits) and may be made available through SAP or third party products, SDKs, documentation or other media.
-
-------------------------------------------------------------------------------
-SUBCOMPONENTS
-
-This project includes the following subcomponents that are subject to separate license terms.
-Your use of these subcomponents is subject to the separate license terms applicable to
-each subcomponent.
-
-Component: deploy.sh
-Licensor: Domenic Denicola
-Website: https://gist.github.com/domenic/ec8b0fc8ab45f39403dd/e445116166c79d7ac35eb38a5d348d546f3d1620
-License: MIT License
-<year> = 2018
-<copyright holders> = Domenic Denicola
-
-------------------------------------------------------------------------------
-
-The MIT License (MIT)
-
-Copyright <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -293,6 +293,6 @@ This project is open to feature requests/suggestions, bug reports etc. via [GitH
 
 ## License
 
-This work is [dual-licensed](LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/cds-plugin-ui5/README.md
+++ b/packages/cds-plugin-ui5/README.md
@@ -181,4 +181,6 @@ Any type of contribution (code contributions, pull requests, issues) to this set
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/dev-approuter/README.md
+++ b/packages/dev-approuter/README.md
@@ -180,4 +180,6 @@ Any type of contribution (code contributions, pull requests, issues) to this set
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/karma-ui5-transpile/README.md
+++ b/packages/karma-ui5-transpile/README.md
@@ -97,4 +97,6 @@ Any type of contribution (code contributions, pull requests, issues) to this set
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-approuter/README.md
+++ b/packages/ui5-middleware-approuter/README.md
@@ -176,6 +176,6 @@ see `test/auth/xs-app-with-localDir.json` for an example!
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-cap/README.md
+++ b/packages/ui5-middleware-cap/README.md
@@ -54,4 +54,6 @@ Any type of contribution (code contributions, pull requests, issues) to this set
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-iasync/README.md
+++ b/packages/ui5-middleware-iasync/README.md
@@ -70,6 +70,6 @@ Additionally, `iasync` injects custom HTML into `index.html`, manipulating brows
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-index/README.md
+++ b/packages/ui5-middleware-index/README.md
@@ -58,6 +58,6 @@ If you want to contribute to `ui5-middleware-index`, please use [`Prettier`](htt
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu), [@stefanbeck3](https://twitter.com/stefanbeck3), [github.com/margopolo](https://github.com/margopolo) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-livereload/README.md
+++ b/packages/ui5-middleware-livereload/README.md
@@ -164,6 +164,6 @@ yep, cross-browser, cross-platform.
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-onelogin/README.md
+++ b/packages/ui5-middleware-onelogin/README.md
@@ -88,4 +88,6 @@ server:
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-serveframework/README.md
+++ b/packages/ui5-middleware-serveframework/README.md
@@ -65,6 +65,6 @@ If you want to contribute to `ui5-middleware-serveframework`, please use [`Prett
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, you may buy [@pmuessig](https://twitter.com/pmuessig) a coke.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-servestatic/README.md
+++ b/packages/ui5-middleware-servestatic/README.md
@@ -72,6 +72,6 @@ The middleware integrates [serve-static](https://github.com/expressjs/serve-stat
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -130,6 +130,6 @@ More details can be found in the documentation of the UI5 CLI for the [`ui5 serv
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-ui5/README.md
+++ b/packages/ui5-middleware-ui5/README.md
@@ -134,4 +134,6 @@ The middleware searches for UI5 application projects in the project dependencies
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-webjars/README.md
+++ b/packages/ui5-middleware-webjars/README.md
@@ -80,6 +80,6 @@ If you want to contribute to `ui5-middleware-webjars`, please use [`Prettier`](h
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, you may buy [@vobu](https://twitter.com/vobu) a beer or [@pmuessig](https://twitter.com/pmuessig) a coke.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-middleware-websocket/README.md
+++ b/packages/ui5-middleware-websocket/README.md
@@ -66,6 +66,6 @@ module.exports = ({ log }) => {
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see him.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-cachebuster/README.md
+++ b/packages/ui5-task-cachebuster/README.md
@@ -95,4 +95,6 @@ Use Cases:
 
 ## License
 
-This work is [licensed](../../LICENSE) under Apache 2.0.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-copyright/README.md
+++ b/packages/ui5-task-copyright/README.md
@@ -69,4 +69,6 @@ Any type of contribution (code contributions, pull requests, issues) to this sho
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-flatten-library/README.md
+++ b/packages/ui5-task-flatten-library/README.md
@@ -65,6 +65,6 @@ To learn more about this feature and to migrate your project to the native Outpu
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally, you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) or [@matthiaso](https://twitter.com/matthiaso) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-i18ncheck/README.md
+++ b/packages/ui5-task-i18ncheck/README.md
@@ -51,6 +51,6 @@ The task reads all XML views and i18n properties files. Then the task cross-chec
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally, you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) or [@fatihpense](https://twitter.com/fatihpense) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-minify-xml/README.md
+++ b/packages/ui5-task-minify-xml/README.md
@@ -64,4 +64,6 @@ builder:
 
 ## License
 
-This work is [licensed](../../LICENSE) under the Apache 2.0 license.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-pwa-enabler/README.md
+++ b/packages/ui5-task-pwa-enabler/README.md
@@ -115,6 +115,6 @@ your own fancy PWA.
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@maxmoehl](https://github.com/maxmoehl) or [@monakac](https://github.com/monakac) a beer when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-task-zipper/README.md
+++ b/packages/ui5-task-zipper/README.md
@@ -88,7 +88,6 @@ The task can be used to zip all project resources in an archive.
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) or [@IObert_](https://twitter.com/IObert_) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
-diff --git a/packages/ui5-task-zipper/readme.md b/packages/ui5-task-zipper/readme.md
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-tooling-less/README.md
+++ b/packages/ui5-tooling-less/README.md
@@ -90,6 +90,6 @@ builder:
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@sebbi](https://app.slack.com/client/T0A7MQSJ1/D01TDU3RMSQ/user_profile/UBV5L8N8M) a beer or buy [@marcel_schork](https://twitter.com/marcel_schork) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -299,6 +299,6 @@ Any type of contribution (code contributions, pull requests, issues) to this sho
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-tooling-stringreplace/README.md
+++ b/packages/ui5-tooling-stringreplace/README.md
@@ -137,6 +137,6 @@ Technically, the middleware intercepts the response for all requests matching th
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally, you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) or [@TheVivekGowda](https://twitter.com/TheVivekGowda) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -193,6 +193,6 @@ Any type of contribution (code contributions, pull requests, issues) to this set
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/packages/ui5-utils-express/README.md
+++ b/packages/ui5-utils-express/README.md
@@ -6,4 +6,6 @@ Utilities for the [express](http://expressjs.com/) web framework (web server).
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/cds-bookshop-ui5-viewer/README.md
+++ b/showcases/cds-bookshop-ui5-viewer/README.md
@@ -6,4 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/cds-bookshop/README.md
+++ b/showcases/cds-bookshop/README.md
@@ -15,4 +15,6 @@ Learn more at https://cap.cloud.sap/docs/get-started/.
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/cds-bookshop/app/ui5-bookshop/README.md
+++ b/showcases/cds-bookshop/app/ui5-bookshop/README.md
@@ -8,4 +8,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-app-simple/README.md
+++ b/showcases/ui5-app-simple/README.md
@@ -6,6 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-app/README.md
+++ b/showcases/ui5-app/README.md
@@ -6,6 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-bookshop-viewer/README.md
+++ b/showcases/ui5-bookshop-viewer/README.md
@@ -6,4 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-tsapp-simple/README.md
+++ b/showcases/ui5-tsapp-simple/README.md
@@ -6,6 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-tsapp-webc/README.md
+++ b/showcases/ui5-tsapp-webc/README.md
@@ -6,6 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-tsapp/README.md
+++ b/showcases/ui5-tsapp/README.md
@@ -6,6 +6,6 @@ Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order 
 
 ## License
 
-This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.
+This work is licensed under [Apache 2.0](../../LICENSE).
 
-When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) a coke when you see them.
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.


### PR DESCRIPTION
## Summary

- **LICENSE**: drop the Beerware dual-license preamble and the `SUBCOMPONENTS` / MIT block (which referenced files and a `deploy.sh` that do not exist in the repo). Keep pure Apache 2.0 plus the SAP / third-party APIs disclaimer.
- **READMEs (37 files)**: standardize the `## License` section to link to the top-level [`LICENSE`](LICENSE) and replace the per-contributor attribution line with a generic, contributor-agnostic thank-you note:

  > Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

No source files carried Beerware headers, and all `package.json` files in the monorepo already declare `Apache-2.0`, so no further changes were required there.

## Test plan

- [x] Sanity-check the `## License` section in a few READMEs renders correctly on GitHub
- [x] Confirm `LICENSE` still contains the Apache 2.0 text and the SAP/third-party APIs disclaimer
- [x] Verify relative links from package and showcase READMEs to the top-level `LICENSE` resolve