### PR TITLE
docs: correct README references and document showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ showcases
 ├── ui5-module                      // UI5 module providing a custom control as NPM package
 ├── ui5-tsapp                       // TypeScript UI5 application
 ├── ui5-tsapp-simple                // simple TypeScript UI5 application using UI5 CLI V3
-└── ui5-tslib                       // TypeScript UI5 library
+├── ui5-tsapp-webc                  // TypeScript UI5 application using UI5 Web Components
+├── ui5-tslib                       // TypeScript UI5 library
+└── ui5-tsmodule                    // TypeScript UI5 module providing a custom control as NPM package
 ```
 
 ## Getting Started
@@ -200,7 +202,7 @@ Available middlewares in this project:
 | [ui5-middleware-iasync](packages/ui5-middleware-iasync/README.md) | sync UI interactions across connected browsers (alpha! careful!) | [![npm version](https://badge.fury.io/js/ui5-middleware-iasync.svg)](https://badge.fury.io/js/ui5-middleware-iasync) |
 | [ui5-middleware-index](packages/ui5-middleware-index/README.md) | serve an HTML file for / (root) | [![npm version](https://badge.fury.io/js/ui5-middleware-index.svg)](https://badge.fury.io/js/ui5-middleware-index) |
 | [ui5-middleware-livereload](packages/ui5-middleware-livereload/README.md) | usage of livereload for development | [![npm version](https://badge.fury.io/js/ui5-middleware-livereload.svg)](https://badge.fury.io/js/ui5-middleware-livereload) |
-| [ui5-middleware-serveframework](packages/ui5-middleware-serveframework/README.md) | serve resources of a locally built framework | [![npm version](https://badge.fury.io/js/ui5-middleware-serveframework.svg)](https://badge.fury.io/js/ui5-middleware-servestatic) |
+| [ui5-middleware-serveframework](packages/ui5-middleware-serveframework/README.md) | serve resources of a locally built framework | [![npm version](https://badge.fury.io/js/ui5-middleware-serveframework.svg)](https://badge.fury.io/js/ui5-middleware-serveframework) |
 | [ui5-middleware-servestatic](packages/ui5-middleware-servestatic/README.md) | serve static resources | [![npm version](https://badge.fury.io/js/ui5-middleware-servestatic.svg)](https://badge.fury.io/js/ui5-middleware-servestatic) |
 | [ui5-middleware-onelogin](packages/ui5-middleware-onelogin/README.md) | enable a generic login support | [![npm version](https://badge.fury.io/js/ui5-middleware-onelogin.svg)](https://badge.fury.io/js/ui5-middleware-onelogin) |
 | [ui5-middleware-simpleproxy](packages/ui5-middleware-simpleproxy/README.md) | simple express proxy | [![npm version](https://badge.fury.io/js/ui5-middleware-simpleproxy.svg)](https://badge.fury.io/js/ui5-middleware-simpleproxy) |
@@ -258,7 +260,7 @@ A calling component accesses a target service by means of the application router
 
 #### `dev-approuter`
 
-[dev-approuter](packages/ui5-middleware-simpleproxy/README.md)
+[dev-approuter](packages/dev-approuter/README.md)
 
 The `dev-approuter` is a development time tooling only for the [SAP Application Router](https://www.npmjs.com/package/@sap/approuter) that can serve [UI5](https://ui5.sap.com/) and [SAP Cloud Application Programming Model (CAP)](https://cap.cloud.sap/docs/) apps that are added as (dev)dependencies to the approuter's `package.json`.
 

--- a/packages/dev-approuter/README.md
+++ b/packages/dev-approuter/README.md
@@ -22,6 +22,7 @@ The `dev-approuter` is a dev time wrapper for the [SAP Application Router](https
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/en) version 18 or higher.
+- [`@sap/approuter`](https://www.npmjs.com/package/@sap/approuter) version 22 or higher (pulled in as a dependency).
 
 ## Starting the `dev-approuter`
 

--- a/packages/dev-approuter/package.json
+++ b/packages/dev-approuter/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",
     "directory": "packages/dev-approuter"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@sap/approuter": ">=22",
     "@sap/xsenv": "6.2.1",

--- a/showcases/approuter/README.md
+++ b/showcases/approuter/README.md
@@ -1,0 +1,22 @@
+# Showcase for the `dev-approuter`
+
+This showcase demonstrates the [`dev-approuter`](../../packages/dev-approuter/README.md), a dev time wrapper for the [SAP Application Router](https://www.npmjs.com/package/@sap/approuter) that can serve UI5 and SAP CDS apps added as `devDependencies`.
+
+Peek at [`package.json`](package.json) and the `xs-app.json`/`xs-dev.json` files in this folder to learn how the approuter is configured and which UI5/CDS apps are wired in as dev dependencies.
+
+## Getting started
+
+From the repository root (after a one-time `pnpm install`):
+
+```bash
+pnpm dev-approuter      # run via the dev-approuter wrapper (recommended for development)
+pnpm start-approuter    # run via the plain @sap/approuter, mimicking productive setup
+```
+
+The approuter listens on port `5000` by default. Set `PORT=…` (or a `default-env.json`) to change it.
+
+## License
+
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-lib/README.md
+++ b/showcases/ui5-lib/README.md
@@ -1,0 +1,30 @@
+# UI5 library showcase
+
+This sample shows a setup for developing a UI5 library, including dev server, build, linting, and Karma-based unit tests.
+
+Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order to learn about the UI5 CLI configuration and its' `npm` package dependencies and configuration options.
+
+## Getting started
+
+From the repository root (after a one-time `pnpm install`):
+
+```bash
+pnpm dev-lib            # run the UI5 dev server (opens the example page on http://localhost:8080)
+pnpm build-lib          # build the library to ./dist
+```
+
+Or from inside this folder:
+
+```bash
+pnpm dev                # dev server
+pnpm build              # build to ./dist
+pnpm start              # serve the built ./dist via ui5-dist.yaml
+pnpm testsuite          # open the QUnit testsuite in the browser
+pnpm test               # lint + Karma headless tests with coverage
+```
+
+## License
+
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-module/README.md
+++ b/showcases/ui5-module/README.md
@@ -1,0 +1,25 @@
+# UI5 module showcase
+
+This sample shows a UI5 module providing a custom control packaged as an NPM package. The module is consumed by other showcases (e.g. [`ui5-app`](../ui5-app/README.md)) via the [`ui5-tooling-modules`](../../packages/ui5-tooling-modules/README.md) extension.
+
+Peek at [`package.json`](package.json) and the source files in this folder to learn how the custom control is shaped and exported.
+
+## Getting started
+
+This module has no own dev server or build step — it is consumed in source form by other showcases through pnpm's workspace linking. After a one-time `pnpm install` at the repository root, simply run a consuming showcase, e.g.:
+
+```bash
+pnpm dev          # runs the ui5-app showcase, which uses this module
+```
+
+To lint the sources locally:
+
+```bash
+pnpm lint
+```
+
+## License
+
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-tslib/README.md
+++ b/showcases/ui5-tslib/README.md
@@ -1,0 +1,32 @@
+# TypeScript UI5 library showcase
+
+This sample shows a TypeScript setup for developing a UI5 library, including dev server, build, linting, type checking, JSDoc generation, and Karma-based unit tests.
+
+Peek at both [`ui5.yaml`](ui5.yaml) and [`package.json`](package.json) in order to learn about the UI5 CLI configuration and its' `npm` package dependencies and configuration options.
+
+## Getting started
+
+From the repository root (after a one-time `pnpm install`):
+
+```bash
+pnpm dev-lib:ts         # run the UI5 dev server (opens the example page on http://localhost:8080)
+pnpm build-lib:ts       # build the library to ./dist
+```
+
+Or from inside this folder:
+
+```bash
+pnpm dev                # dev server
+pnpm build              # build to ./dist
+pnpm start              # serve the built ./dist via ui5-dist.yaml
+pnpm ts-typecheck       # TypeScript type-check only (no emit)
+pnpm testsuite          # open the QUnit testsuite in the browser
+pnpm test               # lint + Karma headless tests with coverage
+pnpm jsdoc              # generate JSDoc output
+```
+
+## License
+
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.

--- a/showcases/ui5-tsmodule/README.md
+++ b/showcases/ui5-tsmodule/README.md
@@ -1,0 +1,22 @@
+# TypeScript UI5 module showcase
+
+This sample shows a TypeScript UI5 module that can be consumed by UI5 apps via the [`ui5-tooling-modules`](../../packages/ui5-tooling-modules/README.md) extension.
+
+Peek at [`package.json`](package.json) and the source files in this folder to learn how the module is shaped and exported.
+
+## Getting started
+
+After a one-time `pnpm install` at the repository root, the module is linked into consuming showcases automatically. To compile the TypeScript sources or lint locally, run from inside this folder:
+
+```bash
+pnpm build              # compile TypeScript via tsc
+pnpm lint               # run eslint
+```
+
+A consuming showcase such as [`ui5-tsapp`](../ui5-tsapp/README.md) will pick this module up via pnpm's workspace linking — start it from the repository root with `pnpm dev:ts`.
+
+## License
+
+This work is licensed under [Apache 2.0](../../LICENSE).
+
+Built with care (and a lot of caffeine). If this helped you build, test, or ship, the next coffee — or drink — is on you when you bump into a contributor.


### PR DESCRIPTION
## Summary
- Fix three correctness bugs in the root [README.md](README.md): missing `ui5-tsapp-webc`/`ui5-tsmodule` entries in the showcases overview, a wrong npm badge URL for `ui5-middleware-serveframework` (was pointing at servestatic), and a broken `dev-approuter` link (was pointing at `ui5-middleware-simpleproxy`).
- Align [packages/dev-approuter](packages/dev-approuter/) docs with reality: declare the `engines.node >=18` field already required by the README, and surface the `@sap/approuter >= 22` prerequisite in the README itself.
- Add minimal READMEs (with a short Getting Started section) for the previously undocumented showcases: `approuter`, `ui5-lib`, `ui5-module`, `ui5-tslib`, `ui5-tsmodule`. They follow the same minimal style as the existing showcase READMEs and link to the root LICENSE.

## Test plan
- [ ] `git diff origin/main...chore/docs-readme-update` reviewed — only docs + one `package.json` engines field
- [ ] Markdown renders correctly on GitHub (links, badges, code fences)
- [ ] Showcase READMEs match the actual scripts in their `package.json`