### PR TITLE
refactor(ui5-tooling-modules): centralize custom-element detection in WebComponentRegistryHelper

### DIFF
--- a/.changeset/ui5-tooling-modules-iscustomelement-helper.md
+++ b/.changeset/ui5-tooling-modules-iscustomelement-helper.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": patch
+---
+
+Detect custom Web Components via a new `WebComponentRegistryHelper.isCustomElement(classDef)` predicate that walks the full superclass chain (skipping the `UI5Element` base class itself, which is paradoxically flagged as a custom element in the metadata). Replaces an inlined check in `rollup-plugin-webcomponents.js` whose hand-rolled superclass walk only looked at the direct superclass and could loop on a `const`-bound class reference. When a class is recognized as a custom element only via inheritance, a warning is now logged so the upstream `custom-elements.json` can be fixed to flag the subclass directly.

--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -252,8 +252,9 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 				modulePath = modulePath.replace(/\\/g, "/");
 				const moduleName = `${npmPackage}/${modulePath}`;
 				const clazz = WebComponentRegistry.getClassDefinition(moduleName);
-				// TODO: base classes must be ignored as UI5Element is flagged as custom element although it is a base class
-				if (clazz && clazz.customElement && npmPackage !== UI5_ELEMENT_NAMESPACE) {
+				// only treat real custom elements (or subclasses of one) as Web Components —
+				// base classes like UI5Element are intentionally excluded by isCustomElement
+				if (clazz && WebComponentRegistryHelper.isCustomElement(clazz) && npmPackage !== UI5_ELEMENT_NAMESPACE) {
 					return clazz;
 				}
 			}

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -278,7 +278,7 @@ class RegistryEntry {
 				this.#connectSuperclass(superclassRef);
 				classDef.superclass = superclassRef;
 			}
-		} else if (classDef.customElement && !WebComponentRegistryHelper.isUI5Element(classDef)) {
+		} else if (WebComponentRegistryHelper.isCustomElement(classDef)) {
 			/*
 			logger.warn(
 				`⚠️ The class '${this.namespace}/${classDef.name}' is a custom element not extending '${WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE}/${WebComponentRegistryHelper.UI5_ELEMENT_CLASS_NAME}!`,

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
@@ -1,3 +1,7 @@
+const SimpleLogger = require("./SimpleLogger");
+
+const logger = SimpleLogger.create("🧬 WCR");
+
 const WebComponentRegistryHelper = {
 	// the class name of the base class of all control wrappers
 	// corresponds to the "sap.ui.core.webc.WebComponent" class at runtime.
@@ -27,6 +31,42 @@ const WebComponentRegistryHelper = {
 
 	isUI5Element(ui5Superclass) {
 		return ui5Superclass.namespace === this.UI5_ELEMENT_NAMESPACE && ui5Superclass.name === this.UI5_ELEMENT_CLASS_NAME;
+	},
+
+	/**
+	 * Checks whether the given class definition represents an actual custom Web Component.
+	 *
+	 * A class is considered a custom element when it carries the <code>customElement</code> flag from
+	 * the custom-elements manifest (and is not the <code>UI5Element</code> base class itself, which is
+	 * paradoxically also flagged as a custom element in the metadata but is a base class, not a usable
+	 * component), OR when any ancestor in its superclass chain is one.
+	 *
+	 * The inherited case is reported via a warning so the upstream <code>custom-elements.json</code> can
+	 * be fixed to flag the subclass directly.
+	 *
+	 * @param {object} classDef a class definition from a WebComponentRegistry entry
+	 * @returns {boolean} whether the class is (or inherits from) a custom Web Component
+	 */
+	isCustomElement(classDef) {
+		if (!classDef) {
+			return false;
+		}
+		// direct flag — the common case
+		if (classDef.customElement && !this.isUI5Element(classDef)) {
+			return true;
+		}
+		// inherited: walk the superclass chain, ignoring the UI5Element base class itself
+		let superclass = classDef.superclass;
+		while (superclass) {
+			if (superclass.customElement && !this.isUI5Element(superclass)) {
+				logger.warn(
+					`The class '${classDef.namespace ?? "?"}/${classDef.name}' is treated as a custom element because its ancestor '${superclass.namespace ?? "?"}/${superclass.name}' is flagged as one. Please mark '${classDef.name}' as 'customElement: true' in the custom-elements manifest.`,
+				);
+				return true;
+			}
+			superclass = superclass.superclass;
+		}
+		return false;
 	},
 
 	isWebComponent(ui5Superclass) {


### PR DESCRIPTION
## Context

The check "is this class an actual Web Component, not just a base class?" lived inline in two places:

- [`rollup-plugin-webcomponents.js#lookupWebComponentsClass`](packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js)
- [`WebComponentRegistry#connectSuperclass`](packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js)

Both ran their own variant of `classDef.customElement && !isUI5Element(classDef)` — the carve-out exists because `UI5Element` is paradoxically flagged as a custom element in the manifest despite being the abstract base class. The plugin's version additionally tried to walk the superclass chain to honour inherited custom-element flags, but the loop never advanced: `clazz` was `const`, so re-reading `clazz?.superclass` each iteration returned the same node.

## Change

Introduce `WebComponentRegistryHelper.isCustomElement(classDef)` and call it from both sites.

The helper returns `true` when:

1. the class itself has `customElement: true` and isn't `UI5Element`, **or**
2. any ancestor in its superclass chain satisfies (1).

Case (2) — the inherited path — emits a `logger.warn` pointing at the descendant and the flagged ancestor, so a missing `customElement: true` in the upstream `custom-elements.json` is surfaced without breaking the build.

The plugin already delegates the analogous `isUI5ElementSubclass` check to `WebComponentRegistryHelper`, so this predicate joins it there and keeps the rule in exactly one place.

## Behaviour

- Real Web Components (e.g. `Avatar`) — still recognized.
- `UI5Element` itself — still excluded.
- Abstract bases like `InputBase` (no `customElement` flag anywhere in the chain) — still rejected.
- A subclass that inherits its custom-element nature from an ancestor but isn't itself flagged in the metadata — now recognized correctly across the full chain, with a warning identifying the metadata gap.

## Verification

- `pnpm --filter ui5-tooling-modules test` → 39/39 passing.
