### PR TITLE
feat: release ui5-middleware-hmr 0.1.0 + ui5-middleware-livereload 3.4.0, list HMR in docs

### DIFF
--- a/.changeset/ui5-middleware-hmr-0-1-0.md
+++ b/.changeset/ui5-middleware-hmr-0-1-0.md
@@ -1,0 +1,28 @@
+---
+"ui5-middleware-hmr": minor
+---
+
+feat(ui5-middleware-hmr): first feature release of the experimental HMR middleware
+
+`ui5-middleware-hmr` performs **hot module replacement** of `webapp` sources on
+change instead of a full-page live reload — reloading only what changed while
+preserving as much application state (route, models, open dialogs) as possible.
+
+Highlights:
+
+- CSS, i18n (`.properties`) and JSON model hot-refresh with no reload
+- leaf module + transitive dependent unload/re-require (static dependency graph)
+- controller changes re-instantiate the owning view(s) in place
+- **XML views and JS views** (TypedView and classic JSView) hot-swap in place;
+  routed targets are refreshed through the router with the active route preserved
+- Component / root-view changes rebuild the Component in place
+- resilient lifecycle: the websocket server and file watcher are torn down on
+  process exit, a websocket error no longer crashes the dev server, invalid
+  `exclusions` patterns are skipped with a warning, and the page reloads once on
+  reconnect after a dev-server restart
+- honest full-reload fallback whenever an in-place strategy isn't available
+
+> Experimental: relies on the private, deprecated `sap.ui.loader._.unloadResources`
+> API and internal control/registry behavior. Intended for local development only
+> and may break across UI5 versions; it feature-detects the API and degrades to a
+> full reload when unavailable. JSON and HTML views are not covered and full-reload.

--- a/.changeset/ui5-middleware-livereload-v5-auto-disable.md
+++ b/.changeset/ui5-middleware-livereload-v5-auto-disable.md
@@ -1,0 +1,21 @@
+---
+"ui5-middleware-livereload": minor
+---
+
+feat(ui5-middleware-livereload): auto-disable under UI5 Tooling V5+ with a `force` override
+
+UI5 Tooling **V5** ships a built-in Live Reload; running this middleware alongside
+it makes the page reload more often than necessary. The middleware now **detects
+UI5 Tooling V5 or higher** (via the running `@ui5/server` major version) and
+**auto-disables itself** there to avoid double reloads.
+
+A new `configuration.force` option overrides the automatic behavior in both
+directions:
+
+- `force: true` keeps the middleware active under V5+ (disable the built-in Live
+  Reload via `--no-live-reload` or `server.settings.liveReload` to avoid a
+  double reload)
+- `force: false` disables the middleware on any tooling version
+
+When the tooling version cannot be detected, the middleware fails open (stays
+enabled) so existing setups keep working.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 > 📖 **The full, browsable docs live at [ui5-community.github.io/ui5-ecosystem-showcase](https://ui5-community.github.io/ui5-ecosystem-showcase/)** — extension catalog, picker, contribution guide, and more.
 
-This monorepo ships **27 community-maintained UI5 CLI extensions** — tasks, middlewares, and full UI5 CLI extensions — plus a set of showcase apps that demonstrate them in practice. It's the reference for what the [UI5 CLI](https://ui5.github.io/cli/) extensibility (custom [tasks](https://ui5.github.io/cli/pages/extensibility/CustomTasks/) and [middlewares](https://ui5.github.io/cli/pages/extensibility/CustomServerMiddleware/)) is capable of.
+This monorepo ships **28 community-maintained UI5 CLI extensions** — tasks, middlewares, and full UI5 CLI extensions — plus a set of showcase apps that demonstrate them in practice. It's the reference for what the [UI5 CLI](https://ui5.github.io/cli/) extensibility (custom [tasks](https://ui5.github.io/cli/pages/extensibility/CustomTasks/) and [middlewares](https://ui5.github.io/cli/pages/extensibility/CustomServerMiddleware/)) is capable of.
 
 > :wave: This is a **community project** — no official SAP support. Use it, file issues, contribute, help others.
 
 ## Quick links
 
 - 🚀 [**Get started**](#getting-started) (clone & run locally)
-- 📦 [**Browse the 27 extensions**](https://ui5-community.github.io/ui5-ecosystem-showcase/extensions/)
+- 📦 [**Browse the 28 extensions**](https://ui5-community.github.io/ui5-ecosystem-showcase/extensions/)
 - 🧭 [**Pick the right tool for your problem**](https://ui5-community.github.io/ui5-ecosystem-showcase/selecting/)
 - 🔌 [**Backend connectivity comparison**](https://ui5-community.github.io/ui5-ecosystem-showcase/backend-connectivity/)
 - 🤝 [**Contribute**](#contributing)
@@ -22,7 +22,7 @@ This monorepo ships **27 community-maintained UI5 CLI extensions** — tasks, mi
 
 ## Highlights
 
-- **27 published packages** — middlewares, tasks, and tooling for daily UI5 development.
+- **28 published packages** — middlewares, tasks, and tooling for daily UI5 development.
 - **Several with millions of monthly NPM downloads** — `ui5-tooling-transpile`, `ui5-tooling-modules`, `ui5-task-zipper`, `ui5-middleware-livereload`, `ui5-middleware-simpleproxy`.
 - **Automated releases** via [Changesets](https://github.com/changesets/changesets) + GitHub Actions, OIDC trusted publishing to NPM.
 - **Spec V3** — built for [`@ui5/cli@3.0.0`](https://ui5.github.io/cli/v3/pages/CLI/) and [`specVersion: "3.0"`](https://ui5.github.io/cli/pages/Configuration/#specification-version-30).
@@ -39,6 +39,7 @@ packages
 ├── ui5-middleware-approuter        // proxy SAP CF / XSA destinations during dev
 ├── ui5-middleware-cap              // embed CAP CDS server middlewares in the UI5 dev server
 ├── ui5-middleware-iasync           // sync UI interactions across browsers (alpha!)
+├── ui5-middleware-hmr              // hot module replacement of webapp sources (experimental!)
 ├── ui5-middleware-index            // serve a generated welcome / start page at /
 ├── ui5-middleware-livereload       // live-reload webapp sources on change
 ├── ui5-middleware-onelogin         // generic login support

--- a/docs/_data/packages.yml
+++ b/docs/_data/packages.yml
@@ -43,6 +43,13 @@
   npm: ui5-middleware-iasync
   bestofui5_indexed: true
 
+- name: ui5-middleware-hmr
+  category: Middleware
+  description: "Experimental: hot module replacement of `webapp` sources on change instead of a full-page live reload."
+  github_path: packages/ui5-middleware-hmr
+  npm: ui5-middleware-hmr
+  bestofui5_indexed: false
+
 - name: ui5-middleware-index
   category: Middleware
   description: Serve a generated welcome / start page for the UI5 dev server root.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -3,13 +3,13 @@ title: Extensions
 layout: default
 nav_order: 2
 permalink: /extensions/
-description: "Full catalog of the 27 UI5 CLI extensions published from this monorepo."
+description: "Full catalog of the 28 UI5 CLI extensions published from this monorepo."
 ---
 
 # Extensions catalog
 {: .no_toc }
 
-The 27 packages below are all maintained in this monorepo and published to NPM under the [`ui5-community`](https://github.com/ui5-community) ownership. Picking the right one? See [Selecting an extension](../selecting/).
+The 28 packages below are all maintained in this monorepo and published to NPM under the [`ui5-community`](https://github.com/ui5-community) ownership. Picking the right one? See [Selecting an extension](../selecting/).
 {: .fs-5 .fw-300 }
 
 > **Looking beyond this repo?** [Best of UI5](https://bestofui5.org/) indexes a much wider set of community packages — tasks, middlewares, libraries, controls, generators, and more. It's the recommended starting point for *finding* a UI5 extension. Most (but [not all](#packages-not-yet-on-best-of-ui5)) of the packages on this page are also indexed there.


### PR DESCRIPTION
## What & why

Follow-up to the `ui5-middleware-hmr` `0.0.1` bootstrap. Now that the package exists on npm and trusted publishing is configured, this:

1. **Lists `ui5-middleware-hmr` in the docs-site extensions catalog** (it was missing).
2. **Releases `ui5-middleware-hmr` 0.1.0** — the feature-complete first release.
3. **Releases `ui5-middleware-livereload` 3.4.0** — publishes the already-merged-but-unreleased UI5 Tooling V5+ auto-disable + `force` override.

Each is a **separate commit**.

## Commits

- **docs**: add `ui5-middleware-hmr` to `docs/_data/packages.yml` (marked not-yet-indexed on bestofui5.org), bump extension counts 27 → 28 on the extensions page + root README, and add it to the README package tree.
- **chore(hmr)**: `minor` changeset → **0.0.1 → 0.1.0** (feature-complete release via the normal changesets/OIDC flow).
- **chore(livereload)**: `minor` changeset → **3.3.1 → 3.4.0** for the UI5 Tooling V5+ auto-disable behavior and the new `configuration.force` override (already on `main`, previously without a changeset).

## Release preview

`changeset status` confirms:

- `ui5-middleware-hmr` → **0.1.0** (minor)
- `ui5-middleware-livereload` → **3.4.0** (minor)

On merge, the Release workflow opens a "Version Packages" PR; merging that publishes both — HMR `0.1.0` via OIDC trusted publishing (now that `0.0.1` established the package), and livereload `3.4.0`.

## Notes

- No package code changed here — this is docs + changesets only. The HMR feature code and the livereload V5 change already landed on `main`.
- HMR remains **experimental** (relies on the private, deprecated `unloadResources` API; degrades to full reload when unavailable).