### PR TITLE
feat(ui5-tooling-transpile): add `ui5-transpile` CLI for ad-hoc transpilation

### DIFF
--- a/.changeset/ui5-tooling-modules-manifest-validator.md
+++ b/.changeset/ui5-tooling-modules-manifest-validator.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": minor
+---
+
+Add upfront validation of Web Components custom-elements manifests. Each `custom-elements.json` / `custom-elements-internal.json` is now run through a dedicated validator immediately after parsing, producing a grouped, severity-ranked report of issues (with stable `WCV###` codes) instead of scattered warnings deep inside the parser. The previously eager `logger.warn`/`logger.error` calls in `WebComponentRegistry` have been retired in favour of the upfront report; runtime fallbacks are unchanged. A new opt-in plugin option `failOnManifestError` (default `false`) lets builds abort when any validator error is found.

--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -36,7 +36,7 @@
  *        `skip`, `scoping`, `scopeSuffix`, `enrichBusyIndicator`, `force`,
  *        `includeAssets`, `forceAllAssets`, `moduleBasePath`,
  *        `removeScopePrefix`, `skipJSDoc`, `skipDtsGeneration`,
- *        `customJSDocTags`, `removeCLDRData`
+ *        `customJSDocTags`, `removeCLDRData`, `failOnManifestError`
  * @param {object} [options.$metadata]
  *        out-parameter object that receives the discovered Web Component
  *        metadata so the parent task can re-use it across invocations
@@ -50,6 +50,7 @@ const WebComponentRegistry = require("./utils/WebComponentRegistry");
 const JSDocSerializer = require("./utils/JSDocSerializer");
 const WebComponentRegistryHelper = require("./utils/WebComponentRegistryHelper");
 const { UI5_ELEMENT_NAMESPACE } = WebComponentRegistryHelper;
+const { validateManifest, formatReport } = require("./utils/CustomElementsManifestValidator");
 
 const { lt, gte } = require("semver");
 const { compile } = require("handlebars");
@@ -58,22 +59,37 @@ const prettier = require("@prettier/sync");
 
 module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, options, $metadata = {} } = {}) {
 	// derive the configuration from the provided options
-	let { skip, scoping, scopeSuffix, enrichBusyIndicator, force, includeAssets, forceAllAssets, moduleBasePath, removeScopePrefix, skipJSDoc, skipDtsGeneration, customJSDocTags, removeCLDRData } =
-		Object.assign(
-			{
-				skip: false,
-				scoping: true,
-				enrichBusyIndicator: false,
-				force: false,
-				includeAssets: false, // experimental (due to race condition!)
-				forceAllAssets: false, // experimental (only a hack due to timing issues when requiring Web Components from one package first and from other later!)
-				skipJSDoc: true,
-				skipDtsGeneration: true,
-				customJSDocTags: ["private"],
-				removeCLDRData: true,
-			},
-			options,
-		);
+	let {
+		skip,
+		scoping,
+		scopeSuffix,
+		enrichBusyIndicator,
+		force,
+		includeAssets,
+		forceAllAssets,
+		moduleBasePath,
+		removeScopePrefix,
+		skipJSDoc,
+		skipDtsGeneration,
+		customJSDocTags,
+		removeCLDRData,
+		failOnManifestError,
+	} = Object.assign(
+		{
+			skip: false,
+			scoping: true,
+			enrichBusyIndicator: false,
+			force: false,
+			includeAssets: false, // experimental (due to race condition!)
+			forceAllAssets: false, // experimental (only a hack due to timing issues when requiring Web Components from one package first and from other later!)
+			skipJSDoc: true,
+			skipDtsGeneration: true,
+			customJSDocTags: ["private"],
+			removeCLDRData: true,
+			failOnManifestError: false,
+		},
+		options,
+	);
 
 	// derive information from the projectInfo
 	const { pkgJson, framework } = projectInfo;
@@ -194,6 +210,15 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 				// load custom elements metadata
 				if (metadataPath) {
 					const customElementsMetadata = JSON.parse(readFileSync(metadataPath, { encoding: "utf-8" }));
+
+					// validate the manifest upfront so structural / contract issues are
+					// surfaced as a grouped, severity-ranked report rather than as scattered
+					// warnings deep inside the parser
+					const validation = validateManifest(customElementsMetadata, { namespace: npmPackage, metadataPath });
+					formatReport(validation.issues, validation.summary, { namespace: npmPackage, metadataPath }, log);
+					if (failOnManifestError && validation.summary.error > 0) {
+						throw new Error(`Custom elements manifest validation failed for ${npmPackage} (${validation.summary.error} error(s)). See log for details.`);
+					}
 
 					// first time registering a new Web Component package
 					try {

--- a/packages/ui5-tooling-modules/lib/utils/CustomElementsManifestValidator.js
+++ b/packages/ui5-tooling-modules/lib/utils/CustomElementsManifestValidator.js
@@ -1,0 +1,502 @@
+/**
+ * Upfront validation of a Custom Elements Manifest before it is handed to the
+ * WebComponentRegistry parser.
+ *
+ * The Custom Elements Manifest (`custom-elements.json` /
+ * `custom-elements-internal.json`) is the contract between a Web Component
+ * package and `ui5-tooling-modules`. The registry parser is intentionally
+ * permissive — when a defect is encountered it recovers (default to `any`,
+ * synthesize a superclass, etc.) and historically emitted an eager warning
+ * deep inside the parsing pipeline. The result was hard to scan and easy to
+ * miss.
+ *
+ * This module exposes a single linear pass over the manifest that:
+ *   - never throws (validation is diagnostic-only);
+ *   - returns a stable, typed list of issues (each with a `WCV###` code, a
+ *     severity, the offending entity and a manifest path);
+ *   - aggregates a per-severity summary;
+ *   - leaves rendering to the caller via `formatReport(...)`.
+ *
+ * The validator does NOT replicate cross-package checks (e.g. unresolvable
+ * superclass references) — those depend on the full registry of loaded
+ * packages and stay in the registry parser. Only same-package contract
+ * violations are checked here.
+ *
+ * @module CustomElementsManifestValidator
+ */
+
+/**
+ * Stable issue catalog. Codes are part of the public surface — adding new
+ * codes is fine, renaming or repurposing existing ones is not.
+ */
+const ISSUE_CODES = Object.freeze({
+	// Root
+	WCV000: { severity: "error", message: "manifest must be a non-null object" },
+	WCV001: { severity: "error", message: "manifest.modules must be an array" },
+	WCV002: { severity: "info", message: "manifest.modules is empty" },
+	// Module
+	WCV010: { severity: "warn", message: "module.kind should be 'javascript-module'" },
+	WCV011: { severity: "error", message: "module.path must be a non-empty string" },
+	WCV012: { severity: "info", message: "module.path has a leading slash — parser will sanitize" },
+	WCV013: { severity: "warn", message: "module.declarations, if present, must be an array" },
+	WCV014: { severity: "warn", message: "module.exports, if present, must be an array" },
+	// Declaration
+	WCV020: { severity: "error", message: "declaration.kind must be one of 'class', 'enum', 'interface'" },
+	WCV021: { severity: "error", message: "declaration.name must be a non-empty string" },
+	WCV022: { severity: "warn", message: "custom-element-definition export references unknown class in same module" },
+	WCV023: { severity: "warn", message: "class is declared but never exported (no module path will be set)" },
+	// Class
+	WCV030: { severity: "warn", message: "class flagged as customElement has no tagName" },
+	WCV031: { severity: "warn", message: "superclass is a dotted string — prefer {name, package, module}" },
+	WCV032: { severity: "warn", message: "superclass.name must be a non-empty string" },
+	WCV033: { severity: "warn", message: "class.members/slots/events, if present, must be arrays" },
+	// Member
+	WCV040: { severity: "error", message: "member.kind must be 'field' or 'method'" },
+	WCV041: { severity: "error", message: "member.name must be a non-empty string" },
+	WCV042: { severity: "warn", message: "field has unclear type (type.text missing) — defaults to 'any'" },
+	WCV043: { severity: "info", message: "type reference is missing 'name'" },
+	// Slot
+	WCV050: { severity: "error", message: "slot.name must be a non-empty string" },
+	WCV051: { severity: "warn", message: "slot has _ui5type without .text — defaults to 'any'" },
+	WCV052: { severity: "info", message: "valueStateMessage slot present but no valueState property" },
+	// Event
+	WCV060: { severity: "error", message: "event.name must be a non-empty string" },
+	WCV061: { severity: "warn", message: "event._ui5parameters, if present, must be an array" },
+	WCV062: { severity: "warn", message: "event parameter has no name" },
+	// Interface
+	WCV070: { severity: "error", message: "interface.name must be a non-empty string" },
+	// Enum
+	WCV080: { severity: "error", message: "enum.name must be a non-empty string" },
+	WCV081: { severity: "warn", message: "enum.members, if present, must be an array" },
+	WCV082: { severity: "error", message: "enum member has no name" },
+	// Cross-reference (same package only)
+	WCV090: { severity: "warn", message: "class _ui5implements references an interface not declared in this package" },
+});
+
+const VALID_DECLARATION_KINDS = new Set(["class", "enum", "interface"]);
+const VALID_MEMBER_KINDS = new Set(["field", "method"]);
+
+// helper: push an Issue with severity/message from ISSUE_CODES
+function pushIssue(issues, code, { path, entity, extra }) {
+	const catalog = ISSUE_CODES[code];
+	if (!catalog) {
+		// guard against typos — should never happen at runtime, but keeps tests honest
+		throw new Error(`unknown WCV code: ${code}`);
+	}
+	issues.push({
+		severity: catalog.severity,
+		code,
+		message: catalog.message,
+		path,
+		entity,
+		...(extra ? { extra } : {}),
+	});
+}
+
+// helper: non-empty string check
+function isNonEmptyString(value) {
+	return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Validate the root shape of the manifest.
+ * @returns {boolean} `true` when validation may continue (i.e. `manifest.modules`
+ *                    is iterable), `false` otherwise.
+ */
+function validateRoot(manifest, issues) {
+	if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+		pushIssue(issues, "WCV000", { path: "$", entity: "<root>" });
+		return false;
+	}
+	if (!Array.isArray(manifest.modules)) {
+		pushIssue(issues, "WCV001", { path: "modules", entity: "<root>" });
+		return false;
+	}
+	if (manifest.modules.length === 0) {
+		pushIssue(issues, "WCV002", { path: "modules", entity: "<root>" });
+	}
+	return true;
+}
+
+function validateModule(module, moduleIdx, issues) {
+	const path = `modules[${moduleIdx}]`;
+	const entity = isNonEmptyString(module?.path) ? module.path : path;
+
+	if (module?.kind !== "javascript-module") {
+		pushIssue(issues, "WCV010", { path: `${path}.kind`, entity });
+	}
+	if (!isNonEmptyString(module?.path)) {
+		pushIssue(issues, "WCV011", { path: `${path}.path`, entity });
+	} else if (module.path.startsWith("/")) {
+		pushIssue(issues, "WCV012", { path: `${path}.path`, entity });
+	}
+	if (module?.declarations !== undefined && !Array.isArray(module.declarations)) {
+		pushIssue(issues, "WCV013", { path: `${path}.declarations`, entity });
+	}
+	if (module?.exports !== undefined && !Array.isArray(module.exports)) {
+		pushIssue(issues, "WCV014", { path: `${path}.exports`, entity });
+	}
+}
+
+function validateClassDecl(decl, declPath, entity, issues) {
+	// customElement flag without tagName
+	if (decl.customElement === true && !isNonEmptyString(decl.tagName)) {
+		pushIssue(issues, "WCV030", { path: `${declPath}.tagName`, entity });
+	}
+	// superclass shape
+	if (decl.superclass !== undefined && decl.superclass !== null) {
+		if (typeof decl.superclass === "string") {
+			pushIssue(issues, "WCV031", { path: `${declPath}.superclass`, entity, extra: decl.superclass });
+		} else if (typeof decl.superclass === "object") {
+			if (!isNonEmptyString(decl.superclass.name)) {
+				pushIssue(issues, "WCV032", { path: `${declPath}.superclass.name`, entity });
+			}
+			// `superclass.name` containing dots is the media-chrome / dotted form too —
+			// the registry parses it the same way regardless of whether superclass is
+			// a bare string or an object with a dotted name. Treat both as WCV031.
+			if (isNonEmptyString(decl.superclass.name) && decl.superclass.name.includes(".")) {
+				pushIssue(issues, "WCV031", { path: `${declPath}.superclass.name`, entity, extra: decl.superclass.name });
+			}
+		}
+	}
+	// array-shaped child collections
+	for (const key of ["members", "slots", "events"]) {
+		if (decl[key] !== undefined && !Array.isArray(decl[key])) {
+			pushIssue(issues, "WCV033", { path: `${declPath}.${key}`, entity, extra: key });
+		}
+	}
+	// members
+	if (Array.isArray(decl.members)) {
+		decl.members.forEach((member, idx) => validateMember(member, `${declPath}.members[${idx}]`, entity, issues));
+	}
+	// slots
+	if (Array.isArray(decl.slots)) {
+		decl.slots.forEach((slot, idx) => validateSlot(slot, `${declPath}.slots[${idx}]`, entity, issues));
+		// cross-slot/member check: valueStateMessage slot + no valueState property
+		const hasValueStateMessage = decl.slots.some((s) => s?.name === "valueStateMessage");
+		const hasValueState = Array.isArray(decl.members) && decl.members.some((m) => m?.kind === "field" && m?.name === "valueState");
+		if (hasValueStateMessage && !hasValueState) {
+			pushIssue(issues, "WCV052", { path: `${declPath}.slots`, entity });
+		}
+	}
+	// events
+	if (Array.isArray(decl.events)) {
+		decl.events.forEach((event, idx) => validateEvent(event, `${declPath}.events[${idx}]`, entity, issues));
+	}
+}
+
+function validateMember(member, memberPath, classEntity, issues) {
+	const entity = isNonEmptyString(member?.name) ? `${classEntity}.${member.name}` : `${classEntity}.${memberPath.match(/\[(\d+)\]$/)?.[1] ?? "?"}`;
+	if (!member || typeof member !== "object") {
+		pushIssue(issues, "WCV041", { path: memberPath, entity });
+		return;
+	}
+	if (!VALID_MEMBER_KINDS.has(member.kind)) {
+		pushIssue(issues, "WCV040", { path: `${memberPath}.kind`, entity, extra: String(member.kind) });
+	}
+	if (!isNonEmptyString(member.name)) {
+		pushIssue(issues, "WCV041", { path: `${memberPath}.name`, entity });
+	}
+	// fields: type.text should be present
+	if (member.kind === "field") {
+		const typeText = member?.type?.text;
+		if (!isNonEmptyString(typeText)) {
+			pushIssue(issues, "WCV042", { path: `${memberPath}.type.text`, entity });
+		}
+		// references must have name
+		if (Array.isArray(member?.type?.references)) {
+			member.type.references.forEach((ref, idx) => {
+				if (!isNonEmptyString(ref?.name)) {
+					pushIssue(issues, "WCV043", { path: `${memberPath}.type.references[${idx}].name`, entity });
+				}
+			});
+		}
+	}
+}
+
+function validateSlot(slot, slotPath, classEntity, issues) {
+	const entity = isNonEmptyString(slot?.name) ? `${classEntity}.slots.${slot.name}` : `${classEntity}.${slotPath.match(/\[(\d+)\]$/)?.[1] ?? "?"}`;
+	if (!slot || typeof slot !== "object") {
+		pushIssue(issues, "WCV050", { path: slotPath, entity });
+		return;
+	}
+	if (!isNonEmptyString(slot.name)) {
+		pushIssue(issues, "WCV050", { path: `${slotPath}.name`, entity });
+	}
+	if (slot._ui5type !== undefined && !isNonEmptyString(slot._ui5type?.text)) {
+		pushIssue(issues, "WCV051", { path: `${slotPath}._ui5type.text`, entity });
+	}
+}
+
+function validateEvent(event, eventPath, classEntity, issues) {
+	const entity = isNonEmptyString(event?.name) ? `${classEntity}.events.${event.name}` : `${classEntity}.${eventPath.match(/\[(\d+)\]$/)?.[1] ?? "?"}`;
+	if (!event || typeof event !== "object") {
+		pushIssue(issues, "WCV060", { path: eventPath, entity });
+		return;
+	}
+	if (!isNonEmptyString(event.name)) {
+		pushIssue(issues, "WCV060", { path: `${eventPath}.name`, entity });
+	}
+	if (event._ui5parameters !== undefined) {
+		if (!Array.isArray(event._ui5parameters)) {
+			pushIssue(issues, "WCV061", { path: `${eventPath}._ui5parameters`, entity });
+		} else {
+			event._ui5parameters.forEach((param, idx) => {
+				if (!isNonEmptyString(param?.name)) {
+					pushIssue(issues, "WCV062", { path: `${eventPath}._ui5parameters[${idx}].name`, entity });
+				}
+			});
+		}
+	}
+}
+
+function validateInterfaceDecl(decl, declPath, entity, issues) {
+	if (!isNonEmptyString(decl.name)) {
+		pushIssue(issues, "WCV070", { path: `${declPath}.name`, entity });
+	}
+}
+
+function validateEnumDecl(decl, declPath, entity, issues) {
+	if (!isNonEmptyString(decl.name)) {
+		pushIssue(issues, "WCV080", { path: `${declPath}.name`, entity });
+	}
+	if (decl.members !== undefined) {
+		if (!Array.isArray(decl.members)) {
+			pushIssue(issues, "WCV081", { path: `${declPath}.members`, entity });
+		} else {
+			decl.members.forEach((member, idx) => {
+				if (!isNonEmptyString(member?.name)) {
+					pushIssue(issues, "WCV082", { path: `${declPath}.members[${idx}].name`, entity });
+				}
+			});
+		}
+	}
+}
+
+function validateExports(module, moduleIdx, declaredClassNames, issues) {
+	if (!Array.isArray(module?.exports)) return;
+	module.exports.forEach((exportDef, idx) => {
+		if (exportDef?.kind === "custom-element-definition") {
+			const refName = exportDef?.declaration?.name;
+			if (isNonEmptyString(refName) && !declaredClassNames.has(refName)) {
+				pushIssue(issues, "WCV022", {
+					path: `modules[${moduleIdx}].exports[${idx}].declaration.name`,
+					entity: refName,
+					extra: refName,
+				});
+			}
+		}
+	});
+}
+
+/**
+ * Validate that classes flagged as exported actually have an `exports[]`
+ * entry that names them. If they don't, the registry never assigns
+ * `classDef.module` (see WebComponentRegistry#parseExports) and the class
+ * ends up effectively orphaned.
+ */
+function checkClassesWithoutExport(module, moduleIdx, issues) {
+	if (!Array.isArray(module?.declarations)) return;
+	const exportedNames = new Set();
+	if (Array.isArray(module.exports)) {
+		for (const exportDef of module.exports) {
+			const name = exportDef?.declaration?.name;
+			if (isNonEmptyString(name)) exportedNames.add(name);
+		}
+	}
+	module.declarations.forEach((decl, idx) => {
+		if (decl?.kind === "class" && isNonEmptyString(decl.name) && !exportedNames.has(decl.name)) {
+			pushIssue(issues, "WCV023", {
+				path: `modules[${moduleIdx}].declarations[${idx}]`,
+				entity: decl.name,
+			});
+		}
+	});
+}
+
+/**
+ * For every class with `_ui5implements`, verify same-package interfaces are
+ * declared somewhere in this manifest. Cross-package references stay the
+ * registry's concern.
+ */
+function crossReferenceImplements(manifest, namespace, issues) {
+	const declaredInterfaces = new Set();
+	for (const module of manifest.modules) {
+		if (!Array.isArray(module?.declarations)) continue;
+		for (const decl of module.declarations) {
+			if (decl?.kind === "interface" && isNonEmptyString(decl.name)) {
+				declaredInterfaces.add(decl.name);
+			}
+		}
+	}
+	manifest.modules.forEach((module, moduleIdx) => {
+		if (!Array.isArray(module?.declarations)) return;
+		module.declarations.forEach((decl, declIdx) => {
+			if (decl?.kind !== "class" || !Array.isArray(decl._ui5implements)) return;
+			decl._ui5implements.forEach((iface, idx) => {
+				const ifaceName = iface?.name;
+				const ifacePackage = iface?.package;
+				if (!isNonEmptyString(ifaceName)) return;
+				// only same-package: cross-package is left to the registry
+				const isSamePackage = !ifacePackage || ifacePackage === namespace;
+				if (isSamePackage && !declaredInterfaces.has(ifaceName)) {
+					pushIssue(issues, "WCV090", {
+						path: `modules[${moduleIdx}].declarations[${declIdx}]._ui5implements[${idx}]`,
+						entity: `${decl.name ?? "<class>"}._ui5implements.${ifaceName}`,
+						extra: ifaceName,
+					});
+				}
+			});
+		});
+	});
+}
+
+/**
+ * Compute a per-severity summary from the flat issues list.
+ */
+function summarize(issues) {
+	const summary = { error: 0, warn: 0, info: 0, total: issues.length };
+	for (const issue of issues) {
+		summary[issue.severity] = (summary[issue.severity] || 0) + 1;
+	}
+	return summary;
+}
+
+/**
+ * Validate a Custom Elements Manifest.
+ *
+ * @param {object} manifest the parsed `custom-elements.json` /
+ *                          `custom-elements-internal.json`
+ * @param {{namespace: string, metadataPath?: string}} ctx
+ * @returns {{issues: Array, summary: {error:number, warn:number, info:number, total:number}, namespace: string, metadataPath: string|undefined}}
+ */
+function validateManifest(manifest, ctx = {}) {
+	const issues = [];
+	const namespace = ctx.namespace;
+	const metadataPath = ctx.metadataPath;
+
+	if (validateRoot(manifest, issues)) {
+		manifest.modules.forEach((module, moduleIdx) => {
+			validateModule(module, moduleIdx, issues);
+
+			// per-module declarations
+			if (Array.isArray(module?.declarations)) {
+				const declaredClassNames = new Set();
+				module.declarations.forEach((decl, declIdx) => {
+					const declPath = `modules[${moduleIdx}].declarations[${declIdx}]`;
+					const entity = isNonEmptyString(decl?.name) ? decl.name : `${declPath}`;
+
+					if (!decl || typeof decl !== "object") {
+						pushIssue(issues, "WCV020", { path: declPath, entity });
+						return;
+					}
+					if (!VALID_DECLARATION_KINDS.has(decl.kind)) {
+						pushIssue(issues, "WCV020", { path: `${declPath}.kind`, entity, extra: String(decl.kind) });
+						return;
+					}
+					if (!isNonEmptyString(decl.name)) {
+						pushIssue(issues, "WCV021", { path: `${declPath}.name`, entity });
+					}
+					if (decl.kind === "class") {
+						if (isNonEmptyString(decl.name)) declaredClassNames.add(decl.name);
+						validateClassDecl(decl, declPath, isNonEmptyString(decl.name) ? decl.name : entity, issues);
+					} else if (decl.kind === "interface") {
+						validateInterfaceDecl(decl, declPath, entity, issues);
+					} else if (decl.kind === "enum") {
+						validateEnumDecl(decl, declPath, entity, issues);
+					}
+				});
+
+				validateExports(module, moduleIdx, declaredClassNames, issues);
+				checkClassesWithoutExport(module, moduleIdx, issues);
+			}
+		});
+
+		crossReferenceImplements(manifest, namespace, issues);
+	}
+
+	return {
+		issues,
+		summary: summarize(issues),
+		namespace,
+		metadataPath,
+	};
+}
+
+// ---- Reporting ---------------------------------------------------------
+
+const SEVERITY_ORDER = { error: 0, warn: 1, info: 2 };
+const SEVERITY_GLYPH = { error: "✗", warn: "⚠", info: "ℹ" };
+
+function pluralize(n, word) {
+	return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function formatHeader(namespace, summary) {
+	const parts = [pluralize(summary.error, "error"), pluralize(summary.warn, "warning"), pluralize(summary.info, "info")];
+	return `[🧬 WCR] Validation for ${namespace ?? "<unknown package>"} (${parts.join(", ")})`;
+}
+
+function sortIssues(issues) {
+	return [...issues].sort((a, b) => {
+		const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+		if (sev !== 0) return sev;
+		return a.code.localeCompare(b.code);
+	});
+}
+
+function formatIssueLine(issue, entityWidth) {
+	const glyph = SEVERITY_GLYPH[issue.severity] ?? "•";
+	const entity = (issue.entity ?? "").slice(0, 50).padEnd(entityWidth);
+	return `  ${glyph} ${issue.code}  ${entity}  ${issue.message}`;
+}
+
+/**
+ * Render the validation result through a UI5-task-style logger (or any
+ * `{info, warn, error}` object). Error-level issues go to `log.error`,
+ * warnings to `log.warn`, info to `log.info` (falling back to `log` when
+ * the logger has no dedicated info channel).
+ *
+ * The UI5 `@ui5/logger` Logger relies on `this`-bound private fields, so
+ * channel methods are invoked through the original log object rather than
+ * being extracted into local variables.
+ *
+ * @param {Array} issues
+ * @param {{error:number, warn:number, info:number, total:number}} summary
+ * @param {{namespace: string}} ctx
+ * @param {{info?: Function, warn: Function, error: Function, log?: Function}} log
+ */
+function formatReport(issues, summary, ctx = {}, log = {}) {
+	// pick the most specific available channel name; we always call through `log`
+	// so the function keeps its `this` (matters for @ui5/logger).
+	const infoChan = log.info ? "info" : log.log ? "log" : log.warn ? "warn" : log.error ? "error" : null;
+	const warnChan = log.warn ? "warn" : infoChan;
+	const errorChan = log.error ? "error" : warnChan;
+	const emit = (chan, line) => {
+		if (!chan || typeof log[chan] !== "function") return;
+		log[chan](line);
+	};
+
+	if (!summary || summary.total === 0) {
+		emit(infoChan, `[🧬 WCR] Validation OK for ${ctx.namespace ?? "<unknown package>"}`);
+		return;
+	}
+
+	emit(infoChan, formatHeader(ctx.namespace, summary));
+
+	const sorted = sortIssues(issues);
+	const entityWidth = Math.min(50, Math.max(...sorted.map((i) => (i.entity ?? "").length), 1));
+
+	for (const issue of sorted) {
+		const line = formatIssueLine(issue, entityWidth);
+		if (issue.severity === "error") emit(errorChan, line);
+		else if (issue.severity === "warn") emit(warnChan, line);
+		else emit(infoChan, line);
+	}
+}
+
+module.exports = {
+	validateManifest,
+	formatReport,
+	ISSUE_CODES,
+};

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -124,7 +124,7 @@ class RegistryEntry {
 					const cacheKey = WebComponentRegistryHelper.deriveCacheKey(classDef);
 					this.classes[cacheKey] = classDef;
 				} else {
-					logger.warn(`class without module: ${classDef}`);
+					// validated upfront: WCV023 (class declared but never exported)
 				}
 			}
 
@@ -207,7 +207,7 @@ class RegistryEntry {
 				moduleContent.interfaces[declarationDef.name] = declarationDef;
 				break;
 			default:
-				logger.error("unknown declaration kind:", declarationDef.kind);
+			// validated upfront: WCV020 (unknown declaration kind)
 		}
 	}
 
@@ -250,7 +250,7 @@ class RegistryEntry {
 				package: npmPackage,
 				file: `dist/${nameParts.join("/")}.js`,
 			};
-			logger.warn(`The class '${this.namespace}/${classDef.name}' detected superclass '${classDef.superclass.package}/${classDef.superclass.name}' from string '${superclassName}'!`);
+			// validated upfront: WCV031 (superclass as dotted string)
 		}
 		if (classDef.superclass) {
 			// determine superclass package (can be cross-package reference)
@@ -671,12 +671,7 @@ class RegistryEntry {
 				return;
 			}
 
-			// DEBUG
-			if (typeDef.isUnclear) {
-				logger.warn(
-					`🤔 unclear type - ${classDef.name} - ${isAssociation ? "association" : "property"} '${propDef.name}' has unclear type '${typeDef.origType}' -> defaulting to 'any', multiple: ${typeDef.ui5TypeInfo.multiple}`,
-				);
-			}
+			// unclear-type for fields validated upfront: WCV042
 
 			// If any property of a class is a form relevant property, the UI5 control class must implement the "sap.ui.core.IFormContent" interface
 			classDef._ui5implementsFormContent ??= propDef._ui5formProperty;
@@ -814,12 +809,7 @@ class RegistryEntry {
 				isUnclear: true,
 			};
 		}
-		// DEBUG
-		if (typeDef.isUnclear) {
-			logger.warn(
-				`🤔 unclear type - ${classDef._ui5QualifiedName} - aggregation '${slotDef.name}' has unclear type '${typeDef.origType}' -> defaulting to 'any', multiple: ${typeDef.ui5TypeInfo.multiple}`,
-			);
-		}
+		// unclear-type for slots validated upfront: WCV051
 
 		// The "default" slot will most likely be transformed into the "content" in UI5
 		if (aggregationName === "default") {
@@ -946,7 +936,11 @@ class RegistryEntry {
 				} else {
 					jsdocInterfaces.push(this.prefixns(interfaceDef.name));
 					unknowInterfaces.add(interfaceDef.name);
-					logger.warn(`🤔 unknown interface - interface ${interfaceDef.name} is not part of the metadata`);
+					// same-package case is validated upfront (WCV090); only warn for
+					// cross-package references that the upfront pass cannot resolve.
+					if (interfaceDef.package && interfaceDef.package !== this.namespace) {
+						logger.warn(`🤔 unknown interface - interface ${interfaceDef.name} is not part of the metadata`);
+					}
 				}
 			});
 		}
@@ -1202,11 +1196,7 @@ class RegistryEntry {
 					},
 				);
 			} else {
-				// this is an interesting inconsistency that does not occur in the UI5 web components
-				// we report it here for custom web component development
-				logger.warn(
-					`The class '${classDef._ui5QualifiedName}' defines a slot called 'valueStateMessage', but does not provide a corresponding 'valueState' property! A UI5 control expects both to be present for correct 'valueState' handling.`,
-				);
+				// validated upfront: WCV052 (valueStateMessage slot without valueState property)
 			}
 		}
 	}

--- a/packages/ui5-tooling-modules/test/CustomElementsManifestValidator.test.js
+++ b/packages/ui5-tooling-modules/test/CustomElementsManifestValidator.test.js
@@ -1,0 +1,577 @@
+const { default: test } = require("ava");
+
+const { validateManifest, formatReport, ISSUE_CODES } = require("../lib/utils/CustomElementsManifestValidator");
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function tuples(result) {
+	return result.issues.map(({ code, severity, entity }) => ({ code, severity, entity }));
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function findIssue(result, code) {
+	return result.issues.find((i) => i.code === code);
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function validClass(overrides = {}) {
+	return {
+		kind: "class",
+		name: "MyComp",
+		customElement: true,
+		tagName: "my-comp",
+		superclass: { name: "UI5Element", package: "@ui5/webcomponents-base", module: "dist/UI5Element.js" },
+		members: [],
+		slots: [],
+		events: [],
+		...overrides,
+	};
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function validModule(overrides = {}) {
+	return {
+		kind: "javascript-module",
+		path: "dist/MyComp.js",
+		declarations: [validClass()],
+		exports: [{ kind: "custom-element-definition", declaration: { name: "MyComp", module: "dist/MyComp.js" } }],
+		...overrides,
+	};
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function validManifest(overrides = {}) {
+	return { schemaVersion: "1.0.0", modules: [validModule()], ...overrides };
+}
+
+// --- ISSUE_CODES sanity ----------------------------------------------------
+
+test("ISSUE_CODES is frozen and covers every documented WCV code", (t) => {
+	t.true(Object.isFrozen(ISSUE_CODES));
+	const codes = Object.keys(ISSUE_CODES);
+	// sanity: at least all codes we explicitly listed in the plan
+	const expected = [
+		"WCV000",
+		"WCV001",
+		"WCV002",
+		"WCV010",
+		"WCV011",
+		"WCV012",
+		"WCV013",
+		"WCV014",
+		"WCV020",
+		"WCV021",
+		"WCV022",
+		"WCV023",
+		"WCV030",
+		"WCV031",
+		"WCV032",
+		"WCV033",
+		"WCV040",
+		"WCV041",
+		"WCV042",
+		"WCV043",
+		"WCV050",
+		"WCV051",
+		"WCV052",
+		"WCV060",
+		"WCV061",
+		"WCV062",
+		"WCV070",
+		"WCV080",
+		"WCV081",
+		"WCV082",
+		"WCV090",
+	];
+	for (const code of expected) {
+		t.true(codes.includes(code), `missing ${code}`);
+	}
+});
+
+// --- Happy path -----------------------------------------------------------
+
+test("happy path manifest produces zero issues", (t) => {
+	const result = validateManifest(validManifest(), { namespace: "my-pkg" });
+	t.is(result.summary.total, 0);
+	t.is(result.summary.error, 0);
+	t.is(result.summary.warn, 0);
+	t.is(result.summary.info, 0);
+	t.is(result.namespace, "my-pkg");
+});
+
+// --- Root checks ----------------------------------------------------------
+
+test("WCV000 — manifest is not an object", (t) => {
+	for (const bad of [null, undefined, 42, "string", []]) {
+		const result = validateManifest(bad, { namespace: "p" });
+		t.true(tuples(result).some((i) => i.code === "WCV000"));
+	}
+});
+
+test("WCV001 — modules is not an array", (t) => {
+	const result = validateManifest({ schemaVersion: "1.0", modules: "nope" }, { namespace: "p" });
+	t.true(tuples(result).some((i) => i.code === "WCV001"));
+});
+
+test("WCV002 — modules is empty", (t) => {
+	const result = validateManifest({ schemaVersion: "1.0", modules: [] }, { namespace: "p" });
+	const issue = findIssue(result, "WCV002");
+	t.truthy(issue);
+	t.is(issue.severity, "info");
+});
+
+// --- Module checks --------------------------------------------------------
+
+test("WCV010 — module.kind is not 'javascript-module'", (t) => {
+	const result = validateManifest(validManifest({ modules: [validModule({ kind: "css-module" })] }), { namespace: "p" });
+	t.true(tuples(result).some((i) => i.code === "WCV010"));
+});
+
+test("WCV011 — module.path is missing", (t) => {
+	const result = validateManifest(validManifest({ modules: [validModule({ path: undefined })] }), { namespace: "p" });
+	t.true(tuples(result).some((i) => i.code === "WCV011"));
+});
+
+test("WCV012 — module.path has leading slash", (t) => {
+	const result = validateManifest(validManifest({ modules: [validModule({ path: "/dist/MyComp.js" })] }), { namespace: "p" });
+	const issue = findIssue(result, "WCV012");
+	t.truthy(issue);
+	t.is(issue.severity, "info");
+});
+
+test("WCV013 — module.declarations is not an array", (t) => {
+	const result = validateManifest(validManifest({ modules: [validModule({ declarations: "x" })] }), { namespace: "p" });
+	t.true(tuples(result).some((i) => i.code === "WCV013"));
+});
+
+test("WCV014 — module.exports is not an array", (t) => {
+	const result = validateManifest(validManifest({ modules: [validModule({ exports: "x" })] }), { namespace: "p" });
+	t.true(tuples(result).some((i) => i.code === "WCV014"));
+});
+
+// --- Declaration checks ---------------------------------------------------
+
+test("WCV020 — unknown declaration kind", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "mixin", name: "M" }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV020");
+	t.truthy(issue);
+	t.is(issue.severity, "error");
+});
+
+test("WCV021 — declaration.name is missing", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "class" /* no name */ }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV021");
+	t.truthy(issue);
+});
+
+test("WCV022 — custom-element-definition export references unknown class", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [validClass({ name: "MyComp" })],
+					exports: [{ kind: "custom-element-definition", declaration: { name: "Ghost" } }],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV022");
+	t.truthy(issue);
+	t.is(issue.entity, "Ghost");
+});
+
+test("WCV023 — class declared but not exported", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [validClass({ name: "Orphan" })],
+					exports: [], // no export for Orphan
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV023");
+	t.truthy(issue);
+	t.is(issue.entity, "Orphan");
+});
+
+// --- Class checks ---------------------------------------------------------
+
+test("WCV030 — customElement without tagName", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ tagName: undefined })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV030"));
+});
+
+test("WCV031 — superclass is a dotted string", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ superclass: "@scope/pkg.Base" })] })],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV031");
+	t.truthy(issue);
+	t.is(issue.extra, "@scope/pkg.Base");
+});
+
+test("WCV031 — superclass object with dotted name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ superclass: { name: "@ui5/webcomponents.UI5Element" } })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV031"));
+});
+
+test("WCV032 — superclass.name is missing", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ superclass: { package: "x" } })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV032"));
+});
+
+test("WCV033 — class.members is not an array", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ members: { not: "array" } })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV033"));
+});
+
+// --- Member checks --------------------------------------------------------
+
+test("WCV040 — member.kind is invalid", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ members: [{ kind: "property", name: "foo" }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV040"));
+});
+
+test("WCV041 — member.name is missing", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ members: [{ kind: "field" /* no name */ }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV041"));
+});
+
+test("WCV042 — field has unclear type", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ members: [{ kind: "field", name: "foo" /* no type.text */ }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV042"));
+});
+
+test("WCV043 — type reference missing name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [
+						validClass({
+							members: [
+								{
+									kind: "field",
+									name: "foo",
+									type: { text: "Foo", references: [{ package: "x" }] },
+								},
+							],
+						}),
+					],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV043");
+	t.truthy(issue);
+	t.is(issue.severity, "info");
+});
+
+// --- Slot checks ----------------------------------------------------------
+
+test("WCV050 — slot.name is missing", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ slots: [{}] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV050"));
+});
+
+test("WCV051 — slot _ui5type with no .text", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ slots: [{ name: "default", _ui5type: {} }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV051"));
+});
+
+test("WCV052 — valueStateMessage slot without valueState property", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [
+						validClass({
+							members: [],
+							slots: [{ name: "valueStateMessage" }],
+						}),
+					],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV052");
+	t.truthy(issue);
+	t.is(issue.severity, "info");
+});
+
+test("WCV052 — does not fire when valueState field is present", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [
+						validClass({
+							members: [{ kind: "field", name: "valueState", type: { text: "string" } }],
+							slots: [{ name: "valueStateMessage" }],
+						}),
+					],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	t.false(tuples(result).some((i) => i.code === "WCV052"));
+});
+
+// --- Event checks ---------------------------------------------------------
+
+test("WCV060 — event.name is missing", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ events: [{}] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV060"));
+});
+
+test("WCV061 — event _ui5parameters is not an array", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ events: [{ name: "change", _ui5parameters: "nope" }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV061"));
+});
+
+test("WCV062 — event parameter has no name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [validModule({ declarations: [validClass({ events: [{ name: "change", _ui5parameters: [{}] }] })] })],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV062"));
+});
+
+// --- Interface check ------------------------------------------------------
+
+test("WCV070 — interface without name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "interface" /* no name */ }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV070"));
+});
+
+// --- Enum checks ----------------------------------------------------------
+
+test("WCV080 — enum without name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "enum" /* no name */, members: [{ name: "A" }] }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV080"));
+});
+
+test("WCV081 — enum.members is not an array", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "enum", name: "MyEnum", members: "nope" }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV081"));
+});
+
+test("WCV082 — enum member has no name", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [{ kind: "enum", name: "MyEnum", members: [{}] }],
+					exports: [],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	t.true(tuples(result).some((i) => i.code === "WCV082"));
+});
+
+// --- Cross-reference (same package) --------------------------------------
+
+test("WCV090 — _ui5implements references undeclared same-package interface", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [validClass({ _ui5implements: [{ name: "IGhost" /* no package or package === ours */ }] })],
+				}),
+			],
+		}),
+		{ namespace: "p" },
+	);
+	const issue = findIssue(result, "WCV090");
+	t.truthy(issue);
+});
+
+test("WCV090 — does not fire for cross-package interface references", (t) => {
+	const result = validateManifest(
+		validManifest({
+			modules: [
+				validModule({
+					declarations: [validClass({ _ui5implements: [{ name: "IOther", package: "@other/pkg" }] })],
+				}),
+			],
+		}),
+		{ namespace: "@my/pkg" },
+	);
+	t.false(tuples(result).some((i) => i.code === "WCV090"));
+});
+
+test("WCV090 — does not fire when the interface is declared in the same package", (t) => {
+	const result = validateManifest(
+		{
+			modules: [
+				{
+					kind: "javascript-module",
+					path: "dist/IButton.js",
+					declarations: [{ kind: "interface", name: "IButton" }],
+					exports: [],
+				},
+				validModule({
+					declarations: [validClass({ _ui5implements: [{ name: "IButton" }] })],
+				}),
+			],
+		},
+		{ namespace: "@my/pkg" },
+	);
+	t.false(tuples(result).some((i) => i.code === "WCV090"));
+});
+
+// --- formatReport smoke test ---------------------------------------------
+
+test("formatReport: zero issues prints a single OK line", (t) => {
+	const lines = { info: [], warn: [], error: [] };
+	const log = {
+		info: (m) => lines.info.push(m),
+		warn: (m) => lines.warn.push(m),
+		error: (m) => lines.error.push(m),
+	};
+	formatReport([], { error: 0, warn: 0, info: 0, total: 0 }, { namespace: "my-pkg" }, log);
+	t.is(lines.info.length, 1);
+	t.regex(lines.info[0], /Validation OK for my-pkg/);
+	t.is(lines.warn.length, 0);
+	t.is(lines.error.length, 0);
+});
+
+test("formatReport: routes issues to channels by severity", (t) => {
+	const lines = { info: [], warn: [], error: [] };
+	const log = {
+		info: (m) => lines.info.push(m),
+		warn: (m) => lines.warn.push(m),
+		error: (m) => lines.error.push(m),
+	};
+	const issues = [
+		{ severity: "error", code: "WCV020", message: "x", entity: "A.kind", path: "modules[0]" },
+		{ severity: "warn", code: "WCV031", message: "y", entity: "B", path: "modules[0]" },
+		{ severity: "info", code: "WCV012", message: "z", entity: "/dist/foo.js", path: "modules[0]" },
+	];
+	formatReport(issues, { error: 1, warn: 1, info: 1, total: 3 }, { namespace: "my-pkg" }, log);
+	// header + info issue go through info; warn issue through warn; error issue through error
+	t.true(lines.info.some((l) => /Validation for my-pkg/.test(l)));
+	t.is(lines.error.length, 1);
+	t.regex(lines.error[0], /WCV020/);
+	t.is(lines.warn.length, 1);
+	t.regex(lines.warn[0], /WCV031/);
+	t.true(lines.info.some((l) => /WCV012/.test(l)));
+});

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -129,6 +129,41 @@ server:
 
 That's it. Now you can transpile your sources with the help of Babel.
 
+## CLI
+
+In addition to the task and middleware, the package ships a small `ui5-transpile` command for transpiling individual files or globs without running a full `ui5 build`. The CLI reuses the same Babel configuration logic as the task/middleware and honors an existing `ui5.yaml` in the working directory (it picks up the configuration of `ui5-tooling-transpile-task`, falling back to `ui5-tooling-transpile-middleware`).
+
+```bash
+# Print transpiled JS to stdout (source map is inlined)
+npx ui5-transpile webapp/Foo.ts
+
+# Write the transpiled file (and a .js.map next to it)
+npx ui5-transpile webapp/Foo.ts -o dist/Foo.js
+
+# Transpile a glob into a mirrored directory layout
+npx ui5-transpile "webapp/**/*.ts" -o dist/
+
+# Watch mode: re-transpile on every change (requires -o)
+npx ui5-transpile "webapp/**/*.ts" -o dist/ --watch
+
+# Read source from stdin and write to stdout
+echo 'const x: number = 1' | npx ui5-transpile --ts -
+```
+
+Available flags:
+
+| Flag | Description |
+|------|-------------|
+| `-o, --out <file\|dir>` | Output target — file for a single input, directory (required) for multiple inputs; omit for stdout (1 input only) |
+| `--cwd <dir>` | Working directory used for `ui5.yaml` / `tsconfig.json` lookup (defaults to `process.cwd()`) |
+| `--ui5-yaml <path>` | Explicit `ui5.yaml` to read the configuration from |
+| `--ts` / `--no-ts` | Force the `transformTypeScript` option on or off |
+| `--no-sourcemaps` | Disable source maps |
+| `--inline-sourcemaps` | Force inline source maps |
+| `-w, --watch` | Re-transpile on file change; keeps the process alive (requires `-o`) |
+| `--debug` | Verbose logging to stderr |
+| `-h, --help`, `-v, --version` | Show help / print version |
+
 ### Advanced Options
 
 Configuration options are added in the configuration section. For JavaScript projects, ensure that no `tsconfig.json` is present in the project root. This would turn the UI5 CLI extension into the TypeScript mode.

--- a/packages/ui5-tooling-transpile/bin/ui5-transpile.js
+++ b/packages/ui5-tooling-transpile/bin/ui5-transpile.js
@@ -1,0 +1,566 @@
+#!/usr/bin/env node
+/* eslint-disable jsdoc/require-jsdoc */
+
+/**
+ * Standalone CLI wrapper around the ui5-tooling-transpile task/middleware logic.
+ *
+ * Reuses the Babel config + transform pipeline from lib/util.js so that single
+ * files or globs can be transpiled without running a full `ui5 build`.
+ *
+ * Usage:
+ *   ui5-transpile [options] <file|glob> [<file|glob> ...]
+ *   ui5-transpile [options] -                # read from stdin → stdout
+ *
+ * See `--help` for the full list of options.
+ */
+
+const path = require("path");
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+const PKG = require("../package.json");
+
+// ANSI helpers (matches packages/ui5-task-copyright/bin/uses-ui5-task-copyright.js)
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const RESET = "\x1b[0m";
+
+function err(prefix, ...messages) {
+	console.error(`${RED}[${prefix}]${RESET} ${messages.join(" ")}`);
+}
+
+function warn(...messages) {
+	console.error(`${YELLOW}[WARN]${RESET} ${messages.join(" ")}`);
+}
+
+function die(message, error) {
+	err("ERROR", message);
+	if (error && process.env.UI5_TRANSPILE_DEBUG === "true") {
+		console.error(error.stack || error);
+	}
+	process.exit(1);
+}
+
+// Logger compatible with the shape used by lib/util.js (see test/util.test.js).
+// All output goes to stderr so stdout stays pipeable for transpiled code.
+function makeLogger(debug) {
+	const out =
+		(level) =>
+		(...messages) =>
+			console.error(`[${level}] ${messages.join(" ")}`);
+	const noop = () => {};
+	return {
+		silly: debug ? out("silly") : noop,
+		verbose: debug ? out("verbose") : noop,
+		perf: debug ? out("perf") : noop,
+		info: debug ? out("info") : noop,
+		warn: out("warn"),
+		error: out("error"),
+		silent: noop
+	};
+}
+
+function printHelp() {
+	const lines = [
+		`Usage: ui5-transpile [options] <file|glob> [<file|glob> ...]`,
+		`       ui5-transpile [options] -            # read from stdin → stdout`,
+		``,
+		`Transpile JavaScript/TypeScript resources via Babel using the same`,
+		`configuration the ui5-tooling-transpile task/middleware would apply.`,
+		``,
+		`Options:`,
+		`  -o, --out <file|dir>     Output file (1 input) or directory (N inputs).`,
+		`                           Omit for stdout (1 input only).`,
+		`      --cwd <dir>          Working directory for config lookup (default: cwd).`,
+		`      --ui5-yaml <path>    Explicit ui5.yaml file (default: <cwd>/ui5.yaml if present).`,
+		`      --ts                 Force TypeScript transformation on.`,
+		`      --no-ts              Force TypeScript transformation off.`,
+		`      --no-sourcemaps      Disable source maps.`,
+		`      --inline-sourcemaps  Force inline source maps.`,
+		`  -w, --watch              Re-transpile on file change (requires -o).`,
+		`      --debug              Verbose logging to stderr.`,
+		`  -h, --help               Show this help and exit.`,
+		`  -v, --version            Print version and exit.`,
+		``,
+		`Examples:`,
+		`  ui5-transpile webapp/Foo.ts`,
+		`  ui5-transpile webapp/Foo.ts -o dist/Foo.js`,
+		`  ui5-transpile "webapp/**/*.ts" -o dist/`,
+		`  ui5-transpile "webapp/**/*.ts" -o dist/ --watch`,
+		`  echo 'const x: number = 1' | ui5-transpile --ts -`
+	];
+	console.log(lines.join("\n"));
+}
+
+function parseArgs(argv) {
+	const args = {
+		inputs: [],
+		out: null,
+		cwd: process.cwd(),
+		ui5YamlPath: null,
+		forceTs: null, // null = unset, true/false from --ts/--no-ts
+		noSourceMaps: false,
+		inlineSourceMaps: false,
+		watch: false,
+		debug: false,
+		stdin: false
+	};
+
+	let i = 0;
+	const next = (flag) => {
+		if (i + 1 >= argv.length) {
+			die(`Missing value for ${flag}`);
+		}
+		return argv[++i];
+	};
+
+	let positionalsOnly = false;
+	for (; i < argv.length; i++) {
+		const token = argv[i];
+		if (positionalsOnly) {
+			args.inputs.push(token);
+			continue;
+		}
+		switch (token) {
+			case "-h":
+			case "--help":
+				printHelp();
+				process.exit(0);
+				break;
+			case "-v":
+			case "--version":
+				console.log(PKG.version);
+				process.exit(0);
+				break;
+			case "-o":
+			case "--out":
+				args.out = next(token);
+				break;
+			case "--cwd":
+				args.cwd = path.resolve(next(token));
+				break;
+			case "--ui5-yaml":
+				args.ui5YamlPath = path.resolve(next(token));
+				break;
+			case "--ts":
+				args.forceTs = true;
+				break;
+			case "--no-ts":
+				args.forceTs = false;
+				break;
+			case "--no-sourcemaps":
+				args.noSourceMaps = true;
+				break;
+			case "--inline-sourcemaps":
+				args.inlineSourceMaps = true;
+				break;
+			case "-w":
+			case "--watch":
+				args.watch = true;
+				break;
+			case "--debug":
+				args.debug = true;
+				process.env.UI5_TRANSPILE_DEBUG = "true";
+				break;
+			case "--":
+				positionalsOnly = true;
+				break;
+			case "-":
+				args.stdin = true;
+				break;
+			default:
+				if (token.startsWith("-")) {
+					die(`Unknown flag: ${token}`);
+				}
+				args.inputs.push(token);
+		}
+	}
+
+	// validate mutually-exclusive combinations
+	if (args.noSourceMaps && args.inlineSourceMaps) {
+		die(`--no-sourcemaps and --inline-sourcemaps are mutually exclusive.`);
+	}
+	if (args.stdin && (args.inputs.length > 0 || args.out || args.watch)) {
+		die(`stdin mode ('-') cannot be combined with positional inputs, -o, or --watch.`);
+	}
+	if (!args.stdin && args.inputs.length === 0) {
+		printHelp();
+		process.exit(1);
+	}
+	if (args.watch && !args.out) {
+		die(`--watch requires -o/--out (incremental output to stdout is not supported).`);
+	}
+
+	return args;
+}
+
+// Locate the ui5.yaml the CLI should honour: explicit > <cwd>/ui5.yaml > none.
+function findUi5Yaml(args) {
+	if (args.ui5YamlPath) {
+		if (!fs.existsSync(args.ui5YamlPath) || !fs.statSync(args.ui5YamlPath).isFile()) {
+			die(`The specified ui5.yaml does not exist: ${args.ui5YamlPath}`);
+		}
+		return args.ui5YamlPath;
+	}
+	const candidate = path.join(args.cwd, "ui5.yaml");
+	return fs.existsSync(candidate) ? candidate : null;
+}
+
+// Extract the task (preferred) or middleware configuration block from a ui5.yaml.
+// Multiple yaml documents are supported (matches lib/postinstall.js).
+function loadUi5Configuration(yamlPath, log) {
+	if (!yamlPath) {
+		return { configuration: {}, isMiddleware: false };
+	}
+	let docs;
+	try {
+		docs = yaml.loadAll(fs.readFileSync(yamlPath, "utf-8"));
+	} catch (e) {
+		if (e.name === "YAMLException") {
+			die(`Failed to parse ${yamlPath}: ${e.message}`);
+		}
+		throw e;
+	}
+	for (const doc of docs || []) {
+		const task = (doc?.builder?.customTasks || []).find((t) => t.name === "ui5-tooling-transpile-task");
+		if (task) {
+			log.verbose(`Using task configuration from ${yamlPath}`);
+			return { configuration: task.configuration || {}, isMiddleware: false };
+		}
+	}
+	for (const doc of docs || []) {
+		const mw = (doc?.server?.customMiddleware || []).find((m) => m.name === "ui5-tooling-transpile-middleware");
+		if (mw) {
+			log.verbose(`Using middleware configuration from ${yamlPath}`);
+			return { configuration: mw.configuration || {}, isMiddleware: true };
+		}
+	}
+	log.verbose(`No ui5-tooling-transpile configuration found in ${yamlPath} — running with defaults.`);
+	return { configuration: {}, isMiddleware: false };
+}
+
+// Apply CLI flag overrides BEFORE createConfiguration normalizes things.
+function applyCliOverrides(configuration, args) {
+	const cfg = Object.assign({}, configuration);
+	if (args.forceTs !== null) {
+		cfg.transformTypeScript = args.forceTs;
+	}
+	if (args.noSourceMaps) {
+		cfg.omitSourceMaps = true;
+	}
+	if (args.debug) {
+		cfg.debug = true;
+	}
+	return cfg;
+}
+
+const GLOB_CHARS = /[*?[\]{}]/;
+
+function isGlob(input) {
+	return GLOB_CHARS.test(input);
+}
+
+// Resolve positional inputs (files or globs) to a deduped, sorted list of
+// absolute paths, filtered by the include/exclude semantics of the task.
+function resolveInputs(inputs, normalizedConfig, args, log) {
+	const set = new Set();
+	const missing = [];
+
+	for (const entry of inputs) {
+		if (isGlob(entry)) {
+			const matches = fs.globSync(entry, { cwd: args.cwd });
+			for (const m of matches) {
+				const abs = path.isAbsolute(m) ? m : path.resolve(args.cwd, m);
+				if (fs.existsSync(abs) && fs.statSync(abs).isFile()) {
+					set.add(abs);
+				}
+			}
+		} else {
+			const abs = path.isAbsolute(entry) ? entry : path.resolve(args.cwd, entry);
+			if (fs.existsSync(abs) && fs.statSync(abs).isFile()) {
+				set.add(abs);
+			} else {
+				missing.push(entry);
+			}
+		}
+	}
+
+	if (missing.length > 0) {
+		die(`Input file(s) not found:\n  - ${missing.join("\n  - ")}`);
+	}
+
+	// Apply include/exclude semantics (same as task/middleware via shouldHandlePath
+	// — but the task checks at the workspace path level, here we use FS paths).
+	const filtered = [];
+	for (const abs of [...set].sort()) {
+		const inExcludes = (normalizedConfig.excludes || []).some((p) => abs.includes(p));
+		const inIncludes = (normalizedConfig.includes || []).some((p) => abs.includes(p));
+		if (inExcludes && !inIncludes) {
+			log.verbose(`Skipping (excluded): ${abs}`);
+			continue;
+		}
+		filtered.push(abs);
+	}
+	return filtered;
+}
+
+// Replace any source extension (.ts/.tsx/.js/.jsx/...) with .js.
+// Same approach as lib/task.js:119.
+function toJsPath(p) {
+	return p.replace(/\.[^.]+$/, ".js");
+}
+
+// Compute the longest common directory prefix of the inputs (for mirroring).
+function commonRoot(absPaths, fallback) {
+	if (absPaths.length === 0) {
+		return fallback;
+	}
+	const split = absPaths.map((p) => path.dirname(p).split(path.sep));
+	let prefix = split[0];
+	for (let i = 1; i < split.length; i++) {
+		const cur = split[i];
+		let j = 0;
+		while (j < prefix.length && j < cur.length && prefix[j] === cur[j]) j++;
+		prefix = prefix.slice(0, j);
+		if (prefix.length === 0) break;
+	}
+	const root = prefix.join(path.sep);
+	return root || fallback;
+}
+
+function deriveSourceMaps(args, writingToFile) {
+	if (args.noSourceMaps) return false;
+	if (args.inlineSourceMaps) return "inline";
+	return writingToFile ? true : "inline";
+}
+
+// Transpile a single source string. Returns { code, map?, outPath? }.
+async function transpileOne({ util, babelConfig, source, absPath, outPath, args }) {
+	const writingToFile = !!outPath;
+	const opts = Object.assign({}, babelConfig, {
+		filename: absPath,
+		sourceMaps: deriveSourceMaps(args, writingToFile)
+	});
+	const result = await util.transformAsync(source, opts);
+	let code = result.code;
+	let mapString = null;
+	if (result.map && writingToFile && !args.inlineSourceMaps && !args.noSourceMaps) {
+		result.map.file = path.basename(outPath);
+		mapString = util.normalizeLineFeeds(JSON.stringify(result.map));
+		code += `\n//# sourceMappingURL=${result.map.file}.map`;
+	}
+	return { code: util.normalizeLineFeeds(code), map: mapString, outPath };
+}
+
+function writeOutput({ code, map, outPath }) {
+	fs.mkdirSync(path.dirname(outPath), { recursive: true });
+	fs.writeFileSync(outPath, code, "utf-8");
+	if (map) {
+		fs.writeFileSync(`${outPath}.map`, map, "utf-8");
+	}
+}
+
+// Resolve the target output path for a given input given the user's -o setting.
+function resolveOutputPath(absInput, inputs, args, root) {
+	if (!args.out) return null; // stdout
+	const outAbs = path.isAbsolute(args.out) ? args.out : path.resolve(args.cwd, args.out);
+	if (inputs.length === 1) {
+		// If -o is an existing directory or has a trailing separator, treat as dir.
+		const looksLikeDir =
+			args.out.endsWith(path.sep) ||
+			args.out.endsWith("/") ||
+			(fs.existsSync(outAbs) && fs.statSync(outAbs).isDirectory());
+		if (looksLikeDir) {
+			const rel = path.relative(root, absInput);
+			return toJsPath(path.join(outAbs, rel));
+		}
+		return toJsPath(outAbs);
+	}
+	// N inputs → -o must be (or become) a directory
+	if (fs.existsSync(outAbs) && !fs.statSync(outAbs).isDirectory()) {
+		die(`-o must be a directory when multiple inputs are given: ${outAbs}`);
+	}
+	const rel = path.relative(root, absInput);
+	return toJsPath(path.join(outAbs, rel));
+}
+
+async function readStdin() {
+	return new Promise((resolve, reject) => {
+		let data = "";
+		process.stdin.setEncoding("utf-8");
+		process.stdin.on("data", (chunk) => (data += chunk));
+		process.stdin.on("end", () => resolve(data));
+		process.stdin.on("error", reject);
+	});
+}
+
+async function runStdin({ util, babelConfig, args }) {
+	const code = await readStdin();
+	// Pick a synthetic filename so preset selection (TS vs JS) works.
+	const ext = args.forceTs === false ? "stdin.js" : "stdin.ts";
+	const result = await util.transformAsync(
+		code,
+		Object.assign({}, babelConfig, {
+			filename: path.join(args.cwd, ext),
+			sourceMaps: "inline"
+		})
+	);
+	process.stdout.write(util.normalizeLineFeeds(result.code));
+}
+
+async function runOnce({ util, babelConfig, args, normalizedConfig, log }) {
+	const resolved = resolveInputs(args.inputs, normalizedConfig, args, log);
+	if (resolved.length === 0) {
+		warn(`No matching input files after applying include/exclude filters.`);
+		return { errors: [], resolved: [] };
+	}
+	// stdout only allowed for 1 input
+	if (!args.out && resolved.length > 1) {
+		die(`Multiple inputs require -o <dir> (cannot stream more than one file to stdout).`);
+	}
+	const root = commonRoot(resolved, args.cwd);
+	const errors = [];
+	for (const abs of resolved) {
+		const outPath = resolveOutputPath(abs, resolved, args, root);
+		try {
+			const source = fs.readFileSync(abs, "utf-8");
+			const out = await transpileOne({ util, babelConfig, source, absPath: abs, outPath, args });
+			if (out.outPath) {
+				writeOutput(out);
+				log.verbose(`Wrote ${out.outPath}`);
+			} else {
+				process.stdout.write(out.code);
+				if (!out.code.endsWith("\n")) process.stdout.write("\n");
+			}
+		} catch (e) {
+			errors.push({ abs, message: e.message || String(e) });
+			log.verbose(e.stack || String(e));
+		}
+	}
+	return { errors, resolved };
+}
+
+// Watch every unique parent directory of the resolved inputs (recursive on
+// platforms that support it — macOS/Windows do). Debounce per file.
+function startWatch({ util, babelConfig, args, normalizedConfig, log }) {
+	const watchedDirs = new Set();
+	const watchers = [];
+	const pending = new Map(); // absPath → timeout
+
+	const reprocessOne = async (abs) => {
+		// Skip files that don't exist anymore (e.g. deleted)
+		if (!fs.existsSync(abs)) return;
+		try {
+			const source = fs.readFileSync(abs, "utf-8");
+			const resolved = resolveInputs(args.inputs, normalizedConfig, args, log);
+			if (!resolved.includes(abs)) return; // not part of the input set
+			const root = commonRoot(resolved, args.cwd);
+			const outPath = resolveOutputPath(abs, resolved, args, root);
+			const out = await transpileOne({ util, babelConfig, source, absPath: abs, outPath, args });
+			writeOutput(out);
+			console.error(`${YELLOW}[watch]${RESET} re-transpiled ${path.relative(args.cwd, abs)}`);
+		} catch (e) {
+			err("watch", `${path.relative(args.cwd, abs)}: ${e.message || e}`);
+		}
+	};
+
+	const schedule = (abs) => {
+		const prev = pending.get(abs);
+		if (prev) clearTimeout(prev);
+		pending.set(
+			abs,
+			setTimeout(() => {
+				pending.delete(abs);
+				reprocessOne(abs);
+			}, 50)
+		);
+	};
+
+	const initial = resolveInputs(args.inputs, normalizedConfig, args, log);
+	for (const abs of initial) {
+		watchedDirs.add(path.dirname(abs));
+	}
+	// Also watch glob roots so newly-created matching files are picked up.
+	for (const entry of args.inputs) {
+		if (isGlob(entry)) {
+			const root = entry.split(GLOB_CHARS)[0];
+			const dir = path.resolve(args.cwd, root || ".");
+			// climb to the nearest existing directory
+			let probe = dir;
+			while (probe && !fs.existsSync(probe)) {
+				probe = path.dirname(probe);
+			}
+			if (probe) watchedDirs.add(probe);
+		}
+	}
+
+	for (const dir of watchedDirs) {
+		try {
+			const w = fs.watch(dir, { recursive: true }, (eventType, filename) => {
+				if (!filename) return;
+				const abs = path.resolve(dir, filename);
+				schedule(abs);
+			});
+			watchers.push(w);
+			log.verbose(`Watching ${dir}`);
+		} catch (e) {
+			warn(`Could not watch ${dir}: ${e.message}`);
+		}
+	}
+
+	const shutdown = () => {
+		for (const w of watchers) {
+			try {
+				w.close();
+				// eslint-disable-next-line no-unused-vars
+			} catch (_e) {
+				/* ignore */
+			}
+		}
+		process.exit(0);
+	};
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+
+	console.error(`${YELLOW}[watch]${RESET} watching for changes — press Ctrl+C to stop`);
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const log = makeLogger(args.debug);
+
+	const yamlPath = findUi5Yaml(args);
+	const { configuration, isMiddleware } = loadUi5Configuration(yamlPath, log);
+
+	const merged = applyCliOverrides(configuration, args);
+
+	const util = require("../lib/util")(log);
+	let normalizedConfig;
+	try {
+		normalizedConfig = util.createConfiguration({ configuration: merged, isMiddleware }, args.cwd);
+	} catch (e) {
+		die(`Failed to build configuration: ${e.message}`, e);
+	}
+	const babelConfig = await util.createBabelConfig({ configuration: normalizedConfig, isMiddleware }, args.cwd);
+
+	if (args.stdin) {
+		await runStdin({ util, babelConfig, args });
+		return;
+	}
+
+	const { errors } = await runOnce({ util, babelConfig, args, normalizedConfig, log });
+	for (const e of errors) {
+		err("ERROR", `${path.relative(args.cwd, e.abs)}: ${e.message}`);
+	}
+
+	if (args.watch) {
+		startWatch({ util, babelConfig, args, normalizedConfig, log });
+		return; // process stays alive via watchers
+	}
+
+	if (errors.length > 0) {
+		process.exit(1);
+	}
+}
+
+main().catch((e) => die(e.message || String(e), e));

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",
     "directory": "packages/ui5-tooling-transpile"
   },
+  "bin": {
+    "ui5-transpile": "./bin/ui5-transpile.js"
+  },
   "dependencies": {
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
@@ -34,7 +37,7 @@
   },
   "scripts": {
     "postinstall": "node ./lib/postinstall.js",
-    "lint": "eslint lib",
+    "lint": "eslint lib bin",
     "test": "ava --no-worker-threads"
   },
   "ava": {


### PR DESCRIPTION
## Why

Today `ui5-tooling-transpile` ships only a UI5 Tooling **task** and **middleware**. To transpile a single file (e.g. for ad-hoc debugging, scripting, or CI checks) you have to run a full `ui5 build` or start the dev server. This PR adds a thin standalone CLI wrapper that reuses the existing Babel pipeline so individual resources can be transpiled directly.

## What

A new `ui5-transpile` command (`bin/ui5-transpile.js`) that:

- accepts one or many files, plus glob patterns (`fs.globSync` — no new runtime deps)
- writes to **stdout** by default; `-o <file|dir>` writes to disk (dir required for N inputs; output mirrors the input layout)
- auto-detects `<cwd>/ui5.yaml` and reuses the `ui5-tooling-transpile-task` (or middleware) configuration; CLI flags override
- supports **stdin** (positional `-`) with inline source maps
- supports **watch mode** (`-w`/`--watch`) with debounced re-transpilation and graceful `SIGINT`/`SIGTERM` shutdown (requires `-o`)
- routes all log output to **stderr** so stdout stays pipeable for the transpiled code

The CLI is a thin shim — `createConfiguration`, `createBabelConfig`, `transformAsync`, and `normalizeLineFeeds` from `lib/util.js` are reused as-is, so behavior stays consistent with the task and middleware.

### Examples

```bash
# Print transpiled JS to stdout (inline source map)
npx ui5-transpile webapp/Foo.ts

# Write next to source (creates Foo.js + Foo.js.map)
npx ui5-transpile webapp/Foo.ts -o dist/Foo.js

# Glob → mirrored directory layout
npx ui5-transpile "webapp/**/*.ts" -o dist/

# Watch mode
npx ui5-transpile "webapp/**/*.ts" -o dist/ --watch

# Pipe from stdin
echo 'const x: number = 1' | npx ui5-transpile --ts -
```

### Flags

| Flag | Description |
|------|-------------|
| `-o, --out <file\|dir>` | Output target — file for 1 input, directory (required) for N inputs; omit = stdout (1 input only) |
| `--cwd <dir>` | Working directory for `ui5.yaml`/`tsconfig.json` lookup |
| `--ui5-yaml <path>` | Explicit `ui5.yaml` to read configuration from |
| `--ts` / `--no-ts` | Force `transformTypeScript` on/off |
| `--no-sourcemaps` | Disable source maps |
| `--inline-sourcemaps` | Force inline source maps |
| `-w, --watch` | Re-transpile on file change; requires `-o` |
| `--debug` | Verbose logging to stderr |
| `-h, --help`, `-v, --version` | Usual |

## Files

- **new** `packages/ui5-tooling-transpile/bin/ui5-transpile.js`
- **edit** `packages/ui5-tooling-transpile/package.json` — added `bin` entry; widened `lint` to also cover `bin/`
- **edit** `packages/ui5-tooling-transpile/README.md` — new `## CLI` section with examples and the flags table

No new runtime dependencies (Node ≥ 22 `fs.globSync` and the existing `js-yaml`).

## Verification

- Single file → stdout: ✅ ES5/UI5 output with inline source map
- Glob → dir: ✅ mirrored layout, each `.js` accompanied by external `.js.map`
- Stdin: ✅ transpiled JS on stdout
- Watch: ✅ re-transpile on edit, clean `SIGINT` shutdown
- `npm run lint` clean for the new file (pre-existing warnings in `lib/` are not introduced here)
- `npm test` → 8/8 pass

## Notes for reviewers

- Marked **draft** while the API surface (flag names, output conventions) is settled.
- The CLI does **not** generate `.d.ts` files. That's a build-time concern of the task and is intentionally out of scope for the CLI.
- One pre-existing footgun was observed in `lib/util.js`: `findBabelConfigOptions` crashes when neither a Babel config nor a `package.json` exists anywhere on the cwd chain. Not introduced by this PR — happy to file a follow-up.
