### PR TITLE
fix(ui5-tooling-modules): skip complex-type lookup when typeInfoRef has no module

### DIFF
--- a/.changeset/webc-registry-typeinforef-without-module.md
+++ b/.changeset/webc-registry-typeinforef-without-module.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": patch
+---
+
+Guard the complex-type lookup in [WebComponentRegistry#parseComplexType](packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js) against type references that have no `module`. `WebComponentRegistryHelper.deriveCacheKey` returns `undefined` for such references, which previously caused the cross-package lookup and "global import" fallback to misfire (e.g. logging `Reference package '…' for complex type '…' not found` and producing unusable cache entries). When `typeInfoRef.module` is missing, skip the complex-type resolution entirely and fall through to the `any` fallback.

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -411,25 +411,29 @@ class RegistryEntry {
 				}
 
 				// case 1b: complex type is enum, interface or class
-				let complexType = this.#parseComplexType(typeInfoRef, this);
-				if (!complexType && this.namespace !== typeInfoRef.package) {
-					// case 1c: check for cross package type reference
-					const refPackage = WebComponentRegistry.getPackage(typeInfoRef.package);
-					if (refPackage) {
-						complexType = this.#parseComplexType(typeInfoRef, refPackage);
-					} else {
-						logger.log(`Reference package '${typeInfoRef.package}' for complex type '${type}' not found`);
-					}
-				} else if (!complexType && typeInfoRef) {
-					// case 1d: not able to find the type but there is a reference ==> try to import original webc type from the importing module itself
-					const refClass = this.classes[typeCacheKey]; //typeInfoRef.module.match(/\/(.*).js$/)?.[1]
-					if (refClass) {
-						return {
-							dtsType: type,
-							ui5Type: "any",
-							packageName: refClass._ui5QualifiedNameSlashes,
-							globalImport: true,
-						};
+				let complexType;
+				if (typeInfoRef.module) {
+					// some types are not having a module
+					complexType = this.#parseComplexType(typeInfoRef, this);
+					if (!complexType && this.namespace !== typeInfoRef.package) {
+						// case 1c: check for cross package type reference
+						const refPackage = WebComponentRegistry.getPackage(typeInfoRef.package);
+						if (refPackage) {
+							complexType = this.#parseComplexType(typeInfoRef, refPackage);
+						} else {
+							logger.log(`Reference package '${typeInfoRef.package}' for complex type '${type}' not found`);
+						}
+					} else if (!complexType && typeInfoRef) {
+						// case 1d: not able to find the type but there is a reference ==> try to import original webc type from the importing module itself
+						const refClass = this.classes[typeCacheKey]; //typeInfoRef.module.match(/\/(.*).js$/)?.[1]
+						if (refClass) {
+							return {
+								dtsType: type,
+								ui5Type: "any",
+								packageName: refClass._ui5QualifiedNameSlashes,
+								globalImport: true,
+							};
+						}
 					}
 				}
 


### PR DESCRIPTION
### Problem

[WebComponentRegistry#parseComplexType](packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js) resolves complex web-component type references (enums / interfaces / classes) by deriving a cache key from `typeInfoRef.module` + `typeInfoRef.name` via [WebComponentRegistryHelper.deriveCacheKey](packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js#L46-L53):

```js
deriveCacheKey(keyDef) {
    if (keyDef?.module) {
        return `${keyDef.module}>>${keyDef.name}`;
    }
    return undefined;
}
```

Some web-component custom-elements manifests carry type references that omit `module` (e.g. ambient or library-internal types). With `module` missing the cache key is `undefined`, so:

- Every registry lookup keyed by `undefined` misses.
- The cross-package branch then logs a misleading `Reference package '<pkg>' for complex type '<t>' not found` and proceeds.
- The "global import" fallback (case 1d) returns a `globalImport` entry whose cache lookup was driven by the same `undefined` key, producing an unusable reference.

### Fix

Guard the entire complex-type resolution block on `typeInfoRef.module`. When the module is missing, skip the registry/cross-package/global-import probes entirely and fall through to the existing `any` fallback that the surrounding code already handles:

```js
let complexType;
if (typeInfoRef.module) { // some types are not having a module
    complexType = this.#parseComplexType(typeInfoRef, this);
    // … cross-package + global-import branches …
}
```

No behavior change for type references that do carry a module — those still flow through the existing cases 1b / 1c / 1d unchanged.

### Notes

- Changeset: `patch` for `ui5-tooling-modules`.
- Removes the noisy log line for manifests with module-less type entries.