### PR TITLE
fix: set liveReload option for @ui5/server v5 MiddlewareManager compat

### DIFF
--- a/.changeset/ui5-server-v5-livereload-compat.md
+++ b/.changeset/ui5-server-v5-livereload-compat.md
@@ -1,0 +1,6 @@
+---
+"ui5-middleware-ui5": patch
+"cds-plugin-ui5": patch
+---
+
+Pass an explicit `liveReload` option when constructing `@ui5/server`'s `MiddlewareManager`, preventing a startup crash (`Cannot read properties of undefined (reading 'active')`) when running on `@ui5/server` v5. The v5 server supplies the `liveReload` default only via a function default parameter, which is bypassed by the explicit `options` object passed here. No effect on `@ui5/server` v4.

--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -155,6 +155,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 				//sendSAPTargetCSP,
 				//serveCSPReports,
 				//simpleIndex: true
+				liveReload: { active: false, token: null },
 			},
 		});
 		await middlewareManager.applyMiddleware(router);

--- a/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
+++ b/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
@@ -106,6 +106,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 			//sendSAPTargetCSP,
 			//serveCSPReports,
 			//simpleIndex: true
+			liveReload: { active: false, token: null },
 		},
 	});
 	await middlewareManager.applyMiddleware(router);


### PR DESCRIPTION
## Problem

UI5 Tooling v5 (currently `5.0.0-alpha.x`) changed the options contract of the internal `@ui5/server` `MiddlewareManager`. When the dev-server stack is run on `@ui5/server@5` (e.g. to evaluate the new incremental-build / build-result caching), `ui5-middleware-ui5` and `cds-plugin-ui5` crash at server startup:

```
TypeError: Cannot read properties of undefined (reading 'active')
    at @ui5/server/lib/middleware/MiddlewareManager.js:245   // active: this.options.liveReload.active
    at MiddlewareManager.addStandardMiddleware
    at applyUI5Middleware (.../lib/applyUI5Middleware.js)
```

## Root cause

`@ui5/server@5` introduced a live-reload feature and expresses its option defaults **only** as a function default parameter:

```js
constructor({graph, rootProject, sources, resources, buildReader, options = {
    sendSAPTargetCSP: false, serveCSPReports: false,
    liveReload: {active: false, token: null}
}}) { /* ... */ this.options = options; }
```

A JS default parameter applies **only when the argument is `undefined`** — it does not backfill missing keys. Both `ui5-middleware-ui5/lib/applyUI5Middleware.js` and `cds-plugin-ui5/lib/applyUI5Middleware.js` pass an explicit (but effectively empty) `options: {}`, so the server default never materialises and `this.options.liveReload` is `undefined`. `addStandardMiddleware()` then dereferences `this.options.liveReload.active` (and `.token`) → crash.

## Fix

Pass an explicit `liveReload: { active: false, token: null }` in the options object in both files. This disables live-reload for the embedded server (the host server / `fiori-tools-appreload` already handles reload), preserving the previous v4 behaviour.

## Backward compatibility

`@ui5/server@4`'s `MiddlewareManager` has no `liveReload` handling at all (its default is just `{sendSAPTargetCSP, serveCSPReports}`), so the extra option is an inert no-op on v4. Peer ranges are intentionally **not** changed — v5 is still alpha; this only removes the crash so the packages are ready when v5 support is added.

## Validation

Validated end-to-end by forcing the entire `@ui5/*` stack to `5.0.0-alpha.5` (npm `overrides` + clean install) in a real consumer project, with both fixes applied via `patch-package`:

- **`ui5-middleware-ui5` (`fiori run`)** — a Fiori freestyle app embeds a UI5 component via `ui5-middleware-ui5`, with CAP (`cds watch`) serving the OData backend. On `@ui5/server@5` the app now **renders with live OData data**, all controls present, and the component's resources (43 files) are live-transpiled and served by `ui5-middleware-ui5`. Before the fix the server died at startup with the `TypeError` above; after, `GET /index.html` returns **200** and the app loads fully.
- **`cds-plugin-ui5` (`cds watch`)** — with the same fix, `cds-plugin-ui5` boots and mounts the UI5 apps on `@ui5/server@5` (it shares the byte-identical `MiddlewareManager` call).
