### PR TITLE
chore: prevent forced major bump of peer dependents (karma-ui5-transpile)

### DIFF
--- a/.changeset/karma-ui5-transpile-patch.md
+++ b/.changeset/karma-ui5-transpile-patch.md
@@ -1,0 +1,5 @@
+---
+"karma-ui5-transpile": patch
+---
+
+Release a patch to pick up the latest `ui5-tooling-transpile`, which adds optional Babel plugin support (JSX/TSX transformation and coverage instrumentation) to the underlying transpilation.


### PR DESCRIPTION
## What

Prevents `karma-ui5-transpile` from being force-released as a **major** version, and adds an explicit changelog entry for its patch release.

Two changes:
1. **`.changeset/config.json`** — enable `onlyUpdatePeerDependentsWhenOutOfRange`. Peer dependents are now only bumped when the new version falls *outside* their declared peer range.
2. **`.changeset/karma-ui5-transpile-patch.md`** — explicit `karma-ui5-transpile: patch` changeset with a documented reason.

## Context

PR #1414 merged optional Babel plugin support into `ui5-tooling-transpile`, leaving a pending **minor** changeset on `main`. Because `karma-ui5-transpile` lists `ui5-tooling-transpile` in its `peerDependencies` (`>=3.2.0`), changesets' default behavior schedules the peer dependent for a **major** bump.

With `onlyUpdatePeerDependentsWhenOutOfRange` enabled, `ui5-tooling-transpile@3.12.0` still satisfies `>=3.2.0`, so no forced major occurs.

## Verification

`changeset status`:
- `ui5-tooling-transpile` → minor (already pending from #1414)
- `karma-ui5-transpile` → patch
- nothing at major

## Note

`___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` is flagged experimental by the changesets team (behavior/name may change in a future changesets patch). It is a repo-wide policy change affecting how all future releases compute peer-dependent bumps, so it may warrant a maintainer's explicit sign-off.