### PR TITLE
fix(ui5-tooling-transpile): preserve `export` modifier on top-level decls in generated d.ts

### DIFF
--- a/.changeset/fix-transpile-stripped-exports.md
+++ b/.changeset/fix-transpile-stripped-exports.md
@@ -1,0 +1,22 @@
+---
+"ui5-tooling-transpile": patch
+---
+
+fix(ui5-tooling-transpile): preserve `export` modifier on top-level
+declarations in generated `.d.ts` files
+
+When the task generates `.d.ts` files for a TypeScript library it wraps the
+original source in `declare module "<fqn>" { ... }` so the emitted type
+definition references the fully-qualified UI5 module name. TSC's d.ts
+emitter however strips the `export` modifier from declarations inside an
+ambient module body, turning previously-exported `type` / `enum` /
+`interface` / `class` / `function` / `const` / `let` / `var` / `namespace`
+declarations into module-private symbols that consumers can no longer
+import.
+
+The task now post-processes the emitted d.ts: it collects the names that
+were re-exported in the original source and re-prepends `export` to the
+matching top-level declarations inside the wrapped module body. Names that
+were never exported in the source remain module-private as before.
+
+Fixes #1380.

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -267,6 +267,48 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 					dtsFilePromises.push(workspace.write(dtsFile));
 				};
 
+				// helper to re-add `export` modifiers to top-level declarations that
+				// TSC strips when it re-emits the source inside the ambient
+				// `declare module "<fqn>" { ... }` wrapper applied above. Without
+				// this, public re-exports in the original *.ts file (e.g.
+				// `export type Foo`, `export enum Bar`, `export interface Baz`,
+				// `export class Qux`, `export const X`, ...) become module-private
+				// in the generated *.d.ts and are no longer importable by
+				// consumers of the library. See issue #1380.
+				const EXPORTABLE_KINDS = "type|enum|interface|class|abstract\\s+class|function|const|let|var|namespace";
+				const restoreStrippedExports = function (dtsContent, originalSource) {
+					// collect names that were re-exported in the original source
+					const exportedNames = new Set();
+					const exportRe = new RegExp(`\\bexport\\s+(?:${EXPORTABLE_KINDS})\\s+(\\w+)`, "g");
+					let match;
+					while ((match = exportRe.exec(originalSource)) !== null) {
+						exportedNames.add(match[1]);
+					}
+					if (exportedNames.size === 0) {
+						return dtsContent;
+					}
+					// walk lines, track brace depth, and re-add `export` at depth 1
+					// (the body of the `declare module "<fqn>" { ... }` wrapper)
+					const declRe = new RegExp(`^(\\s+)(${EXPORTABLE_KINDS})\\s+(\\w+)`);
+					const lines = dtsContent.split(/\r?\n/);
+					let depth = 0;
+					for (let i = 0; i < lines.length; i++) {
+						const line = lines[i];
+						if (depth === 1) {
+							const decl = declRe.exec(line);
+							if (decl && exportedNames.has(decl[3])) {
+								lines[i] = `${decl[1]}export ${line.slice(decl[1].length)}`;
+							}
+						}
+						for (let c = 0; c < line.length; c++) {
+							const ch = line[c];
+							if (ch === "{") depth++;
+							else if (ch === "}") depth--;
+						}
+					}
+					return lines.join("\n");
+				};
+
 				// emit type definitions in-memory and read/write resources from the UI5 workspace
 				const typeDefs = {};
 				const host = ts.createCompilerHost(options);
@@ -289,6 +331,17 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 				host.writeFile = function (fileName, content, writeByteOrderMark, onError, sourceFiles /*, data*/) {
 					const sourceFile = sourceFiles[0]; // we typically only have one source file!
 					config.debug && log.info(`  + [${/(\.d\.ts(?:\.map)?)$/.exec(fileName)[0]}] ${fileName}`);
+					if (/\.d\.ts$/.test(fileName)) {
+						// restore `export` modifiers stripped by TSC's d.ts emitter
+						// when the source was wrapped in `declare module "<fqn>" { ... }`
+						const resourcePath = /^\//.test(sourceFile.fileName)
+							? sourceFile.fileName
+							: `/${sourceFile.fileName}`;
+						const originalSource = sourcesMap[resourcePath];
+						if (originalSource) {
+							content = restoreStrippedExports(content, originalSource);
+						}
+					}
 					if (/\.d\.ts\.map$/.test(fileName)) {
 						// for d.ts.map we need to fix the sources mapping in order to be
 						// able to use the "Go to Source Definition" feature of VSCode

--- a/showcases/ui5-tslib/src/Example.ts
+++ b/showcases/ui5-tslib/src/Example.ts
@@ -8,6 +8,54 @@ import ExampleRenderer from "./ExampleRenderer";
 import { ExampleColor } from "./library";
 
 /**
+ * An additional export to test the re-export of interfaces in d.ts
+ *
+ * @export
+ * @enum {String}
+ */
+export type DummyType = {
+	someProperty: string;
+};
+// fixture: a non-exported type to verify the d.ts post-processing in
+// ui5-tooling-transpile only restores `export` on previously-exported decls
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type LocalType = {
+	someProperty: string;
+};
+
+/**
+ * An additional export to test the re-export of enums in d.ts
+ *
+ * @export
+ * @enum {String}
+ */
+export enum DummyEnum {
+	Value1 = "Value1",
+	Value2 = "Value2",
+}
+// fixture: a non-exported enum (see LocalType note above)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+enum LocalEnum {
+	Value1 = "Value1",
+	Value2 = "Value2",
+}
+
+/**
+ * An additional export to test the re-export of interfaces in d.ts
+ *
+ * @export
+ * @enum {String}
+ */
+export interface DummyInterface {
+	someProperty: string;
+}
+// fixture: a non-exported interface (see LocalType note above)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface LocalInterface {
+	someProperty: string;
+}
+
+/**
  * Constructor for a new <code>ui5.ecosystem.demo.tslib.Example</code> control.
  *
  * Some class description goes here.


### PR DESCRIPTION
Fixes #1380.

## Problem

When `ui5-tooling-transpile` generates `.d.ts` files for a TypeScript library it wraps the original source in `declare module "<fqn>" { ... }` before handing it to TSC, so the emitted declaration references the fully-qualified UI5 module name. Inside that ambient module body, TSC's d.ts emitter strips the `export` modifier from top-level declarations — turning previously re-exported `type` / `enum` / `interface` / `class` / `function` / `const` / `let` / `var` / `namespace` symbols into module-private ones. Consumers of the library can then no longer import them.

For the `ui5-tslib` showcase, `src/Example.ts` already contains `export type DummyType`, `export enum DummyEnum`, `export interface DummyInterface`. Before this fix the generated `dist/.../Example.d.ts` re-emitted them without `export`, making them inaccessible:

```ts
declare module "ui5/ecosystem/demo/tslib/Example" {
    type DummyType  = { ... };        // <-- export missing
    enum DummyEnum { ... }            // <-- export missing
    interface DummyInterface { ... }  // <-- export missing
    export default class Example extends Control { ... }
}
```

The user-reported case in #1380 also covers stripped `class` exports.

## Fix

Post-process the d.ts emitted by TSC inside `host.writeFile` in [packages/ui5-tooling-transpile/lib/task.js](packages/ui5-tooling-transpile/lib/task.js):

1. Collect names that were `export`ed in the original source for the supported kinds (`type | enum | interface | class | abstract class | function | const | let | var | namespace`).
2. Walk the emitted d.ts line by line tracking brace depth.
3. At depth `1` (i.e. directly inside the `declare module "<fqn>" { ... }` wrapper), re-prepend `export ` to declarations whose name matches the collected set.

Names that were never exported in the source remain module-private — verified with new `LocalType` / `LocalEnum` / `LocalInterface` fixtures added to the `ui5-tslib` showcase. The default-exported `Example` class is unaffected since TSC never strips `default`.

## Verification

Rebuilt `showcases/ui5-tslib`. The regenerated `dist/resources/ui5/ecosystem/demo/tslib/Example.d.ts` now correctly emits:

```ts
declare module "ui5/ecosystem/demo/tslib/Example" {
    export type DummyType = { ... };
    type LocalType = { ... };          // stays private — never had export in source
    export enum DummyEnum { ... }
    enum LocalEnum { ... }             // stays private
    export interface DummyInterface { ... }
    interface LocalInterface { ... }   // stays private
    export default class Example extends Control { ... }
}
```

## Notes

- The post-processing runs only for `.d.ts` writes, not `.d.ts.map`.
- Brace counting is done in raw text without lexing strings/comments — adequate for the very narrow shapes a d.ts can take, but if a fully AST-based transformer is preferred I'm happy to follow up.
- Includes a changeset (`patch` bump for `ui5-tooling-transpile`).
