### PR TITLE
ci: run middleware/task tests in parallel via matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    name: Build (exercises task extensions)
     runs-on: ubuntu-latest
     if: "! contains(github.event.head_commit.message, '[skip ci]')"
 
@@ -46,9 +47,54 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # test executes all task extensions
+      # build executes all task extensions
       - name: Build app
         run: pnpm build
 
-      - name: Run tests on middlewares + tasks
-        run: pnpm run test:all
+  test:
+    name: Test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22]
+        package:
+          - ui5-middleware-approuter
+          - ui5-middleware-simpleproxy
+          - ui5-task-cachebuster
+          - ui5-task-copyright
+          - ui5-task-zipper
+          - ui5-tooling-modules
+          - ui5-tooling-transpile
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
+
+      - id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path | tr -d '\n')" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        name: Setup pnpm-cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests on ${{ matrix.package }}
+        run: pnpm --filter ${{ matrix.package }} test


### PR DESCRIPTION
## What

Split [.github/workflows/tests.yml](.github/workflows/tests.yml) into two jobs and parallelize the test run across packages.

- **build** — keeps running \`pnpm build\` (which exercises the task extensions on the showcase app).
- **test** — matrix over the 7 packages with a \`test\` script, each in its own runner. \`fail-fast: false\` so one package's failure doesn't cancel the others.

Matrix packages:

- \`ui5-middleware-approuter\`
- \`ui5-middleware-simpleproxy\`
- \`ui5-task-cachebuster\`
- \`ui5-task-copyright\`
- \`ui5-task-zipper\`
- \`ui5-tooling-modules\`
- \`ui5-tooling-transpile\`

## Why

Previously \`pnpm run test:all\` was \`pnpm --filter "./packages/*" --workspace-concurrency 1 test\`, serializing all 7 ava suites in a single runner. The matrix fans them out for noticeably faster CI; the shared pnpm-store cache keeps per-job install overhead small.

Tests that bind ports already use dynamic \`getPort()\`, so per-package isolation in separate runners is the safer parallelization point than bumping intra-runner concurrency.