### PR TITLE
[PoC] ui5-middleware-ui5: serve mounted module via UI5 CLI v5 build cache (NOT FOR MERGE)

### DIFF
--- a/.changeset/poc-ui5-middleware-ui5-build-cache.md
+++ b/.changeset/poc-ui5-middleware-ui5-build-cache.md
@@ -1,0 +1,6 @@
+---
+---
+
+PoC (NOT FOR MERGE): explore serving a mounted UI5 module through the UI5 CLI v5
+build cache (`graph.serve()` → `BuildServer`) in `ui5-middleware-ui5`, opt-in via
+`buildCache: true`. Intentionally empty changeset — no release.

--- a/.changeset/ui5-server-v5-livereload-compat.md
+++ b/.changeset/ui5-server-v5-livereload-compat.md
@@ -1,0 +1,6 @@
+---
+"ui5-middleware-ui5": patch
+"cds-plugin-ui5": patch
+---
+
+Pass an explicit `liveReload` option when constructing `@ui5/server`'s `MiddlewareManager`, preventing a startup crash (`Cannot read properties of undefined (reading 'active')`) when running on `@ui5/server` v5. The v5 server supplies the `liveReload` default only via a function default parameter, which is bypassed by the explicit `options` object passed here. No effect on `@ui5/server` v4.

--- a/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
+++ b/packages/cds-plugin-ui5/lib/applyUI5Middleware.js
@@ -155,6 +155,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 				//sendSAPTargetCSP,
 				//serveCSPReports,
 				//simpleIndex: true
+				liveReload: { active: false, token: null },
 			},
 		});
 		await middlewareManager.applyMiddleware(router);

--- a/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
+++ b/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
@@ -106,6 +106,7 @@ module.exports = async function applyUI5Middleware(router, options) {
 			//sendSAPTargetCSP,
 			//serveCSPReports,
 			//simpleIndex: true
+			liveReload: { active: false, token: null },
 		},
 	});
 	await middlewareManager.applyMiddleware(router);

--- a/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
+++ b/packages/ui5-middleware-ui5/lib/applyUI5Middleware.js
@@ -3,6 +3,27 @@
 const path = require("path");
 const fs = require("fs");
 
+// === PoC (UI5 CLI v5 build cache) ===========================================
+// Track BuildServers created by the opt-in cache path and release their file
+// watchers + SQLite cache handles once, on a graceful stop. A single shared
+// SIGTERM listener (registered lazily) avoids per-module MaxListeners warnings.
+// SIGTERM only — NOT SIGINT — so the host dev-server's Ctrl+C handling is left
+// untouched. Productisation should call destroy() from the host server's own
+// close hook instead of relying on a process signal.
+const __ui5BuildServers = new Set();
+let __ui5CleanupRegistered = false;
+function __registerBuildServerCleanup(buildServer) {
+	__ui5BuildServers.add(buildServer);
+	if (!__ui5CleanupRegistered) {
+		__ui5CleanupRegistered = true;
+		process.once("SIGTERM", () => {
+			for (const bs of __ui5BuildServers) {
+				bs.destroy().catch(() => {});
+			}
+		});
+	}
+}
+
 /**
  * @typedef applyUI5MiddlewareOptions
  * @type {object}
@@ -69,32 +90,79 @@ module.exports = async function applyUI5Middleware(router, options) {
 
 	const rootProject = graph.getRoot();
 
-	const readers = [];
-	await graph.traverseBreadthFirst(async function ({ project: dep }) {
-		if (dep.getName() === rootProject.getName()) {
-			// Ignore root project
-			return;
+	// === PoC (UI5 CLI v5 build cache) ========================================
+	// Opt-in: serve the mounted module through the v5 build-then-serve cache
+	// (graph.serve -> BuildServer) instead of the live source readers, so the
+	// build result is cached and reused across restarts.
+	// Two gates must BOTH hold, which guarantees ZERO change for @ui5/server v3/v4:
+	//   1. options.buildCache === true        (explicit opt-in via the module config)
+	//   2. typeof graph.serve === "function"  (this API only exists on @ui5/* v5)
+	// Requires an application/component-type configFile that defines the build
+	// TASKS (e.g. ui5-build.yaml). A `type: module` config is NOT supported here.
+	const useBuildCache = options.buildCache === true && typeof graph.serve === "function";
+
+	let resources;
+	if (useBuildCache) {
+		try {
+			const { default: Cache } = await import("@ui5/project/build/cache/Cache");
+			const buildServer = await graph.serve({
+				// Build the root (the mounted module) eagerly at startup so that a
+				// restart hits the cache; mirrors @ui5/server's own serve().
+				initialBuildRootProject: true,
+				excludedTasks: ["minify", "generateLibraryPreload", "generateComponentPreload", "generateBundle"],
+				cache: Cache.Default,
+			});
+			// Track for cleanup immediately (before touching readers), so the watcher
+			// + SQLite handle are released even if a later step throws.
+			__registerBuildServerCleanup(buildServer);
+			buildServer.on("error", (err) => {
+				console.error(`[ui5-middleware-ui5] BuildServer error: ${err?.message ?? err}`);
+				if (err?.stack) {
+					console.error(err.stack);
+				}
+			});
+			resources = {
+				rootProject: buildServer.getRootReader(),
+				dependencies: buildServer.getDependenciesReader(),
+				all: buildServer.getReader(),
+			};
+		} catch (err) {
+			// Degrade to the live source path rather than crash host startup if the
+			// build cache is unavailable (e.g. watcher-init / build-setup failure).
+			console.error(`[ui5-middleware-ui5] build cache unavailable, falling back to live source readers: ${err?.message ?? err}`);
+			resources = undefined;
 		}
-		readers.push(dep.getReader({ style: "runtime" }));
-	});
+	}
 
-	const dependencies = createReaderCollection({
-		name: `Dependency reader collection for project ${rootProject.getName()}`,
-		readers,
-	});
+	if (!resources) {
+		// --- legacy path (v3/v4, v5 without opt-in, or cache fallback): UNCHANGED -
+		const readers = [];
+		await graph.traverseBreadthFirst(async function ({ project: dep }) {
+			if (dep.getName() === rootProject.getName()) {
+				// Ignore root project
+				return;
+			}
+			readers.push(dep.getReader({ style: "runtime" }));
+		});
 
-	const rootReader = rootProject.getReader({ style: "runtime" });
+		const dependencies = createReaderCollection({
+			name: `Dependency reader collection for project ${rootProject.getName()}`,
+			readers,
+		});
 
-	// TODO change to ReaderCollection once duplicates are sorted out
-	const combo = createReaderCollection({
-		name: "server - prioritize workspace over dependencies",
-		readers: [rootReader, dependencies],
-	});
-	const resources = {
-		rootProject: rootReader,
-		dependencies: dependencies,
-		all: combo,
-	};
+		const rootReader = rootProject.getReader({ style: "runtime" });
+
+		// TODO change to ReaderCollection once duplicates are sorted out
+		const combo = createReaderCollection({
+			name: "server - prioritize workspace over dependencies",
+			readers: [rootReader, dependencies],
+		});
+		resources = {
+			rootProject: rootReader,
+			dependencies: dependencies,
+			all: combo,
+		};
+	}
 
 	// TODO: rework ui5-server API and make public
 	const { default: MiddlewareManager } = await import("@ui5/server/internal/MiddlewareManager");


### PR DESCRIPTION
> ## ⚠️ PoC — NOT FOR MERGE
> This is a **proof of concept** to explore *how* `ui5-middleware-ui5` could serve a mounted UI5
> module through the **UI5 CLI v5 build cache**, and to get maintainer feedback on the approach.
> It is built against `@ui5/* 5.0.0-alpha.5` (pre-release) and uses `@ui5/*` **internal** APIs.
> Opening as a draft for discussion, not as a merge candidate.

## What it does
Today `ui5-middleware-ui5` serves the mounted module from **live source readers**
(`getReader({style:"runtime"})`) + the project's serve **middleware**. The new UI5 CLI v5 build
cache (`graph.serve()` → `BuildServer`, backed by SQLite) is never engaged.

This PoC adds an **opt-in** path that mirrors what `@ui5/server`'s own `serve()` does — run the
incremental, cached build and serve the built output:

```js
const buildServer = await graph.serve({
  initialBuildRootProject: true,
  excludedTasks: ["minify","generateLibraryPreload","generateComponentPreload","generateBundle"],
  cache: Cache.Default,
});
resources = { rootProject: buildServer.getRootReader(),
              dependencies: buildServer.getDependenciesReader(),
              all: buildServer.getReader() };
```

## Backward compatibility — the design centre
The new path is behind **two** gates that BOTH must hold:
1. `options.buildCache === true` — explicit per-module opt-in
2. `typeof graph.serve === "function"` — this API exists **only on `@ui5/*` v5**

So on **v3/v4** the gate is always false → the original code runs **unchanged**, and the v5-only
`import("@ui5/project/build/cache/Cache")` (inside the branch) is never evaluated. A `try/catch`
degrades to the legacy path if the build/watcher setup fails (never crashes host startup).

Verified (mounting `ui5-cc-spreadsheetimporter` into a Fiori freestyle app):

| Env | `ProjectGraph.serve` | Path | Component serves | How |
|---|---|---|---|---|
| v5 + `buildCache:true` | function | **build cache** | ✅ 200, transpiled | real run |
| v5, no opt-in | function | legacy live | ✅ 200 | real run |
| **v4** (`@ui5/server` 4.0.6) | **undefined** | legacy live | ✅ 200 | real run |
| **v3** (`@ui5/server` 3.6.1) | **undefined** | legacy (gate false) | n/a | introspection + static gated-import check |

## What needs to become public in `@ui5/*` to productise this
This PoC only works by reaching into **internal / undocumented** APIs. For any tool that *embeds*
the dev server — `ui5-middleware-ui5`, `cds-plugin-ui5`, Fiori tools, `karma-ui5` — to use the build
cache on a stable footing, the following need a public contract. (Verified against
`@ui5/project`/`@ui5/server` `5.0.0-alpha.5`.)

**1. A server-less serve-middleware factory in `@ui5/server` — the core gap.**
`@ui5/server`'s *only* public export is `serve(graph, options)` (its `exports` map is literally
`{ ".": serve }`), and `serve()` **binds an HTTP port and starts a standalone server**. But embedders
already run their own server — CAP's `cds watch`, Fiori tools, an Express host — and need to **mount
UI5's serve stack into their own router**, not spawn a second listener. With no public middleware
API, both `ui5-middleware-ui5` and `cds-plugin-ui5` import `@ui5/server/internal/MiddlewareManager`
— explicitly under `/internal/` (no semver guarantee), and the call site even carries the comment
*"TODO: rework ui5-server API and make public"*.
**Ask:** a public, documented factory — e.g. `getMiddleware({ graph, resources, sources, options }) → express handler` — returning the assembled serve middleware (resource serving, CSP, compression,
live-reload injection, etc.) **without** listening on a port. This is the single most important one:
it's what makes embedding the dev server (cached or not) supportable instead of internal-spelunking
that re-breaks on every minor release.

**2. `ProjectGraph.serve()` made public + documented in `@ui5/project`.**
This is the entry point to the build-then-serve **cache** — it runs the incremental, cached build and
returns a `BuildServer`. It sits directly below `build()` in `ProjectGraph.js`, but unlike `build()`
(which is `@public` with a full parameter block) **`serve()` has no JSDoc at all** — no `@public`, no
documented options. Embedders are guessing at `{ initialBuildRootProject, excludedTasks, cache,
ui5DataDir }`.
**Ask:** mark `serve()` `@public` and document its options and return type.

**3. The `BuildServer` contract made public in `@ui5/project`.**
`graph.serve()` returns a `BuildServer`, but the class is **not in the package `exports`** (only
`./build/cache/Cache`, `./graph`, `./graph/ProjectGraph`, `./graph/projectGraphBuilder` are), so there
is no importable type. Its `getRootReader()/getDependenciesReader()/getReader()` *are* JSDoc-`@public`
— but only reachable off an undocumented return value — and `destroy()` + the `error` event, both
**required for correct lifecycle** (releasing the file watcher and the SQLite cache handle on
shutdown; note the SIGTERM workaround in this PoC), are not part of any published surface.
**Ask:** publish the `BuildServer` reader-accessors, `destroy()`, and event contract — or expose them
as a documented return type of `serve()`.

**4. A capability/version signal (nice-to-have).**
This PoC duck-types `typeof graph.serve === "function"` to detect v5. A documented "is the build-cache
serve available?" check would beat sniffing for a method.

**Already public — the model to follow:** `@ui5/project/build/cache/Cache` (the
`Cache.Default|Force|ReadOnly|Off` enum) *is* a proper public export — exactly the shape items 1–3
need. Net: without #1 especially, every tool that embeds the UI5 dev server re-implements the same
`@ui5/server/internal` glue and re-breaks on each `@ui5/server`/`@ui5/project` release.

## Performance (component build phase, on restart)
| restart | component build |
|---|---|
| cold (populate cache) | 3.53 s |
| warm (cache hit) | **1.8 ms** — `graph.serve()` skips the rebuild |

The per-edit loop is still a full rebuild (the standard `ui5-tooling-transpile`/`-modules` tasks
aren't differential-build-aware — out of scope here).

## ⚠️ Config caveat (important — not transparently drop-in)
The cache path only transpiles via build **tasks**, so the mounted module must be referenced with a
**task-based, `application`/`component`-type** configFile that also carries the `mountPath`
customConfiguration. **A task-only config will NOT serve on the v3/v4 live fallback** (no serve
middleware to transpile). A config meant to be safe across versions must carry **both**
`builder.customTasks` *and* `server.customMiddleware`. The code-path is version-safe; the
*configuration* a user adopts to enable this is effectively v5-oriented.

## Known limitations (PoC)
- Uses `@ui5/server/internal/MiddlewareManager` + `@ui5/project` build internals flagged "TODO: make public" — see the section above; may churn before GA.
- `generateComponentPreload` excluded → `Component-preload.js` 404s; relies on UI5's individual-module fallback (works in dev).
- `BuildServer.destroy()` wired to SIGTERM only (PoC); productisation should hook the host server's close.

## Relationship to #1393
Stacks on #1393 (set `liveReload` for the v5 `MiddlewareManager`) — the diff includes it because it's
not yet in `main`; the **new** contribution here is the opt-in build-cache serve path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
