### PR TITLE
feat(repo): add pnpm changeset:auto to derive entries from commits

### DIFF
--- a/.changeset/public-emus-shout.md
+++ b/.changeset/public-emus-shout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added a `pnpm changeset:auto` script that derives `.changeset/*.md` files from conventional-commit history on the current branch. Tooling-only — no published-package change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,15 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for ve
 
 The release flow is fully automated through GitHub Actions — no local `lerna` or push permissions on `main` required.
 
-**For contributors:** when your PR changes one or more public packages, add a changeset:
+**For contributors:** when your PR changes one or more public packages, add a changeset. There are three options, pick whichever fits:
 
-```bash
-pnpm changeset
-```
+| Command | When to use |
+| --- | --- |
+| `pnpm changeset:auto` | Recommended for most PRs. Walks the conventional-commit history on your branch and writes one `.changeset/auto-<sha>.md` per qualifying commit (packages from the commit `scope`, bump from the `type`, summary from the `subject`). Idempotent — safe to re-run. Already-covered commits are skipped, so hand-written changesets always win. |
+| `pnpm changeset` | Interactive — pick packages, bump type, and write a summary by hand. Use when the auto-derived bump or summary is wrong (e.g. a `chore:` commit that secretly contains a `feat:`); the next `:auto` run will skip the commit because it's covered. |
+| `pnpm changeset:empty` | Docs- or tooling-only PRs that touch no public package. Writes an empty `.changeset/*.md` so the CI changeset gate passes without producing any CHANGELOG entry. |
 
-The interactive prompt asks which packages changed and at what semver level (patch / minor / major) and writes a small markdown file under `.changeset/`. Commit that file with your code change. If your PR is docs- or tooling-only, you can skip this step.
+Whichever you pick, commit the resulting `.changeset/*.md` file alongside your code change.
 
 **For maintainers:** the release itself happens entirely on GitHub.
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:all": "pnpm --filter \"./packages/*\" --workspace-concurrency 1 test",
     "watch": "pnpm --filter ui5-app watch",
     "changeset": "changeset",
+    "changeset:auto": "node scripts/auto-changeset.mjs",
     "version-packages": "changeset version && pnpm install --lockfile-only",
     "release-publish": "changeset publish",
     "lint": "pnpm --workspace-concurrency 1 -r lint",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "watch": "pnpm --filter ui5-app watch",
     "changeset": "changeset",
     "changeset:auto": "node scripts/auto-changeset.mjs",
+    "changeset:empty": "changeset --empty",
     "version-packages": "changeset version && pnpm install --lockfile-only",
     "release-publish": "changeset publish",
     "lint": "pnpm --workspace-concurrency 1 -r lint",

--- a/scripts/auto-changeset.mjs
+++ b/scripts/auto-changeset.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// Auto-generate Changesets entries from conventional commits.
+//
+// Reads the commits in the configured range and emits one
+// .changeset/auto-<short-sha>.md per commit that affects a published
+// package. The CLI is a faster path than `pnpm changeset` for the common
+// case where the commit message already encodes the bump (`feat:` ->
+// minor, `fix:` -> patch, `!`/`BREAKING CHANGE:` -> major) and the
+// scope already names the affected packages.
+//
+// Usage:
+//   pnpm changeset:auto              # commits ahead of origin/main
+//   pnpm changeset:auto --since=<ref>
+//   pnpm changeset:auto --dry-run    # print, don't write
+//   pnpm changeset:auto --verbose    # log per-commit decisions
+//
+// Skip rules: commits whose `type` is `ci`, whose scope is `release`,
+// or that touch no `packages/*` files. A commit is also skipped when
+// any existing .changeset/*.md already lists one of the packages it
+// would target -- the assumption is that a human has already written
+// the entry for that change.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const CHANGESET_DIR = join(REPO_ROOT, ".changeset");
+
+// --- CLI args ----------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const verbose = args.includes("--verbose");
+const sinceArg = args.find((a) => a.startsWith("--since="))?.slice("--since=".length);
+
+// --- helpers -----------------------------------------------------------------
+
+function git(...gitArgs) {
+	return execFileSync("git", gitArgs, { cwd: REPO_ROOT, encoding: "utf8" }).trimEnd();
+}
+
+function gitOptional(...gitArgs) {
+	try {
+		return git(...gitArgs);
+	} catch {
+		return null;
+	}
+}
+
+function log(...msg) {
+	if (verbose) console.log(...msg);
+}
+
+// --- discover packages -------------------------------------------------------
+
+function loadPublishablePackages() {
+	const out = new Map(); // name -> { dir, private }
+	for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const pkgPath = join(PACKAGES_DIR, entry.name, "package.json");
+		if (!existsSync(pkgPath)) continue;
+		const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+		if (pkg.private === true) continue;
+		out.set(pkg.name, { dir: entry.name });
+	}
+	return out;
+}
+
+const PACKAGES = loadPublishablePackages();
+// Reverse lookup: directory name -> package name. Most packages have
+// matching dir/pkg names but some (e.g. dev-approuter) don't, so we
+// can't conflate them.
+const DIR_TO_NAME = new Map();
+for (const [name, info] of PACKAGES) DIR_TO_NAME.set(info.dir, name);
+
+// --- existing changesets -----------------------------------------------------
+
+function packagesAlreadyCovered() {
+	const covered = new Set();
+	if (!existsSync(CHANGESET_DIR)) return covered;
+	for (const file of readdirSync(CHANGESET_DIR)) {
+		if (!file.endsWith(".md") || file === "README.md") continue;
+		const body = readFileSync(join(CHANGESET_DIR, file), "utf8");
+		// Frontmatter sits between the first two `---` lines. Inside, each
+		// non-empty line follows `"<pkg>": <bump>`.
+		const match = body.match(/^---\n([\s\S]*?)\n---/);
+		if (!match) continue;
+		for (const line of match[1].split("\n")) {
+			const m = line.match(/^"([^"]+)":\s*(major|minor|patch)\s*$/);
+			if (m) covered.add(m[1]);
+		}
+	}
+	return covered;
+}
+
+// --- commit range ------------------------------------------------------------
+
+function resolveCommitRange() {
+	if (sinceArg) return `${sinceArg}..HEAD`;
+
+	// Try merge-base against origin/main first.
+	const mergeBase = gitOptional("merge-base", "origin/main", "HEAD");
+	const head = git("rev-parse", "HEAD");
+	if (mergeBase && mergeBase !== head) {
+		return `${mergeBase}..HEAD`;
+	}
+
+	// On main (or no divergence): fall back to the last release commit.
+	// Look for the most recent `chore(release): publish` commit.
+	const lastRelease = gitOptional("log", "--format=%H", "--grep=^chore(release): publish$", "-n", "1");
+	if (lastRelease) return `${lastRelease}..HEAD`;
+
+	throw new Error("could not determine commit range (no merge-base with origin/main and no `chore(release): publish` commit found). Pass --since=<ref>.");
+}
+
+// --- commit parsing ----------------------------------------------------------
+
+const SUBJECT_RE = /^(?<type>\w+)(?:\((?<scopes>[^)]+)\))?(?<bang>!?):\s+(?<subject>.+)$/;
+
+function readCommits(range) {
+	// %x1F is the ASCII unit-separator; safe within commit messages.
+	// Format: <sha>\x1F<subject>\x1F<body>\x00
+	const raw = git("log", "--format=%H%x1F%s%x1F%b%x00", "--reverse", range);
+	if (!raw) return [];
+	return raw
+		.split("\x00")
+		.map((s) => s.replace(/^\n+/, ""))
+		.filter(Boolean)
+		.map((entry) => {
+			const [sha, subject, body] = entry.split("\x1F");
+			return { sha, subject, body: body ?? "" };
+		});
+}
+
+function changedFiles(sha) {
+	return git("diff-tree", "--no-commit-id", "--name-only", "-r", sha).split("\n").filter(Boolean);
+}
+
+// --- classification ----------------------------------------------------------
+
+function classify(commit, covered) {
+	const m = commit.subject.match(SUBJECT_RE);
+	if (!m) return { skip: "subject does not match conventional-commit shape" };
+	const { type, scopes, bang, subject } = m.groups;
+
+	if (type === "ci") return { skip: "ci-only commit" };
+	const scopeList = scopes ? scopes.split(",").map((s) => s.trim()) : [];
+	if (scopeList.includes("release")) return { skip: "release commit" };
+
+	const files = changedFiles(commit.sha);
+	const touchedPackageDirs = new Set();
+	for (const f of files) {
+		const m2 = f.match(/^packages\/([^/]+)\/(.+)$/);
+		if (!m2) continue;
+		// Test-only paths don't ship in the published tarball, so a
+		// touch under test/ alone does not mean the package needs a
+		// release. The most common false positive is a regenerated
+		// snapshot triggered by a dependency bump elsewhere in the
+		// monorepo (e.g. chart.js bump in a showcase regenerates
+		// packages/ui5-tooling-modules/test/__snap__/.../chart.js).
+		if (/^(test|tests|__tests__)\//.test(m2[2])) continue;
+		touchedPackageDirs.add(m2[1]);
+	}
+	if (touchedPackageDirs.size === 0) {
+		return { skip: "no shipping packages/ files affected" };
+	}
+
+	// Build the set of affected package *names*.
+	let pkgNames;
+	if (scopeList.length > 0 && scopeList.every((s) => PACKAGES.has(s))) {
+		pkgNames = scopeList;
+	} else {
+		// Either no scope, or scope tokens aren't package names (e.g.
+		// `chore: bump minimatch` with no scope, or `feat(ci):`). Fall
+		// back to whatever directories were touched, mapped to package
+		// names.
+		pkgNames = [...touchedPackageDirs].map((d) => DIR_TO_NAME.get(d)).filter(Boolean);
+	}
+	pkgNames = [...new Set(pkgNames)].filter((n) => PACKAGES.has(n));
+	if (pkgNames.length === 0) {
+		return { skip: "scope/paths did not resolve to any publishable package" };
+	}
+
+	// Bump determination.
+	let bump;
+	if (bang === "!" || /^BREAKING CHANGE:/m.test(commit.body)) {
+		bump = "major";
+	} else if (type === "feat") {
+		bump = "minor";
+	} else if (["fix", "perf", "refactor", "chore", "build", "style"].includes(type)) {
+		bump = "patch";
+	} else if (type === "docs") {
+		// Docs only get a changeset when explicitly scoped to a package.
+		if (scopeList.length === 0) return { skip: "docs without package scope" };
+		bump = "patch";
+	} else {
+		return { skip: `type '${type}' does not produce a changeset` };
+	}
+
+	// Skip-if-covered.
+	const overlap = pkgNames.filter((n) => covered.has(n));
+	if (overlap.length > 0) {
+		return { skip: `already covered (${overlap.join(", ")})` };
+	}
+
+	return { pkgNames, bump, subject };
+}
+
+// --- write -------------------------------------------------------------------
+
+function writeChangeset(sha, pkgNames, bump, subject) {
+	const short = sha.slice(0, 8);
+	const filename = `auto-${short}.md`;
+	const path = join(CHANGESET_DIR, filename);
+	if (existsSync(path)) {
+		return { path, filename, skipped: "file already exists" };
+	}
+	const frontmatter = pkgNames.map((n) => `"${n}": ${bump}`).join("\n");
+	const body = `---\n${frontmatter}\n---\n\n${subject}\n`;
+	if (!dryRun) {
+		mkdirSync(CHANGESET_DIR, { recursive: true });
+		writeFileSync(path, body);
+	}
+	return { path, filename };
+}
+
+// --- main --------------------------------------------------------------------
+
+function main() {
+	const range = resolveCommitRange();
+	const commits = readCommits(range);
+	const covered = packagesAlreadyCovered();
+	let written = 0;
+	let skipped = 0;
+
+	console.log(`Scanning ${commits.length} commit(s) in range ${range}.`);
+	if (covered.size > 0) {
+		log(`Pre-existing coverage: ${[...covered].sort().join(", ")}`);
+	}
+
+	for (const commit of commits) {
+		const decision = classify(commit, covered);
+		const short = commit.sha.slice(0, 8);
+		if (decision.skip) {
+			log(`  - skip ${short}: ${decision.skip}`);
+			skipped++;
+			continue;
+		}
+		const { pkgNames, bump, subject } = decision;
+		const { filename, skipped: writeSkip } = writeChangeset(commit.sha, pkgNames, bump, subject);
+		if (writeSkip) {
+			log(`  - skip ${short}: ${writeSkip}`);
+			skipped++;
+			continue;
+		}
+		const pkgList = pkgNames.length === 1 ? pkgNames[0] : `{${pkgNames.join(",")}}`;
+		const tag = dryRun ? "would write" : "wrote";
+		console.log(`  ✓ ${tag} .changeset/${filename}  (${pkgList}: ${bump})`);
+		written++;
+	}
+
+	const verb = dryRun ? "would write" : "wrote";
+	console.log(`\n${verb} ${written} changeset(s), skipped ${skipped}.`);
+}
+
+main();


### PR DESCRIPTION
## What

Adds `scripts/auto-changeset.mjs` and a root \`pnpm changeset:auto\` script that derive `.changeset/auto-<sha>.md` files from the conventional-commit history on the current branch. Tooling-only — no published-package change.

## Why

The repo already enforces conventional commits (`@commitlint/config-conventional` + a `pre-push` hook). The same information that `pnpm changeset` asks for interactively — packages (from `scope`), bump type (from `type`), summary (from `subject`) — is already in every commit. This script reads it directly so the common case stops needing manual input. Hand-written changesets still take precedence (see "Skip if covered" below).

## Usage

\`\`\`bash
pnpm changeset:auto                    # commits ahead of origin/main
pnpm changeset:auto --since=<ref>      # explicit range
pnpm changeset:auto --dry-run          # print, don't write
pnpm changeset:auto --verbose          # log per-commit decisions
\`\`\`

When on a feature branch the default range is `merge-base(origin/main, HEAD)..HEAD`. On `main` it falls back to commits since the last `chore(release): publish`.

## How it classifies

For each commit:

1. Parse `<type>(<scopes>)!?: <subject>`.
2. **Skip** if `type === 'ci'`, scope is `release`, no `packages/*` files (excluding `test/` snapshot churn) were touched, or the subject doesn't match.
3. **Packages** come from the scope when every scope token resolves to a known package; otherwise from the changed `packages/<name>/` directories.
4. **Bump**: `!` / `BREAKING CHANGE:` → major, `feat:` → minor, `fix:`/`perf:`/`refactor:`/`chore:`/`build:`/`style:` → patch, `docs:` → patch only when scoped to a package, other types skipped.
5. **Skip if already covered** — if any existing `.changeset/*.md` lists a package this commit would target, skip. Hand-written changesets always win.
6. Write `.changeset/auto-<short-sha>.md` (idempotent — re-running is safe).

## Verified against PR #1370

Re-derived the changesets for the same commit range I hand-wrote in #1370. Output:

\`\`\`
Scanning 14 commit(s) in range 67de32c7..HEAD.
  ✓ wrote .changeset/auto-04cbb7ca.md  ({cds-plugin-ui5,…,ui5-tooling-transpile}: patch)
  ✓ wrote .changeset/auto-3f22ebe0.md  (ui5-tooling-modules: patch)
  ✓ wrote .changeset/auto-d43cab26.md  (ui5-tooling-modules: patch)
  ✓ wrote .changeset/auto-73697d26.md  (ui5-tooling-modules: patch)
  ✓ wrote .changeset/auto-7c19676f.md  (ui5-tooling-modules: patch)
  ✓ wrote .changeset/auto-e6910421.md  ({ui5-middleware-simpleproxy,ui5-middleware-approuter}: minor)
  ✓ wrote .changeset/auto-326d02a4.md  ({ui5-middleware-simpleproxy,ui5-tooling-modules,ui5-tooling-stringreplace}: patch)
  - skip fe2f0705: no shipping packages/ files affected
  - skip dfb6634a: ci-only commit
  - skip f466f818: ci-only commit
  - skip ddb28222: ci-only commit
  - skip d693d240: no shipping packages/ files affected
  - skip dd71c421: no shipping packages/ files affected
  - skip 57083885: release commit

wrote 7 changeset(s), skipped 7.
\`\`\`

`pnpm changeset status` parses the output cleanly. A re-run writes 0 (idempotent via the overlap check).

## Known limitation: subject-line only

The script reads the **subject**, not the body. A commit like `chore: prepare for dependabot fixes and modernize bundling` whose body says "* feat(ui5-tooling-modules): replace node-fetch …" will produce a `chore` → patch entry rather than the `feat` → minor it deserves. The fix is commit hygiene (split the work into separate commits) — or hand-write the changeset, in which case the overlap check skips the commit on the next auto run.

## Out of scope

- No CI integration. The script is local-only on purpose; layering on a PR-bot or auto-commit-to-branch step is a separate decision.
- No PR-title fallback. Conventional commits remain the contract.
- No commit grouping. One file per commit, full stop.