### PR TITLE
chore: add changesets for pending releases

### DIFF
--- a/.changeset/dependency-updates.md
+++ b/.changeset/dependency-updates.md
@@ -1,0 +1,17 @@
+---
+"cds-plugin-ui5": patch
+"ui5-middleware-approuter": patch
+"ui5-middleware-serveframework": patch
+"ui5-middleware-websocket": patch
+"ui5-task-copyright": patch
+"ui5-tooling-transpile": patch
+---
+
+Bump runtime dependencies to clear open dependabot alerts and pick up upstream patch releases:
+
+- `cds-plugin-ui5`: `semver` ^7.8.0 → ^7.8.1
+- `ui5-middleware-approuter`: `@sap/approuter` ^22.0.0 → ^22.0.1
+- `ui5-middleware-serveframework`: `node-fetch` ^2.7.0 → ^3.3.2
+- `ui5-middleware-websocket`: `ws` ^8.20.1 → ^8.21.0
+- `ui5-task-copyright`: `@typescript-eslint/typescript-estree` ^8.59.3 → ^8.60.0
+- `ui5-tooling-transpile`: `@babel/core`, `@babel/preset-env`, `@babel/preset-typescript` → ^7.29.7

--- a/.changeset/http-proxy-middleware-v4.md
+++ b/.changeset/http-proxy-middleware-v4.md
@@ -1,0 +1,6 @@
+---
+"ui5-middleware-simpleproxy": minor
+"ui5-middleware-approuter": minor
+---
+
+Upgrade `http-proxy-middleware` to v4. v4 ships as ESM-only and requires Node >= 22.15.0 (already the CI baseline). The exposed API surface used here (`target`, `changeOrigin`, `secure`, `agent`, `auth`, `headers`, `pathFilter`, `pathRewrite`, `selfHandleResponse`, `xfwd`, `autoRewrite`, `on.proxyReq`/`proxyRes`, `responseInterceptor`, `proxyMiddleware.upgrade`) is unchanged; the `require()` calls were switched to dynamic `await import()` inside the existing async scopes — same pattern already used for `proxy-from-env` and `https-proxy-agent`.

--- a/.changeset/minimatch-v10.md
+++ b/.changeset/minimatch-v10.md
@@ -1,0 +1,7 @@
+---
+"ui5-middleware-simpleproxy": patch
+"ui5-tooling-modules": patch
+"ui5-tooling-stringreplace": patch
+---
+
+Bump `minimatch` from v7 to v10. v9 dropped the default export, so the five `require("minimatch")` sites were switched to the named export `const { minimatch } = require("minimatch")`. The runtime call shape `minimatch(path, pattern)` is unchanged. minimatch 8 raised the Node floor to 20+, which already matches the workspace engines (Node 22 in CI).

--- a/.changeset/tooling-modules-fetch-shim.md
+++ b/.changeset/tooling-modules-fetch-shim.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": minor
+---
+
+Replace `node-fetch` / `cross-fetch` / `isomorphic-fetch` (and any of their subpath imports) with a virtual rollup shim that re-exports `globalThis.fetch`, `Headers`, `Request`, `Response`, `Blob`, `File`, `FormData`, plus inert `AbortError` / `FetchError` / `isRedirect` stubs. The shim is hooked into the rollup chain before commonjs/polyfill resolution so the Node-only sub-graph (`fetch-blob`, `fs.promises`, `node:net`, …) never enters the browser bundle. Fixes the `"isIP" is not exported by "polyfill-node.net.js"` error that `node-fetch@3` introduced.

--- a/.changeset/tooling-modules-polyfill-augment.md
+++ b/.changeset/tooling-modules-polyfill-augment.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": patch
+---
+
+Augment the bundled `node:util` polyfill with `TextEncoder` / `TextDecoder` exports out of the box (previously consumers had to drop a 720-line `_polyfill-overrides_/util.js` copy of the upstream polyfill into every app). Augmentations are registered via a `POLYFILL_AUGMENTATIONS` map keyed by Node built-in name; entries are appended verbatim to the upstream polyfill source as the bundler loads it, and tree-shaking strips appended exports that nothing imports. Per-project `_polyfill-overrides_/` directories remain available for app-specific overrides that should not become global defaults.


### PR DESCRIPTION
Documents the published-package changes that have landed on `main` since the last release (`67de32c7`) so the next `changeset version` run produces accurate per-package CHANGELOG entries.

## Resulting bumps

`pnpm changeset status`:

**minor**
- ui5-middleware-approuter
- ui5-middleware-simpleproxy
- ui5-tooling-modules

**patch**
- cds-plugin-ui5
- ui5-middleware-serveframework
- ui5-middleware-websocket
- ui5-task-copyright
- ui5-tooling-stringreplace
- ui5-tooling-transpile

## Changesets added

| File | Bump | Source commit |
|---|---|---|
| `tooling-modules-fetch-shim.md` | minor | 04cbb7ca |
| `tooling-modules-polyfill-augment.md` | patch | 3f22ebe0 |
| `http-proxy-middleware-v4.md` | minor | e6910421 |
| `minimatch-v10.md` | patch | 326d02a4 |
| `dependency-updates.md` | patch | 04cbb7ca |

## Intentionally omitted

No published-package impact, so no changeset:
- `fe2f0705` — chart.js bump in showcases (not published)
- `dfb6634a`, `f466f818`, `ddb28222`, `d693d240` — CI-only (Changesets rollout already covered by the existing `six-toys-admire.md`)
- `73697d26`, `7c19676f` — docs-only inside ui5-tooling-modules
- `d43cab26` — internal rename of an unexported plugin module
- DevDep-only slices of `04cbb7ca` for ui5-middleware-onelogin (eslint, typescript-eslint) and ui5-task-zipper (yauzl)