### PR TITLE
fix(ui5-tooling-modules): rework bundle cache invalidation

### DIFF
--- a/packages/ui5-tooling-modules/OVERVIEW.md
+++ b/packages/ui5-tooling-modules/OVERVIEW.md
@@ -1,7 +1,7 @@
 # ui5-tooling-modules
 
-**Package Version:** 3.34.5
-**Last Updated:** 2026-02-11
+**Package Version:** 3.36.0
+**Last Updated:** 2026-05-22
 
 ---
 
@@ -68,7 +68,7 @@ UI5 App Code → Scan Dependencies → Bundle with Rollup → Transform to AMD �
   - **Package.json Export Resolution**: Implements Node.js package entry points (exports, browser, main fields)
   - **Dependency Graph Analysis**: Transitive dependency resolution
   - **Wildcard Mapping**: Handles package.json wildcard exports
-  - **Module Caching**: MD5-based cache keys with lastModified tracking
+  - **Module Caching**: SHA-256 layered fingerprint cache keys covering tool sources, configuration, lockfile, and the transitive module graph (see [Caching Architecture](#4-caching-architecture))
 
 #### 4. **Rollup Plugin Ecosystem**
 
@@ -88,26 +88,36 @@ Core plugins in the transformation pipeline:
 
 ## Recent Changes & Current State
 
-### Modified Files (From Git Status)
-The following files have uncommitted changes:
+### Bundle Cache Invalidation Rework
 
-1. **[rollup-plugin-webcomponents.js](lib/rollup-plugin-webcomponents.js)** (Modified)
-   - Added `filterForExternalModules` parameter to plugin options
-   - Added external module filtering in two places:
-     - Before emitting chunks (line 172)
-     - In resolveId hook (line 428)
-   - **Purpose**: Prevent bundling of external dependencies that are provided by other UI5 libraries
+The cache key construction in [util.js](lib/util.js) was reworked end-to-end. The previous key only mixed `mtime(util.js)` + the max `mtime` of the entry modules, which silently reused stale bundles in several common scenarios. See [CACHE-INVALIDATION.md](CACHE-INVALIDATION.md) for the full design and gap analysis.
 
-2. **[task.js](lib/task.js)** (Modified)
-   - Changes not yet committed (likely related to namespace handling or path rewriting)
+**What changed:**
 
-3. **[util.js](lib/util.js)** (Modified)
-   - Changes not yet committed (likely dependency resolution improvements)
+1. **Layered SHA-256 cache key** (replaces the old `md5(myLastModified:lastModified:entry-paths)` key). The new key combines four independent fingerprints, joined with `:` and SHA-256-hashed:
+   - `getToolFingerprint()` — package version + every `.js`/`.mjs`/`.cjs`/`.hbs` file under `lib/`. Memoized once per process.
+   - `getConfigFingerprint(opts)` — stable JSON of all bundle-affecting options (`pluginOptions`, `generatedCode`, `minify`, `inject`, `sourcemap`, `keepDynamicImports`, `skipTransform`, `dynamicEntriesPath`).
+   - `getLockfileFingerprint(cwd)` — `package.json` + nearest lockfile (`pnpm-lock.yaml` / `package-lock.json` / `yarn.lock` / `npm-shrinkwrap.json`), discovered by walking up from `cwd`. Memoized per `(lockfile, package.json)` mtime.
+   - `getInputGraphFingerprint(paths)` — sorted `path\0size\0mtime` triples for the entry modules.
+2. **Two-phase validation for the persistent cache.** When `persistentCache: true`, the recorded transitive module graph (`relatedPaths` on the persisted `BundleInfo`) is re-stat'd on load. A mismatch returns `undefined` from `BundleInfoCache.get()`, forcing a rebuild. This is the case `git checkout` can fool (mtime is rewritten to checkout time, not commit time), so a stale persisted entry can no longer slip past the cheap entry-mtime check.
+3. **`BundleInfo` carries `_inputFingerprint`.** Captured at `BundleInfoCache.store()` time and serialized through `toJSON()` / `fromJSON()`.
+4. **`md5` → `sha256` everywhere.** Both the bundle cache key and `resolveModule`'s `modulesCache` key. No measurable perf impact at these input sizes; silences security scanners flagging `md5`.
+
+**Gaps this closes (vs. the previous key):**
+
+- Editing `rollup-plugin-webcomponents.js`, `rollup-plugin-modules.js`, `WebComponentRegistry.js`, `DTSSerializer.js`, `JSDocSerializer.js`, or any `templates/**/*.hbs` now busts the cache.
+- Bumping `ui5-tooling-modules` itself in `node_modules` (e.g. fresh `pnpm install`) busts the cache.
+- Toggling `minify` / `sourcemap` / `generatedCode` / `inject` / `keepDynamicImports` / `skipTransform` / `dynamicEntriesPath` / `pluginOptions` busts the cache.
+- A change deep in a transitive dependency busts the cache (verified on persistent-cache load).
+- A `pnpm-lock.yaml` / `package-lock.json` bump busts the cache.
+- Fresh `git checkout` / CI runs no longer reuse stale persisted entries.
 
 ### Recent Commit History
 
 | Commit | Description | Impact |
 |--------|-------------|--------|
+| `485131bc` | Allow deeper nested web component classes of the same name (#1318) | Improved Web Components class resolution |
+| `153841c2` | Update dependencies and bump OpenUI5 to 1.148.0 (#1349) | Dependency refresh |
 | `8a5cd402` | Robust parsing and handling of webc metadata (#1316) | Improved Web Components metadata handling |
 | `d7ab7a8e` | Properly lookup package.json for workspaces (#1314) | Fixed workspace/monorepo support |
 | `1ca62f1e` | Import base package for all entry modules (#1310) | Fixed Web Components base package imports |
@@ -177,22 +187,52 @@ NPM Package → CEM Parsing → WebComponentRegistry → UI5 Wrapper Generation 
 
 ### 4. Caching Architecture
 
-Two-tier caching system:
+Two-tier caching system with a layered SHA-256 fingerprint as the cache key. See [CACHE-INVALIDATION.md](CACHE-INVALIDATION.md) for the full design rationale.
 
-**In-Memory Cache** (BundleInfoCache):
-- Cache key: MD5(lastModified + moduleNames + paths)
-- Stores complete BundleInfo objects
+**In-Memory Cache** (`BundleInfoCache`, [util.js](lib/util.js)):
+
+- Stores complete `BundleInfo` objects keyed by the layered fingerprint
 - Cleared on process restart
 
-**Persistent Cache** (when enabled):
-- Location: `.ui5-tooling-modules/*.bundleinfo.json`
+**Persistent Cache** (when `persistentCache: true`):
+
+- Location: `<cwd>/.ui5-tooling-modules/<key>.bundleinfo.json`
 - Survives server restarts
 - Should be gitignored
+- On load, the recorded transitive module graph is re-stat'd against disk; mismatches force a rebuild
 
-**Cache Invalidation**:
-- Triggered by file changes (via Chokidar watcher)
-- MD5 hash includes file modification times
-- Util.js modification time included in cache key
+#### Cache Key Construction
+
+The bundle cache key is the SHA-256 of four colon-joined fingerprints:
+
+```
+sha256(toolFp : configFp : lockfileFp : entryGraphFp : "name@path,...")
+```
+
+| Layer | Inputs | Cost |
+| ----- | ------ | ---- |
+| `getToolFingerprint()` | `name@version` + every `.js`/`.mjs`/`.cjs`/`.hbs` under `lib/` (content-hashed) | Paid once per process (memoized) |
+| `getConfigFingerprint(opts)` | Stable JSON of `pluginOptions`, `generatedCode`, `minify`, `inject`, `sourcemap`, `keepDynamicImports`, `skipTransform`, `dynamicEntriesPath` | Negligible (single hash of a small JSON string) |
+| `getLockfileFingerprint(cwd)` | `package.json` + nearest lockfile (pnpm/npm/yarn) | Memoized per `(lockfile, package.json)` mtime |
+| `getInputGraphFingerprint(paths)` | Sorted `path\0size\0mtime` triples for entry modules | One `stat()` per entry module |
+
+#### Two-Phase Validation
+
+The cache check happens *before* `createBundle()`, but the full transitive module graph is only known *after* (Rollup discovers it during bundling). The fast/slow split:
+
+- **Fast pre-check** (every cache lookup): hash entry-module path/size/mtime + the layers above. Cheap.
+- **Confirmation step** (persistent-cache load only): re-stat the recorded `relatedPaths` on the persisted `BundleInfo` and compare against the stored `_inputFingerprint`. Catches the `git checkout` / CI case where mtime is rewritten to checkout time and the entry-mtime check would otherwise pass.
+
+After each successful build, `BundleInfoCache.store()` captures `getInputGraphFingerprint(bundleInfo.getRelatedPaths())` onto the `BundleInfo` so the next persistent load can verify it.
+
+#### What invalidates the cache (automatically)
+
+- `ui5-tooling-modules` version bump (covered by tool fingerprint)
+- Any edit under `lib/**/*.{js,mjs,cjs,hbs}` (covered by tool fingerprint)
+- Any change to `pluginOptions` / `minify` / `sourcemap` / `inject` / `generatedCode` / `keepDynamicImports` / `skipTransform` / `dynamicEntriesPath` (covered by config fingerprint)
+- `package.json` or lockfile change in any ancestor of `cwd` (covered by lockfile fingerprint)
+- Add/remove/edit of any entry module (covered by entry-graph fingerprint)
+- Edit of any transitive dependency, when loading the persistent cache (covered by the confirmation step on `relatedPaths`)
 
 ### 5. Dependency Rewriting
 

--- a/packages/ui5-tooling-modules/README.md
+++ b/packages/ui5-tooling-modules/README.md
@@ -61,11 +61,11 @@ The following configuration options are relevant for the `task` and the `middlew
   &nbsp;
 
 - *skipCache*: `boolean`
-  For development scenarios, the module cache can be disabled by setting this option to true. Normally, if a module changes (e.g. bundledefs), this change is detected and the bundle is recreated. This just forces the regeneration always (defaults to `false`)
+  For development scenarios, the module cache can be disabled by setting this option to true. Normally the cache is invalidated automatically whenever any of the following change: the `ui5-tooling-modules` version itself, any of its source files, the resolved configuration (e.g. `minify`, `inject`, `pluginOptions`), the project's `package.json`/lockfile, or any file in the bundle's transitive module graph. This option just forces the regeneration always (defaults to `false`)
   &nbsp;
 
 - *persistentCache*: `boolean` *experimental feature*
-  With this option, the bundle information will be persistent and will be available again after the restart of the development server or for the next execution of your build task. The bundle information is stored in the working directory in the folder `.ui5-tooling-modules` folder. It's recommended to put this folder into `.gitignore` (defaults to `false`)
+  With this option, the bundle information will be persistent and will be available again after the restart of the development server or for the next execution of your build task. The bundle information is stored in the working directory in the folder `.ui5-tooling-modules` folder. It's recommended to put this folder into `.gitignore`. On load, persisted entries are validated against the recorded transitive module graph (path + size + mtime) so a fresh checkout or CI run cannot silently reuse a stale bundle. (defaults to `false`)
   &nbsp;
 
 - *keepDynamicImports*: `boolean|String[]` *experimental feature*

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -28,6 +28,156 @@ const parseJS = require("./utils/parseJS");
 const { createHash } = require("crypto");
 const sanitize = require("sanitize-filename");
 
+// ============================================================================
+// Cache invalidation helpers — sha256 layered fingerprint (Option A)
+// See packages/ui5-tooling-modules/CACHE-INVALIDATION.md for the design.
+// ============================================================================
+
+const TOOL_LIB_DIR = __dirname;
+const LOCKFILE_NAMES = ["pnpm-lock.yaml", "package-lock.json", "yarn.lock", "npm-shrinkwrap.json"];
+const TOOL_SOURCE_EXTS = new Set([".js", ".mjs", ".cjs", ".hbs"]);
+const TOOL_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
+
+/**
+ * Recursively walks a directory, collecting files matching the given extensions.
+ * @param {string} dir directory to walk
+ * @param {string[]} [out] accumulator array (used by recursion)
+ * @returns {string[]} absolute file paths whose extension is in TOOL_SOURCE_EXTS
+ */
+function walkDirSync(dir, out = []) {
+	for (const dirent of readdirSync(dir, { withFileTypes: true })) {
+		if (dirent.isDirectory()) {
+			if (!TOOL_SKIP_DIRS.has(dirent.name)) {
+				walkDirSync(path.join(dir, dirent.name), out);
+			}
+		} else if (dirent.isFile() && TOOL_SOURCE_EXTS.has(path.extname(dirent.name))) {
+			out.push(path.join(dir, dirent.name));
+		}
+	}
+	return out;
+}
+
+/**
+ * Stable JSON stringification so config objects produce identical fingerprints
+ * regardless of key insertion order.
+ * @param {string|number|boolean|null|object|Array} obj value to serialize
+ * @returns {string} deterministic JSON string
+ */
+function stableStringify(obj) {
+	if (obj === null || typeof obj !== "object") return JSON.stringify(obj);
+	if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+	const keys = Object.keys(obj).sort();
+	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+let _toolFingerprint;
+/**
+ * Fingerprint of the tooling itself: package version + content of all source
+ * files under lib/ (js/mjs/cjs/hbs). Memoized for the lifetime of the process,
+ * so the I/O is paid once.
+ * @returns {string} sha256 hex digest of the tool sources
+ */
+function getToolFingerprint() {
+	if (_toolFingerprint) return _toolFingerprint;
+	const pkg = require("../package.json");
+	const files = walkDirSync(TOOL_LIB_DIR).sort();
+	const h = createHash("sha256");
+	h.update(`${pkg.name}@${pkg.version}\n`);
+	for (const f of files) {
+		h.update(`${path.relative(TOOL_LIB_DIR, f)}\0`);
+		h.update(readFileSync(f));
+		h.update("\0");
+	}
+	return (_toolFingerprint = h.digest("hex"));
+}
+
+/**
+ * Fingerprint of every option that affects bundle output.
+ * @param {object} opts the configuration options used by getBundleInfo
+ * @returns {string} sha256 hex digest of the stable JSON of `opts`
+ */
+function getConfigFingerprint(opts) {
+	const relevant = {
+		pluginOptions: opts.pluginOptions ?? null,
+		generatedCode: opts.generatedCode ?? null,
+		minify: !!opts.minify,
+		inject: opts.inject ?? null,
+		sourcemap: !!opts.sourcemap,
+		keepDynamicImports: opts.keepDynamicImports ?? null,
+		skipTransform: opts.skipTransform ?? null,
+		dynamicEntriesPath: opts.dynamicEntriesPath ?? null,
+	};
+	return createHash("sha256").update(stableStringify(relevant)).digest("hex");
+}
+
+const _lockfileFingerprintCache = new Map();
+/**
+ * Fingerprint of the project's package.json + lockfile, so dependency-version
+ * bumps invalidate the cache. Walks up from `cwd` to find the nearest lockfile.
+ * Memoized per (lockfile, package.json) mtime.
+ * @param {string} cwd current working directory to start the lockfile search from
+ * @returns {string} sha256 hex digest of the lockfile + package.json contents
+ */
+function getLockfileFingerprint(cwd) {
+	let lockfile;
+	let dir = cwd;
+	for (;;) {
+		for (const name of LOCKFILE_NAMES) {
+			const candidate = path.join(dir, name);
+			if (existsSync(candidate)) {
+				lockfile = candidate;
+				break;
+			}
+		}
+		if (lockfile) break;
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	const pkgJson = lockfile ? path.join(path.dirname(lockfile), "package.json") : path.join(cwd, "package.json");
+	const pkgJsonExists = existsSync(pkgJson);
+	const lockMtime = lockfile ? statSync(lockfile).mtimeMs : 0;
+	const pkgMtime = pkgJsonExists ? statSync(pkgJson).mtimeMs : 0;
+	const cacheKey = `${lockfile || ""}@${lockMtime}:${pkgJson}@${pkgMtime}`;
+	if (_lockfileFingerprintCache.has(cacheKey)) {
+		return _lockfileFingerprintCache.get(cacheKey);
+	}
+	const h = createHash("sha256");
+	if (lockfile) {
+		h.update(`${path.basename(lockfile)}\0`);
+		h.update(readFileSync(lockfile));
+		h.update("\0");
+	}
+	if (pkgJsonExists) {
+		h.update("package.json\0");
+		h.update(readFileSync(pkgJson));
+		h.update("\0");
+	}
+	const fp = h.digest("hex");
+	_lockfileFingerprintCache.set(cacheKey, fp);
+	return fp;
+}
+
+/**
+ * Fingerprint of a set of input file paths, using path + size + mtime. Used
+ * for both the cheap pre-bundle check (entry modules) and the full transitive
+ * graph validation step (recorded `relatedPaths` of a persisted BundleInfo).
+ * @param {string[]} paths absolute file paths to fingerprint
+ * @returns {string} sha256 hex digest of the path/size/mtime triples
+ */
+function getInputGraphFingerprint(paths) {
+	const h = createHash("sha256");
+	for (const p of [...new Set(paths)].sort()) {
+		try {
+			const st = statSync(p);
+			h.update(`${p}\0${st.size}\0${st.mtimeMs}\0`);
+		} catch {
+			h.update(`${p}\0MISSING\0`);
+		}
+	}
+	return h.digest("hex");
+}
+
 const { runInContext, createContext } = require("vm");
 
 const { minVersion } = require("semver");
@@ -280,7 +430,18 @@ class BundleInfoCache {
 		} else if (persist) {
 			const bundleInfoPath = this.#cachePath(key);
 			if (existsSync(bundleInfoPath)) {
-				return (this.#bundleInfoCache[key] = new BundleInfo().fromJSON(readFileSync(bundleInfoPath, { encoding: "utf8" })));
+				const loaded = new BundleInfo().fromJSON(readFileSync(bundleInfoPath, { encoding: "utf8" }));
+				// Re-stat the recorded transitive module graph as a confirmation step.
+				// On fresh checkouts (e.g. CI / `git checkout`) entry-only mtime checks
+				// can produce a false positive; this validates the full graph.
+				const recordedFp = loaded.getInputFingerprint();
+				if (recordedFp) {
+					const currentFp = getInputGraphFingerprint(loaded.getRelatedPaths());
+					if (recordedFp !== currentFp) {
+						return undefined;
+					}
+				}
+				return (this.#bundleInfoCache[key] = loaded);
 			}
 		}
 		return undefined;
@@ -288,6 +449,9 @@ class BundleInfoCache {
 	static store(key, bundleInfo, { persist } = {}) {
 		this.#bundleInfoCache[key] = bundleInfo;
 		if (persist) {
+			// Capture the transitive input graph fingerprint so a future persistent
+			// cache load can verify the recorded graph still matches disk state.
+			bundleInfo.setInputFingerprint(getInputGraphFingerprint(bundleInfo.getRelatedPaths()));
 			const bundleInfoPath = this.#cachePath(key);
 			mkdir(path.dirname(bundleInfoPath), { recursive: true })
 				.then(() => {
@@ -305,9 +469,18 @@ class BundleInfoCache {
  */
 class BundleInfo {
 	_entries = [];
+	_inputFingerprint = null;
 	fromJSON(s) {
-		this._entries = JSON.parse(s)._entries;
+		const parsed = JSON.parse(s);
+		this._entries = parsed._entries;
+		this._inputFingerprint = parsed._inputFingerprint ?? null;
 		return this;
+	}
+	setInputFingerprint(fp) {
+		this._inputFingerprint = fp;
+	}
+	getInputFingerprint() {
+		return this._inputFingerprint;
 	}
 	getEntry(name) {
 		return this._entries.find((entry) => entry.name === name);
@@ -839,7 +1012,7 @@ module.exports = function (log, projectInfo) {
 		// ignore module paths starting with a segment from the ignore list (TODO: maybe a better check?)
 		resolveModule: function resolveModule(moduleName, { cwd = process.cwd(), depPaths = [], additionalDeps = [] } = {}) {
 			// create a cache key for the module and check the cache
-			const cacheKey = createHash("md5")
+			const cacheKey = createHash("sha256")
 				.update(`${[moduleName, cwd, ...depPaths].sort().join(",")}`)
 				.digest("hex");
 			if (modulesCache[cacheKey]) {
@@ -1284,9 +1457,9 @@ module.exports = function (log, projectInfo) {
 						: skipTransform;
 				};
 
-				// determine the list of modules to transpile and get the latest lastModified
-				// flag to determine when we finally need to rebuild the bundle information
-				let lastModified = -1;
+				// determine the list of modules to transpile (per-module mtimes are
+				// captured into the input fingerprint via getInputGraphFingerprint
+				// when computing the cache key further down).
 				for (const moduleName of moduleNames) {
 					const modulePath = that.resolveModule(moduleName, { cwd, depPaths });
 					// the following must apply:
@@ -1306,7 +1479,6 @@ module.exports = function (log, projectInfo) {
 								lastModified: new Date((await stat(modulePath)).mtime).getTime(),
 							};
 							bundleInfo.addModule(module);
-							lastModified = Math.max(lastModified, module.lastModified);
 						} else if (isCMJSModule) {
 							bundleInfo.addScript(that.getResource(moduleName, { cwd, depPaths, isMiddleware }));
 						} else {
@@ -1315,15 +1487,37 @@ module.exports = function (log, projectInfo) {
 					}
 				}
 
-				// create a cache key which includes the last modified timestamp and the module names
+				// create a cache key from a layered sha256 fingerprint:
+				//   1) tool sources + version (memoized once per process)
+				//   2) all bundle-affecting configuration options
+				//   3) project package.json + lockfile (catches dependency bumps)
+				//   4) entry modules: path + size + mtime
+				// Transitive module graph is captured after the build and verified on
+				// persistent-cache load (see BundleInfoCache.get/store).
+				// See packages/ui5-tooling-modules/CACHE-INVALIDATION.md for the design.
 				const modules = bundleInfo.getModules();
-				const myLastModified = new Date((await stat(__filename)).mtime).getTime();
-				const cacheKey = createHash("md5")
+				const entryFp = getInputGraphFingerprint(modules.map((module) => module.path));
+				const cacheKey = createHash("sha256")
 					.update(
-						`${myLastModified}:${lastModified}:${modules
-							.map((module) => `${module.name}@${module.path}`)
-							.sort()
-							.join(",")}`,
+						[
+							getToolFingerprint(),
+							getConfigFingerprint({
+								pluginOptions,
+								generatedCode,
+								minify,
+								inject,
+								sourcemap,
+								keepDynamicImports,
+								skipTransform,
+								dynamicEntriesPath,
+							}),
+							getLockfileFingerprint(cwd),
+							entryFp,
+							modules
+								.map((module) => `${module.name}@${module.path}`)
+								.sort()
+								.join(","),
+						].join(":"),
 					)
 					.digest("hex");
 


### PR DESCRIPTION
## Summary

Replaces the bundle cache key in `lib/util.js` with a layered SHA-256 fingerprint so the cache no longer silently re-uses stale bundles when the tool, its configuration, or the dependency graph changes.

The old key only mixed `mtime(util.js)` and the max `mtime` of the **entry** modules. That left several blind spots:

- edits to other tool sources (`rollup-plugin-webcomponents.js`, `WebComponentRegistry.js`, `templates/**/*.hbs`, …)
- `ui5-tooling-modules` version bumps in `node_modules` (no source-file mtime change)
- changes to bundle-affecting options (`minify`, `inject`, `pluginOptions`, `generatedCode`, `keepDynamicImports`, `skipTransform`, `dynamicEntriesPath`, `sourcemap`)
- changes deep inside transitive dependencies (only entry mtimes were checked)
- `package.json` / `pnpm-lock.yaml` / `package-lock.json` bumps
- fresh `git checkout` and CI runs (`mtime` is rewritten to checkout time)

## What's in the new key

The cache key is now \`sha256(toolFp : configFp : lockfileFp : entryGraphFp : "name@path,…")\` where each fingerprint is independent:

| Layer | Inputs | Cost |
| ----- | ------ | ---- |
| \`getToolFingerprint()\` | \`name@version\` + every \`.js\`/\`.mjs\`/\`.cjs\`/\`.hbs\` under \`lib/\` (content-hashed) | Memoized once per process |
| \`getConfigFingerprint(opts)\` | Stable JSON of all bundle-affecting options | Negligible |
| \`getLockfileFingerprint(cwd)\` | \`package.json\` + nearest lockfile (pnpm/npm/yarn) | Memoized per \`(lockfile, package.json)\` mtime |
| \`getInputGraphFingerprint(paths)\` | Sorted \`path\0size\0mtime\` triples for entry modules | One \`stat()\` per entry module |

## Two-phase validation

The cache check happens **before** \`createBundle()\` but the full transitive graph is only known **after** Rollup runs. The new flow keeps the fast pre-check (above) and adds a confirmation step on **persistent-cache load only**: re-stat the recorded \`relatedPaths\` of the persisted \`BundleInfo\` against the stored \`_inputFingerprint\`, return \`undefined\` on mismatch. This catches the \`git checkout\` / CI case where checkout-time mtimes can fool the entry-only check.

After each successful build, \`BundleInfoCache.store()\` captures the input-graph fingerprint onto the \`BundleInfo\` so the next persistent load can verify it.

## Other changes in this commit

- \`resolveModule\`'s \`modulesCache\` key switched from \`md5\` to \`sha256\` (silences security scanners; no measurable perf impact at these input sizes).
- \`README.md\`: refreshed \`skipCache\` and \`persistentCache\` descriptions to reflect the new automatic invalidation triggers and the on-load integrity check.
- \`OVERVIEW.md\`: updated version banner, replaced the outdated "Recent Changes" section with a focused write-up of this rework, and rewrote the "Caching Architecture" section with the layered key, fingerprint cost table, and two-phase validation.

## Test plan

- [ ] \`cd packages/ui5-tooling-modules && npm test\` passes
- [ ] First build (no cache) produces a bundle as before
- [ ] Second build with no changes is a cache hit
- [ ] Editing a transitive dependency forces a rebuild on persistent-cache load
- [ ] Toggling \`minify\` / \`sourcemap\` / \`pluginOptions\` forces a rebuild
- [ ] Bumping a dependency in \`pnpm-lock.yaml\` forces a rebuild
- [ ] Fresh \`git checkout\` of a different branch with a persisted cache no longer silently reuses the old bundle