### PR TITLE
feat(ui5-tooling-transpile): support optional babel plugins via config

### DIFF
--- a/.changeset/ui5-tooling-transpile-jsx-coverage.md
+++ b/.changeset/ui5-tooling-transpile-jsx-coverage.md
@@ -1,0 +1,9 @@
+---
+"ui5-tooling-transpile": minor
+---
+
+Add native JSX/TSX transformation and coverage instrumentation support.
+
+- New `transformJSX` configuration option (`boolean|Object`) enables the optional peer dependency [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/babel-plugin-transform-react-jsx) to transform JSX/TSX syntax. When the value is an object, it is passed through as the plugin's options (e.g. `runtime`, `importSource`). When enabled and no explicit `filePattern` is set, the default file pattern is extended to also handle `jsx`/`tsx` files (`.+(js|jsx)` or `.+(ts|tsx)`).
+- New `coverage` configuration option (`boolean|Object`) enables the optional peer dependency [`babel-plugin-istanbul`](https://www.npmjs.com/package/babel-plugin-istanbul) to instrument the transpiled code for coverage collection. When the value is an object, it is passed through as the plugin's options.
+- Both plugins are only added when the respective configuration option is present/truthy AND the optional dependency can be resolved; otherwise a warning is logged and transpilation continues without the plugin. Both are declared as optional `peerDependencies`.

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -97,6 +97,12 @@ The following configuration options will only be taken into account if no inline
 - removeConsoleStatements: `boolean`  
   includes the [babel-plugin-transform-remove-console](https://babeljs.io/docs/en/babel-plugin-transform-remove-console) which removes the console statement from the transpiled code
 
+- transformJSX: `boolean|Object`
+  includes the [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/babel-plugin-transform-react-jsx) into Babels plugin configuration to transform JSX/TSX syntax into JavaScript; this requires the optional peer dependency `@babel/plugin-transform-react-jsx` to be installed (if missing, a warning is logged and JSX/TSX will not be transformed); if the value is type of `Object` the configuration option is considered to be `true` and the configuration object will be used for the plugin (e.g. `{ "runtime": "automatic", "importSource": "..." }`); when enabled and no explicit `filePattern` is configured, the default `filePattern` is extended to also handle `jsx`/`tsx` files (`.+(js|jsx)` or `.+(ts|tsx)`)
+
+- coverage: `boolean|Object`
+  includes the [`babel-plugin-istanbul`](https://www.npmjs.com/package/babel-plugin-istanbul) into Babels plugin configuration to instrument the code for coverage collection; this requires the optional peer dependency `babel-plugin-istanbul` to be installed (if missing, a warning is logged and the code will not be instrumented); if the value is type of `Object` the configuration option is considered to be `true` and the configuration object will be used for the plugin; the plugin is added last so that it instruments the already transformed source
+
 > :warning: When using `builder` > `settings` > `includeDependency` to add references to other projects (libraries, modules, ...) which also require a Babel transformation, the Babel configuration lookup or the `tsconfig.json` lookup will take place relative to the current working directory. If you want to ensure to use project local configurations in this case, inline the Babel configuration `babelConfig` and the `transformTypeScript` (with `true`=TS or `false`=JS) switch explicitly in the `ui5.yaml`.
 
 ## Usage

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -327,10 +327,17 @@ module.exports = function (log) {
 			const defaultExcludes = [".png", ".jpeg", ".jpg"]; // still needed?
 			const excludes = defaultExcludes.concat(config.excludes || config.excludePatterns || []);
 
+			// derive whether JSX/TSX should be transformed or not
+			const transformJSX = config.transformJSX;
+
 			// determine the file pattern from config or based on TypeScript project
 			let filePattern = config.filePattern; // .+(ts|tsx)
 			if (filePattern === undefined) {
-				filePattern = transformTypeScript ? ".ts" : ".js";
+				if (transformJSX) {
+					filePattern = transformTypeScript ? ".+(ts|tsx)" : ".+(js|jsx)";
+				} else {
+					filePattern = transformTypeScript ? ".ts" : ".js";
+				}
 			}
 
 			// derive transformation parameters
@@ -357,6 +364,8 @@ module.exports = function (log) {
 				tsConfigFile,
 				transformModulesToUI5,
 				transformAsyncToPromise,
+				transformJSX,
+				coverage: config.coverage,
 				targetBrowsers: config.targetBrowsers,
 				removeConsoleStatements: config.removeConsoleStatements,
 				skipBabelPresetPluginResolve: config.skipBabelPresetPluginResolve
@@ -394,7 +403,9 @@ module.exports = function (log) {
 					"transpileAsync",
 					"transformModulesToUI5",
 					"transformAsyncToPromise",
-					"removeConsoleStatements"
+					"removeConsoleStatements",
+					"transformJSX",
+					"coverage"
 				].forEach((config) => {
 					if (configuration?.[config] !== undefined) {
 						log.warn(`Ignoring configuration option "${config}" due to external configuration!`);
@@ -535,6 +546,30 @@ module.exports = function (log) {
 				}
 			}
 
+			// add the plugin to transform JSX/TSX to JavaScript
+			// the plugin is only added when the configuration option
+			// transformJSX is present/truthy and the optional dependency
+			// "@babel/plugin-transform-react-jsx" can be resolved
+			if (configuration?.transformJSX) {
+				if (resolveNodeModule("@babel/plugin-transform-react-jsx", cwd)) {
+					// if the configuration option transformJSX is an object
+					// it contains the configuration options for the plugin
+					// (e.g. { runtime: "automatic", importSource: "..." })
+					if (typeof configuration.transformJSX === "object") {
+						babelConfigOptions.plugins.push([
+							"@babel/plugin-transform-react-jsx",
+							configuration.transformJSX
+						]);
+					} else {
+						babelConfigOptions.plugins.push("@babel/plugin-transform-react-jsx");
+					}
+				} else {
+					log.warn(
+						`Missing dependency "@babel/plugin-transform-react-jsx"! JSX/TSX will not be transformed until dependency has been added...`
+					);
+				}
+			}
+
 			// add plugin to remove console statements
 			if (configuration?.removeConsoleStatements) {
 				babelConfigOptions.plugins.push("transform-remove-console");
@@ -552,6 +587,27 @@ module.exports = function (log) {
 						inlineHelpers: true
 					}
 				]);
+			}
+
+			// add plugin to instrument the code for coverage collection
+			// the plugin is only added when the configuration option
+			// coverage is present/truthy and the optional dependency
+			// "babel-plugin-istanbul" can be resolved - it is added last
+			// so that it wraps the already transformed source
+			if (configuration?.coverage) {
+				if (resolveNodeModule("babel-plugin-istanbul", cwd)) {
+					// if the configuration option coverage is an object
+					// it contains the configuration options for the plugin
+					if (typeof configuration.coverage === "object") {
+						babelConfigOptions.plugins.push(["babel-plugin-istanbul", configuration.coverage]);
+					} else {
+						babelConfigOptions.plugins.push("babel-plugin-istanbul");
+					}
+				} else {
+					log.warn(
+						`Missing dependency "babel-plugin-istanbul"! Code will not be instrumented until dependency has been added...`
+					);
+				}
 			}
 
 			// include the source maps

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -25,10 +25,18 @@
     "ava": "^8.0.1"
   },
   "peerDependencies": {
-    "@ui5/ts-interface-generator": ">=0.8.0"
+    "@babel/plugin-transform-react-jsx": "^7.0.0",
+    "@ui5/ts-interface-generator": ">=0.8.0",
+    "babel-plugin-istanbul": ">=6.0.0"
   },
   "peerDependenciesMeta": {
+    "@babel/plugin-transform-react-jsx": {
+      "optional": true
+    },
     "@ui5/ts-interface-generator": {
+      "optional": true
+    },
+    "babel-plugin-istanbul": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
+      '@babel/plugin-transform-react-jsx':
+        specifier: ^7.0.0
+        version: 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env':
         specifier: ^7.29.7
         version: 7.29.7(@babel/core@7.29.7)
@@ -594,6 +597,9 @@ importers:
       '@ui5/ts-interface-generator':
         specifier: '>=0.8.0'
         version: 0.11.1(typescript@6.0.3)
+      babel-plugin-istanbul:
+        specifier: '>=6.0.0'
+        version: 8.0.0
       babel-plugin-transform-async-to-promises:
         specifier: ^0.8.18
         version: 0.8.18
@@ -1719,6 +1725,12 @@ packages:
 
   '@babel/plugin-transform-property-literals@7.29.7':
     resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -10772,6 +10784,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)':
     dependencies:


### PR DESCRIPTION
## What

Adds two opt-in configuration options to `ui5-tooling-transpile` that extend the auto-generated babel configuration. Each is gated on **both** the option being set **and** the corresponding optional dependency being resolvable — if the option is set but the dependency is missing, a warning is logged and the plugin is skipped (transpilation continues).

### `transformJSX` (`boolean|Object`)
Adds [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/babel-plugin-transform-react-jsx) to the plugins. An object value is passed straight through as the plugin's options (e.g. `runtime`, `importSource`). When enabled and no explicit `filePattern` is configured, the default file pattern is extended to also cover the respective jsx/tsx sources (`.+(js|jsx)` / `.+(ts|tsx)`).

### `coverage` (`boolean|Object`)
Adds [`babel-plugin-istanbul`](https://www.npmjs.com/package/babel-plugin-istanbul) for coverage instrumentation. An object value is passed through as the plugin's options. Added last so it instruments the already transformed source.

## Details

- Both new dependencies are declared as **optional `peerDependencies`**, following the existing `@ui5/ts-interface-generator` pattern.
- Both options are added to the ignored-config warning list, so users are warned when an external/inline babel config is in use.
- README documents both options.

## Verification

- `npm run lint` — clean (only pre-existing unrelated warnings).
- `npm test` — all existing tests pass.
- Runtime checks: with the deps absent, the warnings fire and no plugins are added; with the deps resolvable, both plugins are assembled with their object options passed through, in the expected order.

A changeset (`minor`) is included.