### PR TITLE
chore(repo): supply-chain hardening (minReleaseAge, pkgMgr hash, SECURITY.md, CODEOWNERS)

### DIFF
--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,0 +1,6 @@
+---
+---
+
+chore(repo): supply-chain hardening — pin pnpm minimumReleaseAge explicitly,
+pin packageManager with sha512, add SECURITY.md, add CODEOWNERS for
+release-critical paths. Repo-only; no package bumps.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Code owners for supply-chain-sensitive paths.
+#
+# These are the files where a malicious change is hardest to undo
+# after the fact: workflows that run with secrets, the release config
+# that publishes to npm, the workspace overrides/allowBuilds list, and
+# the lockfile. Requiring a maintainer review on these paths is a
+# concrete defense against worm-style attacks where a compromised
+# contributor account otherwise pushes a single bad commit.
+#
+# Everything else is intentionally not covered here so day-to-day
+# package work is not gated on this team.
+
+/.github/workflows/        @ui5-community/maintainers
+/.github/dependabot.yml    @ui5-community/maintainers
+/.github/CODEOWNERS        @ui5-community/maintainers
+/.changeset/config.json    @ui5-community/maintainers
+/pnpm-workspace.yaml       @ui5-community/maintainers
+/pnpm-lock.yaml            @ui5-community/maintainers
+/package.json              @ui5-community/maintainers
+/SECURITY.md               @ui5-community/maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in any package
+published from this repository (or in the repository tooling itself),
+please **do not open a public issue**.
+
+Use **[GitHub Private Vulnerability Reporting][pvr]** instead:
+
+1. Go to the [Security tab][security] of this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the form. The maintainers receive the report privately and
+   coordinate a fix and disclosure with you.
+
+[pvr]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability
+[security]: https://github.com/ui5-community/ui5-ecosystem-showcase/security
+
+## Supported Versions
+
+Only the latest published version of each package is supported with
+security fixes. Older majors do not receive backports unless explicitly
+called out in a release note.
+
+## Scope
+
+In scope:
+
+- The packages published from `packages/*` to npm under the
+  `ui5-community` org.
+- The CI workflows under `.github/workflows/` and the release
+  configuration that produces those packages.
+
+Out of scope:
+
+- Demo applications under `showcases/*`. These exist to exercise the
+  middleware/task extensions and are not intended for production use.
+- Vulnerabilities in third-party dependencies that are already tracked
+  by Dependabot or upstream advisories — please report those upstream.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git"
   },
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.5.0+sha512.2/zE+Bz0hZev1Lw5H/3xLBHxqfuDo5W/prCi2cwv2P/rr9scy9UpYyFT95OQTCYVt/Cf4aNFRz/Rw1hFFyqOsQ==",
   "scripts": {
     "build": "pnpm --filter ui5-app build",
     "build:sc": "pnpm --filter ui5-app build:sc",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,14 @@ allowBuilds:
 
 enablePrePostScripts: false
 
+# Refuse to install package versions younger than this many minutes. The
+# typical npm-worm window (Shai-Hulud, etc.) is hours: malicious
+# versions are usually yanked well within a day. pnpm 11 defaults to
+# 1440 (24h); pin it explicitly so the setting can't silently change
+# under us if pnpm flips the default in a future major, and so
+# anyone running pnpm 10 here picks up the same behavior.
+minimumReleaseAge: 1440
+
 minimumReleaseAgeExclude:
   - "@eslint/plugin-kit@0.7.2"
   - eslint@10.4.1


### PR DESCRIPTION
## Why

Concrete defenses against npm-worm-style supply-chain attacks (Shai-Hulud and similar), plus a couple of related housekeeping items the repo was missing.

No package code changes; this is repo-only.

## What

### \`pnpm-workspace.yaml\` — pin \`minimumReleaseAge: 1440\` explicitly

The repo had \`minimumReleaseAgeExclude\` already, but no \`minimumReleaseAge\` itself — meaning the exclude list was a no-op on pnpm < 11 and silently relying on a default on pnpm 11. Pin the value so:

- it can't change under us if pnpm flips the default in a future major,
- anyone still on pnpm 10 picks up the same protection.

24h is the sweet spot: most malicious npm versions are yanked within hours, and legit fast-moving dev tooling (eslint, lint-staged) is already covered by the existing exclude list.

### \`package.json\` — add \`+sha512\` integrity to \`packageManager\`

\`\`\`diff
- "packageManager": "pnpm@11.5.0",
+ "packageManager": "pnpm@11.5.0+sha512.2/zE+...",
\`\`\`

Corepack verifies pnpm's tarball against this hash before running it on a clean machine. Hash sourced from \`https://registry.npmjs.org/pnpm/11.5.0\` \`dist.integrity\`.

### \`SECURITY.md\`

Documents the disclosure path (GitHub Private Vulnerability Reporting on the repo's Security tab) and scope (\`packages/*\` + workflows in scope, \`showcases/*\` out of scope).

> **Repo admins:** if PVR isn't enabled yet, turn it on under \`Settings → Code security and analysis → Private vulnerability reporting\`.

### \`.github/CODEOWNERS\`

Requires \`@ui5-community/maintainers\` review on supply-chain-sensitive paths only:

- \`.github/workflows/\`, \`.github/dependabot.yml\`, \`.github/CODEOWNERS\`
- \`.changeset/config.json\`
- \`pnpm-workspace.yaml\`, \`pnpm-lock.yaml\`
- root \`package.json\`
- \`SECURITY.md\`

Day-to-day package work is intentionally not gated. Branch protection (\"Require review from Code Owners\") needs to be enabled separately for this to be enforced — without it, CODEOWNERS just auto-requests the review.

> **Repo admins:** confirm \`@ui5-community/maintainers\` is the right team handle, and enable the branch protection toggle.

## What this PR does **not** do

Out of scope for this PR but worth a follow-up:

- The \`release.yml\` \`NPM_BOOTSTRAP_TOKEN\` non-OIDC fallback can be removed once OIDC publishing is fully bootstrapped for every published package.
- \`packages/ui5-tooling-transpile\` and \`packages/ui5-tooling-modules\` ship a \`postinstall\` script. It's gated on opt-in env vars today, but would be safer as an explicit \`npx … register\` command. Behavior change for users, so doing it separately.

## Changeset

\`.changeset/security-hardening.md\` is empty (no package bumps); it's there to satisfy the changeset-required CI check.