### PR TITLE
fix(cds-plugin-ui5,ui5-middleware-ui5): recognize UI5 CLI v5 'component' type

### DIFF
--- a/.changeset/support-component-type.md
+++ b/.changeset/support-component-type.md
@@ -1,0 +1,6 @@
+---
+"cds-plugin-ui5": patch
+"ui5-middleware-ui5": patch
+---
+
+Recognize UI5 projects with `type: component` (introduced in UI5 CLI v5) alongside `type: application` when discovering UI5 modules in [findUI5Modules.js](packages/cds-plugin-ui5/lib/findUI5Modules.js). Fixes [#1392](https://github.com/ui5-community/ui5-ecosystem-showcase/issues/1392).

--- a/packages/cds-plugin-ui5/lib/findUI5Modules.js
+++ b/packages/cds-plugin-ui5/lib/findUI5Modules.js
@@ -132,7 +132,8 @@ module.exports = async function findUI5Modules({ cwd, cds, skipLocalApps, skipDe
 			// extract the configuration
 			const ui5Config = ui5Configs?.[0];
 			const isApplication = ui5Config?.type === "application";
-			if (isApplication) {
+			const isComponent = ui5Config?.type === "component";
+			if (isApplication || isComponent) {
 				// determine the module path based on the location of the ui5.yaml
 				const modulePath = path.dirname(ui5YamlPath);
 

--- a/packages/ui5-middleware-ui5/lib/findUI5Modules.js
+++ b/packages/ui5-middleware-ui5/lib/findUI5Modules.js
@@ -67,7 +67,8 @@ module.exports = async function findUI5Modules({ cwd, config, log }) {
 			// extract the configuration
 			const ui5Config = ui5Configs?.[0];
 			const isApplication = ui5Config?.type === "application";
-			if (isApplication) {
+			const isComponent = ui5Config?.type === "component";
+			if (isApplication || isComponent) {
 				// determine the module path based on the location of the ui5.yaml
 				const modulePath = path.dirname(ui5YamlPath);
 


### PR DESCRIPTION
Fixes #1392.

UI5 CLI v5 introduces a new project type `component` in addition to the existing `application` type. The module discovery in [packages/cds-plugin-ui5/lib/findUI5Modules.js](packages/cds-plugin-ui5/lib/findUI5Modules.js) and [packages/ui5-middleware-ui5/lib/findUI5Modules.js](packages/ui5-middleware-ui5/lib/findUI5Modules.js) previously only matched `application`, so component-typed UI5 projects were silently skipped.

### Change

Treat `type: component` the same as `type: application` when collecting UI5 modules:

```js
const isApplication = ui5Config?.type === "application";
const isComponent = ui5Config?.type === "component";
if (isApplication || isComponent) {
    // ...
}
```

A changeset is included so both packages get a patch release.