### PR TITLE
fix(ui5-tooling-modules): keep Node.js 20 support by holding `ignore-walk` at ^8.0.0

### DIFF
--- a/.changeset/keep-node20-ignore-walk.md
+++ b/.changeset/keep-node20-ignore-walk.md
@@ -1,0 +1,7 @@
+---
+"ui5-tooling-modules": patch
+---
+
+fix(ui5-tooling-modules): keep Node.js 20 support by holding `ignore-walk` at `^8.0.0`
+
+`ignore-walk@9` is a Node-engines-only bump (no API changes) that raises the required Node.js version to `^22.22.2 || ^24.15.0 || >=26.0.0`. Since the only usage site is unchanged between v8 and v9, downgrade to `^8.0.0` so the package keeps working on Node.js 20 (`^20.17.0 || >=22.9.0`). See `DEPENDENCIES.md` for the rationale and the conditions under which this hold-back can be lifted.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,55 @@
+# Dependency Decisions
+
+This document records intentional decisions to **hold back** or **deviate from**
+the latest version of a dependency, including the reasoning. The goal is to
+make it easy to revisit these pins when the constraints that motivated them
+change (e.g. a project-wide minimum Node.js bump).
+
+When you add or change an entry here, update both the rationale **and** the
+"Revisit when …" trigger so a future maintainer (or Dependabot/Renovate
+reviewer) can decide quickly whether the hold-back still applies.
+
+---
+
+## Pinned / held-back dependencies
+
+### `ignore-walk` — held at `^8.0.0` (latest is `9.x`)
+
+- **Package(s) affected:** [`ui5-tooling-modules`](packages/ui5-tooling-modules)
+- **Held since:** 2026-06
+- **Latest version available:** `9.x`
+- **Pinned at:** `^8.0.0`
+
+#### Rationale
+
+`ignore-walk@9` is a Node-engines-only bump (no API changes) that raises the
+required Node.js version to `^22.22.2 || ^24.15.0 || >=26.0.0`, dropping
+Node.js 20 entirely.
+
+| Version | Node.js engines |
+| --- | --- |
+| `ignore-walk@9` | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
+| `ignore-walk@8` | `^20.17.0 \|\| >=22.9.0` |
+| `ignore-walk@7` | `^18.17.0 \|\| >=20.5.0` |
+
+`ui5-tooling-modules` is a UI5 CLI extension and therefore consumed by UI5
+application projects in their build pipelines. Forcing those projects onto
+Node.js 22.22.2+ purely because of an internal `ignore-walk` upgrade is a
+disproportionate constraint — Node.js 20 is still a supported LTS line and
+broadly used in UI5 build environments.
+
+The only usage in `ui5-tooling-modules` is `walk.sync({ path })` in
+[`packages/ui5-tooling-modules/lib/util.js`](packages/ui5-tooling-modules/lib/util.js),
+which is identical in v8 and v9 — so there is no functional reason to upgrade
+ahead of a project-wide Node.js floor bump.
+
+#### Revisit when …
+
+- The repository (or `ui5-tooling-modules` specifically) raises its supported
+  Node.js floor to `>=22.22.2`, **or**
+- `ignore-walk@9+` introduces a feature/fix we actually need, **or**
+- `ignore-walk@8` reaches end-of-life / receives a security advisory that is
+  not patched on the v8 line.
+
+When any of the above is true, bump to the latest `ignore-walk` and remove
+this entry.

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -39,7 +39,7 @@
     "estree-walker": "^3.0.3",
     "fast-xml-parser": "^5.8.0",
     "handlebars": "^4.7.9",
-    "ignore-walk": "^9.0.0",
+    "ignore-walk": "^8.0.0",
     "js-yaml": "^4.1.1",
     "minimatch": "^10.2.5",
     "prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,8 +528,8 @@ importers:
         specifier: ^4.7.9
         version: 4.7.9
       ignore-walk:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^8.0.0
+        version: 8.0.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -6316,9 +6316,9 @@ packages:
     resolution: {integrity: sha512-T4gbf83A4NH95zvhVYZc+qWocBBGlpzUXLPGurJggw/WIOwicfXJChLDP/iBZnN5WqROSu5Bm3hhle4z8a8YGQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  ignore-walk@9.0.0:
-    resolution: {integrity: sha512-tCBEZV2z2FNpIDl2vrhiWzIHzs4qOAuIDEO85eS02vZ3L1U3P56qpPL8GuGGAijDktAEaq2swMkO/Fmbo7YmfQ==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+  ignore-walk@8.0.0:
+    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -16480,7 +16480,7 @@ snapshots:
     dependencies:
       minimatch: 9.0.9
 
-  ignore-walk@9.0.0:
+  ignore-walk@8.0.0:
     dependencies:
       minimatch: 10.2.5
 


### PR DESCRIPTION
## Why

`ignore-walk@9` is a **Node-engines-only bump** (no API changes) that raises the required Node.js version to `^22.22.2 || ^24.15.0 || >=26.0.0`, dropping Node.js 20 entirely.

| Version  | Node.js engines                              |
| -------- | -------------------------------------------- |
| `9.x`    | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0`       |
| `8.x`    | `^20.17.0 \|\| >=22.9.0`                     |
| `7.x`    | `^18.17.0 \|\| >=20.5.0`                     |

`ui5-tooling-modules` is consumed by UI5 application projects in their build pipelines. Forcing those projects onto Node.js 22.22.2+ purely because of an internal `ignore-walk` upgrade is a disproportionate constraint — Node.js 20 is still a supported LTS line and broadly used in UI5 build environments.

The only usage site is `walk.sync({ path })` in `packages/ui5-tooling-modules/lib/util.js`, which is identical between v8 and v9 — so there is no functional reason to upgrade ahead of a project-wide Node.js floor bump.

## What

- ⬇️ `packages/ui5-tooling-modules/package.json`: `ignore-walk` `^9.0.0` → `^8.0.0`
- 🔄 `pnpm-lock.yaml` updated accordingly
- 📝 New top-level `DEPENDENCIES.md` documenting **why** this is held back and **when** to revisit (so a future Dependabot/Renovate review can decide quickly whether the hold-back still applies)
- 🦋 Changeset (patch) for `ui5-tooling-modules`

## Verification

- \`pnpm install\` resolved cleanly
- \`pnpm --filter ui5-tooling-modules test\` — all 39 tests pass
- \`pnpm --filter ui5-tooling-modules lint\` — 0 errors (only pre-existing JSDoc warnings)

## Revisit when …

(also captured in \`DEPENDENCIES.md\`)

- The repo (or this package specifically) raises its supported Node.js floor to \`>=22.22.2\`, **or**
- \`ignore-walk@9+\` introduces a feature/fix we actually need, **or**
- \`ignore-walk@8\` reaches end-of-life or receives a security advisory not patched on the v8 line.