### PR TITLE
ci: add changeset status PR gate + switch to GitHub changelog generator

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "ui5-community/ui5-ecosystem-showcase" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/six-toys-admire.md
+++ b/.changeset/six-toys-admire.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: add `changeset status` PR gate and switch to `@changesets/changelog-github` for richer CHANGELOG entries.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,12 @@ jobs:
       # Fails the PR if no changeset describes the change.
       # Add one with `pnpm changeset` (or `pnpm changeset --empty` for
       # PRs that don't need a release entry) and commit it.
+      # We check `.changesets` (not `.releases`) so that empty changesets
+      # — which have 0 package bumps but still document the PR — pass.
       - name: Verify changeset is present
         run: |
           pnpm changeset status --since=origin/main --output=/tmp/cs.json
-          if [ "$(jq '.releases | length' /tmp/cs.json)" -eq 0 ]; then
+          if [ "$(jq '.changesets | length' /tmp/cs.json)" -eq 0 ]; then
             echo "::error::No changeset found on this PR. Run 'pnpm changeset' (or 'pnpm changeset --empty' for PRs that don't need a release entry) and commit the file."
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,53 @@ env:
   HUSKY_SKIP: true
 
 jobs:
+  changeset:
+    name: Changeset present
+    runs-on: ubuntu-latest
+    # Skip on the auto-generated release PR (it consumes all changesets).
+    if: "github.head_ref != 'changeset-release/main' && ! contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need full history so `changeset status --since=origin/main` can diff.
+          fetch-depth: 0
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
+
+      - id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path | tr -d '\n')" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        name: Setup pnpm-cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fails the PR if no changeset describes the change.
+      # Add one with `pnpm changeset` (or `pnpm changeset --empty` for
+      # PRs that don't need a release entry) and commit it.
+      - name: Verify changeset is present
+        run: |
+          pnpm changeset status --since=origin/main --output=/tmp/cs.json
+          if [ "$(jq '.releases | length' /tmp/cs.json)" -eq 0 ]; then
+            echo "::error::No changeset found on this PR. Run 'pnpm changeset' (or 'pnpm changeset --empty' for PRs that don't need a release entry) and commit the file."
+            exit 1
+          fi
+
   build:
     name: Build (exercises task extensions)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ncu": "ncu -w --root"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.7.0
+        version: 0.7.0(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.9.1)
@@ -1833,6 +1836,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
+
   '@changesets/cli@2.31.0':
     resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
     hasBin: true
@@ -1845,6 +1851,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.4':
     resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.16':
     resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
@@ -4952,6 +4961,9 @@ packages:
   data-with-position@0.5.0:
     resolution: {integrity: sha512-GhsgEIPWk7WCAisjwBkOjvPqpAlVUOSl1CTmy9KyhVMG1wxl29Zj5+J71WhQ/KgoJS/Psxq6Cnioz3xdBjeIWQ==}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
     engines: {node: '>=4.0'}
@@ -5187,6 +5199,10 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -10743,6 +10759,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.7.0(encoding@0.1.13)':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0(encoding@0.1.13)
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.31.0(@types/node@25.9.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
@@ -10795,6 +10819,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.8.1
+
+  '@changesets/get-github-info@0.8.0(encoding@0.1.13)':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -14715,6 +14746,8 @@ snapshots:
     dependencies:
       yaml-ast-parser: 0.0.43
 
+  dataloader@1.4.0: {}
+
   date-format@4.0.14: {}
 
   date-time@3.1.0:
@@ -14924,6 +14957,8 @@ snapshots:
   dot-properties@1.1.1: {}
 
   dotenv@17.4.2: {}
+
+  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## What

Two follow-ups to the recent Lerna→Changesets migration (f466f81):

1. **Switch the changelog generator** to [`@changesets/changelog-github`](https://github.com/changesets/changesets/tree/main/packages/changelog-github) — future `CHANGELOG.md` entries will include PR links, commit SHAs, and contributor handles instead of bare bullet points.
2. **Add a `changeset status` CI gate** that fails PRs without an accompanying `.changeset/*.md`, so we never merge a code change that won't appear in any changelog.

## Why

Right now nothing in CI nudges contributors to add a changeset. After f466f81 the release flow depends entirely on those `.md` files — a forgotten one means a silent unreleased change. The gate makes the requirement explicit; the GitHub changelog generator makes the resulting changelog actually useful for end users.

## Changes

- `.changeset/config.json` — `"changelog"` switched from `@changesets/cli/changelog` to `["@changesets/changelog-github", { "repo": "ui5-community/ui5-ecosystem-showcase" }]`
- `package.json` — adds `@changesets/changelog-github@^0.7.0` to root `devDependencies` (lockfile updated accordingly)
- `.github/workflows/tests.yml` — new `changeset` job runs alongside `build` and `test` on every PR:
  - Runs `pnpm changeset status --since=origin/main --output=/tmp/cs.json`
  - Fails if `.releases.length == 0` (the JSON-output check is needed because plain `changeset status` exits 0 even when no changesets are present)
  - Skipped automatically on the auto-generated `changeset-release/main` PR (which has consumed all changesets by definition)

## How to use

For PRs touching shipped packages, add a normal changeset:

```bash
pnpm changeset
```

For PRs that don't need a release entry (CI-only, docs, showcases), use:

```bash
pnpm changeset --empty
```

This PR includes its own empty changeset (`.changeset/six-toys-admire.md`) to demonstrate / pass the new gate.

## Notes

- `--since=origin/main` plus `fetch-depth: 0` on the checkout ensures the diff has full history available
- The `if:` condition that excludes `changeset-release/main` mirrors the upstream `changesets/action` convention
- Switching changelog generators won't retroactively rewrite existing `CHANGELOG.md` files — only new entries will use the richer format