### PR TITLE
feat(ui5-tooling-modules): add create-webc-controls CLI to generate UI5 control wrappers

### DIFF
--- a/.changeset/create-webc-controls-cli.md
+++ b/.changeset/create-webc-controls-cli.md
@@ -1,0 +1,7 @@
+---
+"ui5-tooling-modules": minor
+---
+
+feat(ui5-tooling-modules): add `create-webc-controls` CLI to generate UI5 control wrappers from a custom-elements.json
+
+Adds a standalone, dependency-invocable CLI (`create-webc-controls`) and a programmatic `generateControls()` API that process a custom elements manifest via the `WebComponentRegistry` and serialize the UI5 package glue plus one control wrapper per described class into an output folder. The generated UI5 namespace can be remapped independently from the npm package name (`ui5Namespace`) and a leading module path segment can be stripped (`stripModulePrefix`, e.g. `dist`), which enables generating wrappers for native HTML element packages such as `@ui5/html` under a target namespace like `sap.ui.core.html.elements`.

--- a/packages/ui5-tooling-modules/cli/createControls.js
+++ b/packages/ui5-tooling-modules/cli/createControls.js
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+/**
+ * Standalone CLI to generate UI5 control wrappers from a "custom-elements.json"
+ * (custom-elements-manifest) file.
+ *
+ * Usage:
+ *   create-webc-controls <custom-elements.json> <outputFolder> [options]
+ *
+ * Arguments:
+ *   <custom-elements.json>  path or file:// URL to the custom elements manifest
+ *   <outputFolder>          folder that receives the generated UI5 control files
+ *
+ * Options:
+ *   --namespace <name>          override the package namespace (default: name from nearest package.json)
+ *   --version <version>         override the package version (default: version from nearest package.json)
+ *   --framework-version <ver>   UI5 framework version used for version-dependent generation (default: 2.0.0)
+ *   -h, --help                  show this help
+ *
+ * It reuses the WebComponentRegistry to process the manifest and the existing
+ * handlebars templates (UI5Package.hbs / UI5Control.hbs) to serialize the UI5
+ * package glue and one wrapper control per class described by the metadata.
+ *
+ * In contrast to the rollup plugin this runs without a bundler: it processes a
+ * single manifest (no cross-package dependency resolution) and therefore mainly
+ * targets native HTML element packages (e.g. "@ui5/html") whose wrappers extend
+ * "sap/ui/core/html/HTMLElement" and have no runtime Web Component to import.
+ */
+const { join, dirname, resolve } = require("path");
+const { readFileSync, writeFileSync, mkdirSync, existsSync } = require("fs");
+const { fileURLToPath } = require("url");
+
+const { compile } = require("handlebars");
+const prettier = require("@prettier/sync");
+
+const WebComponentRegistry = require("../lib/utils/WebComponentRegistry");
+const WebComponentRegistryHelper = require("../lib/utils/WebComponentRegistryHelper");
+const { UI5_ELEMENT_NAMESPACE } = WebComponentRegistryHelper;
+
+const TEMPLATES_DIR = join(__dirname, "..", "lib", "templates");
+
+// prettier options for the generated sources (kept in sync with the rollup plugin)
+const PRETTIER_OPTIONS = { semi: true, trailingComma: "none", parser: "babel" };
+
+// -------------------------------------------------------------------------
+// argument parsing
+// -------------------------------------------------------------------------
+
+function printUsage() {
+	console.log(
+		[
+			"Usage: create-webc-controls <custom-elements.json> <outputFolder> [options]",
+			"",
+			"Arguments:",
+			"  <custom-elements.json>  path or file:// URL to the custom elements manifest",
+			"  <outputFolder>          folder that receives the generated UI5 control files",
+			"",
+			"Options:",
+			"  --namespace <name>            override the npm package namespace (default: name from nearest package.json)",
+			"  --ui5-namespace <ns>          UI5 namespace for the generated artifacts, dot or slash notation (default: the npm namespace)",
+			'  --strip-module-prefix <seg>   leading module path segment to strip from the generated names, e.g. "dist"',
+			"  --version <version>           override the package version (default: version from nearest package.json)",
+			"  --framework-version <ver>     UI5 framework version for version-dependent generation (default: 2.0.0)",
+			"  -h, --help                    show this help",
+		].join("\n"),
+	);
+}
+
+function parseArgs(argv) {
+	const positional = [];
+	const options = { frameworkVersion: "2.0.0" };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const readValue = (inline) => (inline !== undefined ? inline : argv[++i]);
+		if (arg === "-h" || arg === "--help") {
+			options.help = true;
+		} else if (arg.startsWith("--ui5-namespace")) {
+			options.ui5Namespace = readValue(arg.split("=")[1]);
+		} else if (arg.startsWith("--strip-module-prefix")) {
+			options.stripModulePrefix = readValue(arg.split("=")[1]);
+		} else if (arg.startsWith("--namespace")) {
+			options.namespace = readValue(arg.split("=")[1]);
+		} else if (arg.startsWith("--framework-version")) {
+			options.frameworkVersion = readValue(arg.split("=")[1]);
+		} else if (arg.startsWith("--version")) {
+			options.version = readValue(arg.split("=")[1]);
+		} else if (arg.startsWith("--")) {
+			throw new Error(`Unknown option: ${arg}`);
+		} else {
+			positional.push(arg);
+		}
+	}
+	options.input = positional[0];
+	options.output = positional[1];
+	return options;
+}
+
+// convert a path or file:// URL into an absolute filesystem path
+function toPath(input) {
+	if (input.startsWith("file:")) {
+		return fileURLToPath(input);
+	}
+	return resolve(input);
+}
+
+// walk up from the given directory to find the nearest package.json
+function findNearestPackageJson(startDir) {
+	let dir = startDir;
+	for (;;) {
+		const candidate = join(dir, "package.json");
+		if (existsSync(candidate)) {
+			return { path: candidate, json: JSON.parse(readFileSync(candidate, "utf-8")) };
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			return undefined;
+		}
+		dir = parent;
+	}
+}
+
+// -------------------------------------------------------------------------
+// template loading
+// -------------------------------------------------------------------------
+
+function loadAndCompileTemplate(templateName) {
+	const templateFile = readFileSync(join(TEMPLATES_DIR, templateName), { encoding: "utf-8" });
+	return compile(templateFile);
+}
+
+// -------------------------------------------------------------------------
+// file emission
+// -------------------------------------------------------------------------
+
+function writeGeneratedFile(outputDir, moduleName, code) {
+	const targetFile = join(outputDir, `${moduleName}.js`);
+	mkdirSync(dirname(targetFile), { recursive: true });
+	writeFileSync(targetFile, prettier.format(code, PRETTIER_OPTIONS), { encoding: "utf-8" });
+	return targetFile;
+}
+
+// -------------------------------------------------------------------------
+// package (library) generation — mirrors buildPackage() of the rollup plugin
+// -------------------------------------------------------------------------
+
+function buildPackage({ package: pkg, template, outputDir }) {
+	// the generated library module path and qualified name follow the (remappable) UI5 namespace,
+	// not the physical npm package name
+	const source = pkg.ui5Namespace;
+	const version = pkg.version;
+	// absolute UI5 module names (see buildWrapper) -> no relative root navigation needed
+	const rootPath = "";
+
+	const metadataObject = {
+		name: pkg.qualifiedNamespace,
+		version,
+		dependencies: ["sap.ui.core"],
+		types: Object.keys(pkg.enums).map((enumName) => pkg.enums[enumName]._ui5QualifiedName),
+		interfaces: Object.keys(pkg.interfaces).map((interfaceName) => pkg.interfaces[interfaceName]._ui5QualifiedName),
+		controls: Object.keys(pkg.customElements).map((elementName) => pkg.customElements[elementName]._ui5QualifiedName),
+		elements: [],
+		rootPath,
+	};
+	const metadata = JSON.stringify(metadataObject, undefined, 2);
+
+	const isBaseLib = pkg.namespace === UI5_ELEMENT_NAMESPACE;
+
+	const code = template({
+		isBaseLib,
+		metadata,
+		namespace: pkg.qualifiedNamespace,
+		interfaces: pkg.interfaces,
+		hasEnums: Object.keys(pkg.enums).length > 0,
+		enums: pkg.enums,
+		dependencies: pkg.dependencies?.map((dep) => `${rootPath}${dep}`),
+		// no bundler chunk and no monkey patches in the standalone scenario:
+		// native HTML packages don't ship a runtime Web Component package
+		monkeyPatches: "",
+		webcPackage: undefined,
+	});
+
+	return writeGeneratedFile(outputDir, source, code);
+}
+
+// -------------------------------------------------------------------------
+// control wrapper generation — mirrors buildWrapper() of the rollup plugin
+// -------------------------------------------------------------------------
+
+function serializeMetadata(clazz, namespace) {
+	const ui5Metadata = clazz._ui5metadata;
+	const metadataObject = Object.assign({}, ui5Metadata, {
+		tag: ui5Metadata.tag,
+		designtime: `${namespace}/designtime/${clazz.name}.designtime`,
+	});
+	// default values are special cased to avoid JSON.stringify() escaping them, which
+	// would make them invalid in the generated code. Must stay in sync with the rollup plugin.
+	return JSON.stringify(
+		metadataObject,
+		function (key, value) {
+			if (key === "defaultValue") {
+				switch (value) {
+					case undefined:
+					case "undefined":
+						return undefined;
+					case "":
+						return value;
+					default:
+						try {
+							return JSON.parse(value);
+						} catch {
+							console.warn(`The defaultValue for ${clazz.name} is not a valid JSON string: ${value}. Removing the defaultValue property from the metadata.`);
+							return undefined;
+						}
+				}
+			}
+			return value;
+		},
+		2,
+	);
+}
+
+function buildWrapper({ clazz, template, outputDir, emitted }) {
+	// emission path + imports follow the (remappable, strip-aware) UI5 qualified name
+	const resolvedSource = clazz._ui5QualifiedNameSlashes;
+	if (emitted.has(resolvedSource)) {
+		return [];
+	}
+	emitted.add(resolvedSource);
+
+	const written = [];
+
+	const ui5Metadata = clazz._ui5metadata;
+	const ui5ClassName = clazz._ui5QualifiedName;
+	const ui5Superclass = clazz.superclass;
+	const namespace = ui5Metadata.namespace;
+
+	const metadata = serializeMetadata(clazz, namespace);
+
+	// no bundler chunk in the standalone scenario -> no runtime Web Component module to import
+	let webcClass = undefined;
+	// generated wrappers are plain AMD sources placed in a resource tree, so we import via
+	// fully-qualified (absolute) UI5 module names instead of fragile relative "../.." paths
+	const rootPath = "";
+
+	// whether the class is a UI5 Web Component (extends UI5Element)
+	const isClazzUI5Element = WebComponentRegistryHelper.isSubclassOf(clazz, "@ui5/webcomponents-base", "UI5Element");
+
+	// MessageMixin / LabelEnablement install method wrappers into a shared prototype slot.
+	// Applying them twice in the same prototype chain causes infinite recursion, so we only
+	// emit them on the topmost ancestor that introduces the flag; subclasses inherit them.
+	// EnabledPropagator is intentionally NOT gated (per-wrapper closure, safe to chain).
+	const superChainHas = (c, flag) => {
+		for (let s = c?.superclass; s?._ui5specifics; s = s.superclass) {
+			if (s._ui5specifics[flag]) {
+				return true;
+			}
+		}
+		return false;
+	};
+	const needsLabelEnablement = clazz._ui5specifics.needsLabelEnablement && !superChainHas(clazz, "needsLabelEnablement");
+	const needsEnabledPropagator = clazz._ui5specifics.needsEnabledPropagator;
+	const needsMessageMixin = clazz._ui5specifics.needsMessageMixin && !superChainHas(clazz, "needsMessageMixin");
+
+	// determine the superclass UI5 module name and import it
+	let webcBaseClass = "sap/ui/core/webc/WebComponent";
+	if (WebComponentRegistryHelper.isUi5CoreHTMLElement(ui5Superclass)) {
+		// native HTML elements extend the core HTMLElement base class
+		webcBaseClass = "sap/ui/core/html/HTMLElement";
+	} else if (ui5Superclass?._ui5metadata && !WebComponentRegistryHelper.isUI5Element(ui5Superclass)) {
+		webcBaseClass = clazz.superclass._ui5QualifiedNameSlashes;
+		// ensure the superclass wrapper exists as well
+		written.push(...buildWrapper({ clazz: clazz.superclass, template, outputDir, emitted }));
+	}
+
+	// no runtime class import required for native HTML elements
+	if (WebComponentRegistryHelper.isSubclassOf(clazz, "sap.ui.core.html", "HTMLElement")) {
+		webcClass = undefined;
+	}
+
+	const code = template({
+		ui5ClassName,
+		jsDocClassHeader: undefined,
+		// if a UI5 superclass exists we import the package module, otherwise the Web Component module
+		namespace: ui5Superclass ? `${rootPath}${namespace}` : webcClass,
+		metadata,
+		webcClass,
+		webcBaseClass: webcBaseClass !== "sap/ui/core/webc/WebComponent" ? `${rootPath}${webcBaseClass}` : webcBaseClass,
+		needsLabelEnablement,
+		needsEnabledPropagator,
+		needsMessageMixin,
+		importWebCModule: isClazzUI5Element && !!webcClass,
+	});
+
+	written.push(writeGeneratedFile(outputDir, resolvedSource, code));
+	return written;
+}
+
+// -------------------------------------------------------------------------
+// programmatic API
+// -------------------------------------------------------------------------
+
+/**
+ * Processes a custom elements manifest via the WebComponentRegistry and writes
+ * the UI5 package glue plus one control wrapper per described class into the
+ * output folder.
+ *
+ * @param {object} opts options
+ * @param {string} opts.input path or file:// URL to the custom elements manifest
+ * @param {string} opts.output output folder for the generated UI5 control files
+ * @param {string} [opts.namespace] npm package namespace (default: name from nearest package.json)
+ * @param {string} [opts.ui5Namespace] UI5 namespace used for the generated artifacts, dot or slash notation (default: the npm namespace)
+ * @param {string} [opts.stripModulePrefix] leading module path segment to strip from the generated names, e.g. "dist"
+ * @param {string} [opts.version] package version (default: version from nearest package.json)
+ * @param {string} [opts.frameworkVersion] UI5 framework version for version-dependent generation (default: 2.0.0)
+ * @returns {string[]} the list of generated file paths
+ */
+function generateControls({ input, output, namespace: namespaceOverride, ui5Namespace, stripModulePrefix, version: versionOverride, frameworkVersion = "2.0.0" } = {}) {
+	if (!input || !output) {
+		throw new Error("Both a custom-elements.json path (input) and an output folder (output) are required.");
+	}
+
+	const metadataPath = toPath(input);
+	if (!existsSync(metadataPath)) {
+		throw new Error(`Custom elements manifest not found: ${metadataPath}`);
+	}
+
+	let customElementsMetadata;
+	try {
+		customElementsMetadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+	} catch (err) {
+		throw new Error(`Failed to parse custom elements manifest ${metadataPath}: ${err.message}`, { cause: err });
+	}
+
+	// derive namespace/version from the nearest package.json unless overridden
+	const npmPackagePath = dirname(metadataPath);
+	const pkg = findNearestPackageJson(npmPackagePath);
+	const namespace = namespaceOverride || pkg?.json?.name;
+	const version = versionOverride || pkg?.json?.version;
+
+	if (!namespace) {
+		throw new Error("Could not determine the package namespace. Provide it via the namespace option or ensure a package.json is present next to the manifest.");
+	}
+
+	const isUI5WebComponents = namespace === UI5_ELEMENT_NAMESPACE || Object.keys(pkg?.json?.dependencies || {}).includes(UI5_ELEMENT_NAMESPACE);
+
+	const outputDir = resolve(output);
+
+	console.log(`Processing "${namespace}"${version ? `@${version}` : ""} from ${metadataPath}`);
+
+	// process the manifest via the WebComponentRegistry (single-file, no dependency resolution)
+	WebComponentRegistry.clear();
+	const registryEntry = WebComponentRegistry.register({
+		customElementsMetadata,
+		namespace,
+		ui5Namespace,
+		stripModulePrefix,
+		library: undefined,
+		isUI5WebComponents,
+		isOpenUI5OrSAPUI5Lib: false,
+		frameworkVersion,
+		scopeSuffix: undefined, // no scoping in the standalone scenario
+		npmPackagePath: pkg ? dirname(pkg.path) : npmPackagePath,
+		version,
+		skipDtsGeneration: true,
+		skipJSDoc: true,
+		customJSDocTags: ["private"],
+	});
+
+	if (!registryEntry) {
+		throw new Error("The WebComponentRegistry did not return an entry for the given manifest.");
+	}
+
+	// compile the templates
+	const ui5PackageTemplate = loadAndCompileTemplate("UI5Package.hbs");
+	const ui5ControlTemplate = loadAndCompileTemplate("UI5Control.hbs");
+
+	const written = [];
+
+	// [1] generate the UI5 package (library) glue
+	written.push(buildPackage({ package: registryEntry, template: ui5PackageTemplate, outputDir }));
+
+	// [2] generate one control wrapper per class described by the metadata
+	const emitted = new Set();
+	Object.keys(registryEntry.classes).forEach((cacheKey) => {
+		const clazz = registryEntry.classes[cacheKey];
+		if (clazz?._ui5metadata) {
+			written.push(...buildWrapper({ clazz, template: ui5ControlTemplate, outputDir, emitted }));
+		}
+	});
+
+	console.log(`Generated ${written.length} file(s) into ${outputDir}`);
+	return written;
+}
+
+// -------------------------------------------------------------------------
+// CLI
+// -------------------------------------------------------------------------
+
+function main() {
+	let options;
+	try {
+		options = parseArgs(process.argv.slice(2));
+	} catch (err) {
+		console.error(err.message);
+		printUsage();
+		process.exit(1);
+	}
+
+	if (options.help) {
+		printUsage();
+		return;
+	}
+
+	if (!options.input || !options.output) {
+		console.error("Error: both a custom-elements.json path and an output folder are required.\n");
+		printUsage();
+		process.exit(1);
+	}
+
+	try {
+		generateControls({
+			input: options.input,
+			output: options.output,
+			namespace: options.namespace,
+			ui5Namespace: options.ui5Namespace,
+			stripModulePrefix: options.stripModulePrefix,
+			version: options.version,
+			frameworkVersion: options.frameworkVersion,
+		});
+	} catch (err) {
+		console.error(`Error: ${err.message}`);
+		process.exit(1);
+	}
+}
+
+module.exports = { generateControls };
+
+// only run the CLI when this file is executed directly (not when imported)
+if (require.main === module) {
+	main();
+}

--- a/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
+++ b/packages/ui5-tooling-modules/lib/templates/UI5Package.hbs
@@ -1,13 +1,13 @@
 /*!
  * ${copyright}
  */
-sap.ui.define([
-  "{{webcPackage}}",{{#if isBaseLib}}
+sap.ui.define([{{#if webcPackage}}
+  "{{webcPackage}}",{{/if}}{{#if isBaseLib}}
   "sap/ui/core/webc/WebComponent",{{/if}}{{#if hasEnums}}
   "sap/ui/base/DataType",{{/if}}{{#each dependencies}}
   "{{this}}",{{/each}}
-], function(
-  WebCPackage,{{#if isBaseLib}}
+], function({{#if webcPackage}}
+  WebCPackage,{{/if}}{{#if isBaseLib}}
   WebComponent,{{/if}}{{#if hasEnums}}
   DataType,{{/if}}
 ) {
@@ -17,7 +17,7 @@ sap.ui.define([
   {{/if}}
 
 	// re-export package object
-  const pkg = Object.assign({}, WebCPackage);
+  const pkg = {{#if webcPackage}}Object.assign({}, WebCPackage){{else}}{}{{/if}};
 
 	// export the UI5 metadata along with the package
 	pkg["_ui5metadata"] = {{{metadata}}};

--- a/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
+++ b/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
@@ -218,7 +218,7 @@ const JSDocSerializer = {
 				alias: `@name module:${interfaceDef._ui5QualifiedNameSlashes}`,
 				entityType: "@interface",
 				// TODO: the override tag is not really correct, as the interface itself is not overridden but its implementing classes are. We might want to change this in the future.
-				override: `@ui5-module-override ${registryEntry.namespace} ${interfaceDef.name}`,
+				override: `@ui5-module-override ${registryEntry.ui5Namespace} ${interfaceDef.name}`,
 				additionalTags: registryEntry.customJSDocTags.map((tag) => `@${tag}`).join("\n"),
 			});
 		});
@@ -234,7 +234,7 @@ const JSDocSerializer = {
 				additionalTags: registryEntry.customJSDocTags.map((tag) => `@${tag}`).join("\n"),
 				alias: `@alias module:${enumDef._ui5QualifiedNameSlashes}`,
 				// TODO: the override tag is not really correct, as the enum itself is not overridden but its values are. We might want to change this in the future.
-				override: `@ui5-module-override ${registryEntry.namespace} ${enumDef._derivedUi5ClassName}`,
+				override: `@ui5-module-override ${registryEntry.ui5Namespace} ${enumDef._derivedUi5ClassName}`,
 			});
 			enumDef.values.forEach((value) => {
 				const description = value.description || value.name;

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -53,12 +53,33 @@ let _classAliases = {};
 class RegistryEntry {
 	#customElementsMetadata = {};
 
-	constructor({ customElementsMetadata, namespace, scopeSuffix, npmPackagePath, version, customJSDocTags, frameworkVersion, isOpenUI5OrSAPUI5Lib, isUI5WebComponents }) {
+	constructor({
+		customElementsMetadata,
+		namespace,
+		ui5Namespace,
+		stripModulePrefix,
+		scopeSuffix,
+		npmPackagePath,
+		version,
+		customJSDocTags,
+		frameworkVersion,
+		isOpenUI5OrSAPUI5Lib,
+		isUI5WebComponents,
+	}) {
 		this.#customElementsMetadata = customElementsMetadata;
 		this.namespace = namespace;
 		this.scopeSuffix = scopeSuffix;
 		this.npmPackagePath = npmPackagePath;
-		this.qualifiedNamespace = slash2dot(this.namespace);
+		// The npm package name (this.namespace) stays the physical identity used for module
+		// resolution, class aliases and cross-package superclass lookup. The UI5 namespace used
+		// for the generated artifacts (class names, module paths, imports) can be remapped
+		// independently, e.g. "@ui5/html" -> "sap/ui/core/html/elements". It is normalized to the
+		// slash notation; defaults to the npm namespace so existing generation stays unchanged.
+		this.ui5Namespace = (ui5Namespace || this.namespace).replace(/\./g, "/");
+		// optional leading module path segment (e.g. the build output "dist") that is stripped
+		// from module paths so it does not leak into the generated UI5 names
+		this.stripModulePrefix = stripModulePrefix;
+		this.qualifiedNamespace = slash2dot(this.ui5Namespace);
 		//this.moduleBasePath = moduleBasePath;
 		//this.qualifiedNamespace = `${moduleBasePath ? slash2dot(this.moduleBasePath) + "." : ""}${slash2dot(removeScopePrefix ? this.namespace.replace(/^@/, "") : this.namespace)}`;
 		// TODO: The following conversion of "-" to "_" is a workaround for testing the UI5 JSDoc build.
@@ -90,7 +111,16 @@ class RegistryEntry {
 	#deriveUi5ClassNames(classDef) {
 		// Calculate fully qualified class name based on the module name from the custom elements manifest
 		// e.g. dist/Avatar.js -> dist.Avatar
-		let convertedClassName = classDef.module.replace(/\//g, ".");
+		let modulePath = classDef.module;
+		// optionally strip a leading module base path (e.g. the build output "dist/") so it does
+		// not leak into the generated UI5 names, e.g. dist/enums/Boolean.js -> enums/Boolean.js
+		if (this.stripModulePrefix) {
+			const prefix = this.stripModulePrefix.replace(/^\/+|\/+$/g, "");
+			if (prefix) {
+				modulePath = modulePath.replace(new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/`), "");
+			}
+		}
+		let convertedClassName = modulePath.replace(/\//g, ".");
 		const _derivedUi5ClassName = convertedClassName.replace(/\.(js|ts)$/, "");
 
 		const _ui5QualifiedName = `${this.qualifiedNamespace}.${_derivedUi5ClassName}`;
@@ -272,10 +302,21 @@ class RegistryEntry {
 
 			let superclassRef = refPackage.classes[superclassLookupName] || refPackage.classes[superclassLookupNameFallback];
 			if (!superclassRef) {
-				logger.error(`The class '${classDef._ui5QualifiedName}' has an unknown superclass '${superclassLookupName}' using default '@ui5/webcomponents-base/UI5Element'!`);
-				const refPackage = WebComponentRegistry.getPackage(WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE);
-				superclassRef = (refPackage || this).classes[WebComponentRegistryHelper.UI5_ELEMENT_CACHE_KEY];
-				classDef.superclass = superclassRef;
+				// a missing superclass is ok as long as it's part of the HTML project
+				if (classDef.namespace === "@ui5/html") {
+					classDef.superclass = {
+						name: "HTMLElement",
+						package: "sap.ui.core",
+						namespace: "sap.ui.core.html",
+						module: "sap/ui/core/html/HTMLElement.js",
+					};
+				} else {
+					// General error case
+					logger.error(`The class '${classDef._ui5QualifiedName}' has an unknown superclass '${superclassLookupName}' using default '@ui5/webcomponents-base/UI5Element'!`);
+					const refPackage = WebComponentRegistry.getPackage(WebComponentRegistryHelper.UI5_ELEMENT_NAMESPACE);
+					superclassRef = (refPackage || this).classes[WebComponentRegistryHelper.UI5_ELEMENT_CACHE_KEY];
+					classDef.superclass = superclassRef;
+				}
 			} else {
 				this.#connectSuperclass(superclassRef);
 				classDef.superclass = superclassRef;
@@ -1191,7 +1232,7 @@ class RegistryEntry {
 	 */
 	#initClass(classDef) {
 		classDef._ui5metadata = {
-			namespace: this.namespace,
+			namespace: this.ui5Namespace,
 			qualifiedNamespace: this.qualifiedNamespace,
 			tag: classDef.scopedTagName || classDef.tagName,
 			interfaces: [],
@@ -1313,6 +1354,8 @@ const WebComponentRegistry = {
 	 * @param {object} options the options object
 	 * @param {object} options.customElementsMetadata the custom elements metadata object
 	 * @param {string} options.namespace the namespace of the web component package
+	 * @param {string} [options.ui5Namespace] the UI5 namespace used for the generated artifacts (dot or slash notation); defaults to the npm namespace
+	 * @param {string} [options.stripModulePrefix] leading module path segment to strip from the generated names (e.g. "dist")
 	 * @param {string} options.library the library of the web component package
 	 * @param {string} options.frameworkVersion the UI5 framework version used
 	 * @param {boolean} options.isUI5WebComponents whether it is a package based on UI5 Web Components or not
@@ -1328,6 +1371,8 @@ const WebComponentRegistry = {
 	register({
 		customElementsMetadata,
 		namespace,
+		ui5Namespace,
+		stripModulePrefix,
 		library,
 		frameworkVersion,
 		isUI5WebComponents,
@@ -1349,6 +1394,8 @@ const WebComponentRegistry = {
 			entry = _registry[namespace] = new RegistryEntry({
 				customElementsMetadata,
 				namespace,
+				ui5Namespace,
+				stripModulePrefix,
 				scopeSuffix,
 				npmPackagePath,
 				version,

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistryHelper.js
@@ -10,6 +10,27 @@ const WebComponentRegistryHelper = {
 	UI5_ELEMENT_MODULE: "dist/UI5Element.js",
 
 	/**
+	 * Helper function to check whether the given class inherits from the provided class name.
+	 *
+	 * @param {object} classDef a class definition from a WebComponentRegistry entry
+	 * @param {string} namespace the class namespace
+	 * @param {string} className the class name
+	 * @returns {boolean} whether the class inherits from the provided class name
+	 */
+	isSubclassOf(classDef, namespace, className) {
+		let superclass = classDef.superclass,
+			isSubclass = false;
+		while (superclass) {
+			if (superclass?.namespace === namespace && superclass?.name === className) {
+				isSubclass = true;
+				break;
+			}
+			superclass = superclass.superclass;
+		}
+		return isSubclass;
+	},
+
+	/**
 	 * Helper function to check whether the given class inherits from UI5Element, the base class for all
 	 * UI5 web components.
 	 *
@@ -17,20 +38,18 @@ const WebComponentRegistryHelper = {
 	 * @returns {boolean} whether the class inherits from UI5Element
 	 */
 	isUI5ElementSubclass(classDef) {
-		let superclass = classDef.superclass,
-			isUI5ElementSubclass = false;
-		while (superclass) {
-			if (superclass?.namespace === this.UI5_ELEMENT_NAMESPACE && superclass?.name === this.UI5_ELEMENT_CLASS_NAME) {
-				isUI5ElementSubclass = true;
-				break;
-			}
-			superclass = superclass.superclass;
-		}
-		return isUI5ElementSubclass;
+		return this.isSubclassOf(classDef, this.UI5_ELEMENT_NAMESPACE, this.UI5_ELEMENT_CLASS_NAME);
 	},
 
 	isUI5Element(ui5Superclass) {
 		return ui5Superclass.namespace === this.UI5_ELEMENT_NAMESPACE && ui5Superclass.name === this.UI5_ELEMENT_CLASS_NAME;
+	},
+
+	/**
+	 * Checks whether the class def is a core HTML element.
+	 */
+	isUi5CoreHTMLElement(ui5Superclass) {
+		return ui5Superclass?.namespace === "sap.ui.core.html" && ui5Superclass?.name === "HTMLElement";
 	},
 
 	/**

--- a/packages/ui5-tooling-modules/package.json
+++ b/packages/ui5-tooling-modules/package.json
@@ -5,6 +5,9 @@
   "author": "Peter Muessig",
   "license": "Apache-2.0",
   "homepage": "https://github.com/ui5-community/ui5-ecosystem-showcase/tree/main/packages/ui5-tooling-modules#readme",
+  "bin": {
+    "create-webc-controls": "cli/createControls.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ui5-community/ui5-ecosystem-showcase.git",


### PR DESCRIPTION
Tooling for creating UI5 wrapper controls for native HTML elements.
