### PR TITLE
fix(ui5-tooling-modules): sync defaultValue handling between rollup plugin and Handlebars helper

### DIFF
--- a/.changeset/fix-ui5-tooling-modules-defaultvalue-sync.md
+++ b/.changeset/fix-ui5-tooling-modules-defaultvalue-sync.md
@@ -1,0 +1,9 @@
+---
+"ui5-tooling-modules": patch
+---
+
+Sync `defaultValue` serialization between `rollup-plugin-webcomponents` and the Handlebars `json` helper so the generated UI5 metadata is identical regardless of code path.
+
+- In `rollup-plugin-webcomponents`, pass a replacer to `JSON.stringify` that mirrors the Handlebars helper: drop `undefined`/`"undefined"` defaults, keep `""` as-is, and `JSON.parse` everything else so booleans, numbers, objects, and quoted strings come out as proper JSON values (e.g. `true` instead of `"true"`, `"Button"` instead of `'"Button"'`).
+- Drop non-parseable values with a warning instead of emitting invalid JSON.
+- Added cross-reference comments on both sides to keep the two implementations in sync.

--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -360,7 +360,35 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 					tag: ui5Metadata.tag,
 					designtime: `${namespace}/designtime/${clazz.name}.designtime`, // add a default designtime
 				});
-				metadata = JSON.stringify(metadataObject, undefined, 2);
+				// default values are special cased here to avoid the JSON.stringify() from escaping them, which would make them invalid in the generated code.
+				// !!! Note: This must be in sync with the default value handling in the HandlebarsHelper, otherwise the generated code will be different. !!!
+				metadata = JSON.stringify(
+					metadataObject,
+					function (key, value) {
+						if (key === "defaultValue") {
+							switch (value) {
+								case undefined:
+								case "undefined":
+									// drop the property entirely; emitted as the sentinel and removed below
+									return undefined;
+								case "":
+									// emit as empty string; will be replaced below with the original value (which is a valid JSON string)
+									return value;
+								default:
+									try {
+										return JSON.parse(value);
+									} catch {
+										// if the value is not a valid JSON string, we just remove the defaultValue property from the metadata, as it is not valid JSON.
+										// This can happen for example when the defaultValue is corrupt.
+										log.warn(`The defaultValue for ${clazz.name} is not a valid JSON string: ${value}. Removing the defaultValue property from the metadata.`);
+										return undefined;
+									}
+							}
+						}
+						return value;
+					},
+					2,
+				);
 			} else {
 				metadata = JSDocSerializer.serializeMetadata(clazz);
 			}

--- a/packages/ui5-tooling-modules/lib/utils/HandlebarsHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/HandlebarsHelper.js
@@ -14,6 +14,7 @@ const { readFileSync } = require("fs");
  */
 handlebars.registerHelper("json", function (context, space) {
 	// default values are special cased here to avoid the JSON.stringify() from escaping them, which would make them invalid in the generated code.
+	// !!! Note: This must be in sync with the default value handling in the rollup-plugin-webcomponents, otherwise the generated code will be different. !!!
 	if (context.defaultValue && context.defaultValue !== "undefined") {
 		const sanitizedContext = { ...context, defaultValue: "" };
 		const json = JSON.stringify(sanitizedContext, null, space);

--- a/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
+++ b/packages/ui5-tooling-modules/test/__snap__/4370bd2f/@ui5/webcomponents/dist/CheckBox.js
@@ -22,17 +22,16 @@ sap.ui.define(
           properties: {
             accessibleName: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             checked: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             enabled: {
               type: "boolean",
-              defaultValue: "true",
+              defaultValue: true,
               mapping: {
                 type: "property",
                 to: "disabled",
@@ -42,37 +41,35 @@ sap.ui.define(
             displayOnly: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             indeterminate: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             name: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             readonly: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             required: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             text: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             value: {
               type: "string",
               mapping: "property",
-              defaultValue: '"on"'
+              defaultValue: "on"
             },
             valueState: {
               type: "sap.ui.core.ValueState",
@@ -80,12 +77,12 @@ sap.ui.define(
                 formatter: "_mapValueState",
                 parser: "_parseValueState"
               },
-              defaultValue: '"None"'
+              defaultValue: "None"
             },
             wrappingType: {
               type: "@ui5.webcomponents.dist.types.WrappingType",
               mapping: "property",
-              defaultValue: '"Normal"'
+              defaultValue: "Normal"
             },
             width: {
               type: "sap.ui.core.CSSSize",

--- a/packages/ui5-tooling-modules/test/__snap__/56bfa72a/@luigi-project/container/LuigiContainer.js
+++ b/packages/ui5-tooling-modules/test/__snap__/56bfa72a/@luigi-project/container/LuigiContainer.js
@@ -17,118 +17,95 @@ sap.ui.define(
           properties: {
             activeFeatureToggleList: {
               type: "string[]",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             allowRules: {
               type: "string[]",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             anchor: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             authData: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             clientPermissions: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             context: {
               type: "any",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             deferInit: {
               type: "boolean",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             dirtyStatus: {
               type: "boolean",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             documentTitle: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             hasBack: {
               type: "boolean",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             label: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             locale: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             noShadow: {
               type: "boolean",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             nodeParams: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             pathParams: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             sandboxRules: {
               type: "string[]",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             searchParams: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             skipCookieCheck: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             skipInitCheck: {
               type: "boolean",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             theme: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             userSettings: {
               type: "object",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             viewurl: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             webcomponent: {
               type: "any",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             text: {
               type: "string",

--- a/packages/ui5-tooling-modules/test/__snap__/64fb0379/@ui5/webcomponents/dist/Button.js
+++ b/packages/ui5-tooling-modules/test/__snap__/64fb0379/@ui5/webcomponents/dist/Button.js
@@ -23,31 +23,29 @@ sap.ui.define(
             accessibilityAttributes: {
               type: "any",
               mapping: "property",
-              defaultValue: "{}"
+              defaultValue: {}
             },
             accessibleDescription: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             accessibleName: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             accessibleRole: {
               type: "@ui5.webcomponents.dist.types.ButtonAccessibleRole",
               mapping: "property",
-              defaultValue: '"Button"'
+              defaultValue: "Button"
             },
             design: {
               type: "@ui5.webcomponents.dist.types.ButtonDesign",
               mapping: "property",
-              defaultValue: '"Default"'
+              defaultValue: "Default"
             },
             enabled: {
               type: "boolean",
-              defaultValue: "true",
+              defaultValue: true,
               mapping: {
                 type: "property",
                 to: "disabled",
@@ -56,38 +54,35 @@ sap.ui.define(
             },
             endIcon: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             form: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             icon: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             loading: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             loadingDelay: {
               type: "float",
               mapping: "property",
-              defaultValue: "1000"
+              defaultValue: 1000
             },
             submits: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             type: {
               type: "@ui5.webcomponents.dist.types.ButtonType",
               mapping: "property",
-              defaultValue: '"Button"'
+              defaultValue: "Button"
             },
             text: {
               type: "string",

--- a/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
+++ b/packages/ui5-tooling-modules/test/__snap__/d726ec84/@ui5/webcomponents/dist/Panel.js
@@ -21,43 +21,41 @@ sap.ui.define(
           properties: {
             accessibleName: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             accessibleRole: {
               type: "@ui5.webcomponents.dist.types.PanelAccessibleRole",
               mapping: "property",
-              defaultValue: '"Form"'
+              defaultValue: "Form"
             },
             collapsed: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             fixed: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             headerLevel: {
               type: "@ui5.webcomponents.dist.types.TitleLevel",
               mapping: "property",
-              defaultValue: '"H2"'
+              defaultValue: "H2"
             },
             headerText: {
               type: "string",
-              mapping: "property",
-              defaultValue: "undefined"
+              mapping: "property"
             },
             noAnimation: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             stickyHeader: {
               type: "boolean",
               mapping: "property",
-              defaultValue: "false"
+              defaultValue: false
             },
             text: {
               type: "string",


### PR DESCRIPTION
## Summary

Aligns the `defaultValue` serialization in [rollup-plugin-webcomponents.js](packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js) with the existing logic in [HandlebarsHelper.js](packages/ui5-tooling-modules/lib/utils/HandlebarsHelper.js), so the generated metadata is identical regardless of which code path produces it.

## Changes

- **[rollup-plugin-webcomponents.js](packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js)**: Pass a replacer to `JSON.stringify` for the metadata object that handles `defaultValue` specially:
  - `undefined` / `"undefined"` → property dropped
  - `""` → emitted as empty string
  - otherwise → parsed via `JSON.parse` so booleans, numbers, objects and quoted strings come out as proper JSON values (e.g. `true` instead of `"true"`, `"Button"` instead of `'"Button"'`)
  - non-parseable values are dropped with a warning
- **[HandlebarsHelper.js](packages/ui5-tooling-modules/lib/utils/HandlebarsHelper.js)**: Added a sync note pointing at the rollup plugin so the two stay aligned.
- **Snapshots**: Updated `CheckBox`, `Button`, `Panel` and `LuigiContainer` snapshots to reflect the corrected metadata output.
- **Changeset**: Added a `patch` changeset for `ui5-tooling-modules`.

## Why

Previously, `defaultValue` was serialized as a JSON string (e.g. `"true"`, `'"Button"'`, `"undefined"`) which made the metadata inconsistent and invalid for the UI5 runtime. The Handlebars-based path already handled this; the rollup plugin path did not. Both now produce the same shape.