### PR TITLE
fix(ui5-tooling-modules): avoid applying method-wrapping mixins twice in a wrapper inheritance chain

### DIFF
--- a/.changeset/webc-messagemixin-double-apply.md
+++ b/.changeset/webc-messagemixin-double-apply.md
@@ -1,0 +1,16 @@
+---
+"ui5-tooling-modules": patch
+---
+
+fix(webcomponents): avoid applying method-wrapping mixins twice in a wrapper inheritance chain
+
+`MessageMixin` and `LabelEnablement` install method wrappers (`destroy`, `setLabelFor`,
+`exit`, `setRequired`, ...) by capturing the previous method into a shared prototype slot
+that the wrapper resolves via `this` at call time. Emitting them on both a class and its
+superclass (e.g. `DateRangePicker extends DatePicker`, `MultiInput extends Input`) made the
+wrapper capture the ancestor's already-wrapped method and call itself — an infinite
+recursion (`RangeError: Maximum call stack size exceeded`) the first time that method runs,
+e.g. on `destroy()` during view re-instantiation or when routing away. These mixins are now
+emitted only on the topmost ancestor that introduces them; subclasses inherit the wrapped
+methods. `EnabledPropagator` is intentionally left unchanged — it captures via a per-wrapper
+closure, so nested application is safe.

--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -397,10 +397,32 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 
 			const webcClass = chunkName && posix.relative(dirname(resolvedSource), chunkName);
 
-			// UI5 specific features
-			const needsLabelEnablement = clazz._ui5specifics.needsLabelEnablement;
+			// UI5 specific features.
+			//
+			// MessageMixin and LabelEnablement both install method wrappers (destroy / setLabelFor
+			// / exit / setRequired ...) by capturing the previous method into a SHARED prototype
+			// slot (this.fnDestroy, n.__orig_setLabelFor, ...) that the wrapper resolves via `this`
+			// at call time. Applying either a second time in the SAME prototype chain captures the
+			// ancestor's already-wrapped method, so the wrapper ends up calling itself — infinite
+			// recursion / stack overflow the first time that method runs (e.g. destroy() on
+			// DateRangePicker extends DatePicker, or MultiInput extends Input). We therefore emit
+			// each such mixin only on the TOPMOST ancestor that introduces it; subclasses inherit
+			// the already-wrapped methods.
+			//
+			// EnabledPropagator is intentionally NOT gated: it captures the previous method into a
+			// per-wrapper CLOSURE variable (var i = this.getEnabled; ... i.apply(this)), so nested
+			// wrappers chain safely and double application is harmless — gating it would be wrong.
+			const superChainHas = (c, flag) => {
+				for (let s = c?.superclass; s?._ui5specifics; s = s.superclass) {
+					if (s._ui5specifics[flag]) {
+						return true;
+					}
+				}
+				return false;
+			};
+			const needsLabelEnablement = clazz._ui5specifics.needsLabelEnablement && !superChainHas(clazz, "needsLabelEnablement");
 			const needsEnabledPropagator = clazz._ui5specifics.needsEnabledPropagator;
-			const needsMessageMixin = clazz._ui5specifics.needsMessageMixin;
+			const needsMessageMixin = clazz._ui5specifics.needsMessageMixin && !superChainHas(clazz, "needsMessageMixin");
 
 			// Determine the superclass UI5 module name and import it
 			let webcBaseClass = "sap/ui/core/webc/WebComponent";


### PR DESCRIPTION
## Problem

Editing a `.view.xml` that contains certain UI5 Web Component controls (e.g. `DateRangePicker`, `MultiInput`) — or navigating away from a view containing them — throws:

```
Uncaught (in promise) RangeError: Maximum call stack size exceeded
    at ManagedObject.getId (ManagedObject.js:1472)
    at fnClass.destroy (MessageMixin.js:101)
    at fnClass.destroy (MessageMixin.js:114)
    at fnClass.destroy (MessageMixin.js:114)
    ...
```

## Root cause

`MessageMixin` and `LabelEnablement` install method wrappers (`destroy`, `setLabelFor`, `exit`, `setRequired`, …) by capturing the previous method into a **shared prototype slot** (`this.fnDestroy`, `n.__orig_setLabelFor`, …) that the wrapper resolves via `this` at call time.

The generated Web Component wrappers emitted `MessageMixin.call(prototype)` on **both** a class and its superclass whenever both declare a `valueStateMessage` slot:

- `DateRangePicker extends DatePicker`
- `MultiInput extends Input`
- `DateTimePicker extends DatePicker`, `DateTimeInput extends Input`, `@ui5/webcomponents-ai` `Input`/`TextArea`

The subclass's second application captures the ancestor's **already-wrapped** method into the same slot, so the wrapper calls itself → infinite recursion the first time `destroy()` runs (view re-instantiation, routing away, etc.).

## Fix

Emit each **slot-capturing** mixin (`MessageMixin`, `LabelEnablement`) only on the **topmost ancestor** that introduces it; subclasses inherit the wrapped methods. A small `superChainHas(clazz, flag)` helper walks the superclass chain.

`EnabledPropagator` is **intentionally left unchanged** — it captures the previous method into a **per-wrapper closure** (`var i = this.getEnabled; … i.apply(this)`), so nested application chains safely and gating it would be incorrect.

## Verification

- All `ui5-tooling-modules` tests pass (`util.test.js`, `webc.test.js`).
- Rebuilt the `ui5-tsapp-webc` showcase and confirmed the emitted wrappers:
  - `MessageMixin.call` present on `Input`/`DatePicker`, **absent** on `DateRangePicker`/`MultiInput`.
  - `EnabledPropagator.call` still present on subclasses (`ToggleButton`, `DateRangePicker`, `MultiInput`) as intended.
- Editing the view / destroying the controls no longer recurses.