### PR TITLE
feat(ui5-task-zipper): add includes/excludes glob filtering for the archive

### DIFF
--- a/.changeset/ui5-task-zipper-include-exclude.md
+++ b/.changeset/ui5-task-zipper-include-exclude.md
@@ -1,0 +1,19 @@
+---
+"ui5-task-zipper": minor
+---
+
+feat(ui5-task-zipper): add `includes`/`excludes` glob filtering for the archive
+
+The native `builder.resources.excludes` in `ui5.yaml` only filters *source* files
+and cannot remove artifacts created during the build (source maps, `-dbg.js` debug
+bundles). Two new configuration options let you shape the archive contents directly:
+
+- **`excludes`**: glob patterns for build resources to omit from the archive, e.g.
+  `**/*.map`, `**/*-dbg.js` — keeping production deployment archives lightweight.
+- **`includes`**: glob patterns restricting the archive to an allow-list of
+  resources, e.g. `Component.js`, `manifest.json`, `css/**`.
+
+Patterns are matched via `minimatch`. Both options accept `includePatterns` /
+`excludePatterns` as backward-compatible aliases (following the ui5-tooling-transpile
+naming convention). `excludes` wins over `includes`, and `additionalFiles` are not
+affected by the patterns.

--- a/packages/ui5-task-zipper/README.md
+++ b/packages/ui5-task-zipper/README.md
@@ -29,6 +29,12 @@ Default value: `<app-id.zip>`
 - additionalFiles: `String<Array>` or `Object<Array>`
 List of files to be included in the ZIP archive relative to the project root or Map of of files to be included in the ZIP archive relative to the project root and target path in the ZIP archive.
 
+- includes: `String<Array>` (old alias: `includePatterns`)
+List of glob patterns matched against the archive-relative resource paths. When provided, only build resources matching at least one pattern are added to the archive (allow-list), e.g. `Component.js`, `manifest.json`, `css/**`.
+
+- excludes: `String<Array>` (old alias: `excludePatterns`)
+List of glob patterns matched against the archive-relative resource paths. Build resources matching any pattern are omitted from the archive, e.g. `**/*.map`, `**/*-dbg.js`. Unlike the native `builder.resources.excludes` in `ui5.yaml` (which only filters source files), this also removes files generated during the build such as source maps and debug bundles. The `additionalFiles` are not affected by these patterns.
+
 - onlyZip: `true|false`
 Set this to `true` to omit the resources contained in the ZIP from the build result (typically in the `dist` folder). By default, the build result contains all resources and the ZIP.
 
@@ -81,6 +87,31 @@ builder:
       - sap.ui.table
       - ui5.ecosystem.demo.lib
 ```
+
+### Include or exclude files from the archive
+
+Use the `excludes` option to strip files from the archive that are generated during the build but not needed for a production deployment, such as source maps (`.map`) and debug bundles (`-dbg.js`). Use the `includes` option to restrict the archive to an allow-list of resources. Both options accept an array of glob patterns (matched against the archive-relative resource paths):
+
+```yaml
+builder:
+  customTasks:
+  - name: ui5-task-zipper
+    afterTask: generateVersionInfo
+    configuration:
+      archiveName: "my-app-deployment"
+      # exclude generated artifacts from the archive
+      excludes:
+        - "**/*.map"
+        - "**/*-dbg.js"
+      # or: only include these resources in the archive
+      includes:
+        - "Component.js"
+        - "manifest.json"
+        - "css/**"
+        - "i18n/**"
+```
+
+If a resource matches both an `includes` and an `excludes` pattern, `excludes` wins.
 
 ## How it works
 

--- a/packages/ui5-task-zipper/lib/zipper.js
+++ b/packages/ui5-task-zipper/lib/zipper.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const yazl = require("yazl");
+const { minimatch } = require("minimatch");
 
 /**
  * Determines the project name from the given resource collection.
@@ -51,6 +52,8 @@ const absoluteToRelativePaths = (manifest) => {
  * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
  * @param {string} [parameters.options.configuration.archiveName] ZIP archive name (defaults to project namespace)
  * @param {string} [parameters.options.configuration.additionalFiles] List of additional files to be included
+ * @param {string[]} [parameters.options.configuration.includes] Glob patterns; when set, only build resources matching at least one pattern are added to the archive (alias: includePatterns)
+ * @param {string[]} [parameters.options.configuration.excludes] Glob patterns; build resources matching any pattern are omitted from the archive (alias: excludePatterns)
  * @param {object} parameters.taskUtil the task utilities
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
@@ -68,6 +71,24 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 	const includeDependencies = options && options.configuration && options.configuration.includeDependencies;
 	const onlyZip = options && options.configuration && options.configuration.onlyZip;
 	const zipName = `${defaultName || options.projectNamespace.replace(/\//g, "")}.zip`;
+
+	// glob patterns to include/exclude build resources from the archive (aliases: includePatterns/excludePatterns)
+	const includes = options?.configuration?.includes || options?.configuration?.includePatterns || [];
+	const excludes = options?.configuration?.excludes || options?.configuration?.excludePatterns || [];
+
+	// determine whether a build resource should be part of the archive based on the include/exclude globs
+	// eslint-disable-next-line jsdoc/require-jsdoc
+	function shouldIncludeResource(resourcePath) {
+		// exclude wins: drop the resource if it matches any exclude glob
+		if (excludes.some((glob) => minimatch(resourcePath, glob))) {
+			return false;
+		}
+		// when includes are given, only keep resources matching at least one include glob
+		if (includes.length > 0) {
+			return includes.some((glob) => minimatch(resourcePath, glob));
+		}
+		return true;
+	}
 
 	// determine the dependencies resource collection to be included
 	const deps =
@@ -107,10 +128,15 @@ module.exports = async function ({ log, workspace, dependencies, options, taskUt
 					// resource should not be part of the build result -> no need to include it in the zip
 					return;
 				}
+				const resourcePath = resource.getPath().replace(prefixPath, "").replace(/^\//, "");
+				if (!shouldIncludeResource(resourcePath)) {
+					// resource is filtered out by the include/exclude globs -> keep it in the build result but skip the zip
+					isDebug && log.info(`Skipping ${resource.getPath()} (excluded by include/exclude configuration).`);
+					return;
+				}
 				if (onlyZip) {
 					taskUtil.setTag(resource, OmitFromBuildResult, true);
 				}
-				const resourcePath = resource.getPath().replace(prefixPath, "").replace(/^\//, "");
 				if (!zipEntries.includes(resourcePath)) {
 					zipEntries.push(resourcePath);
 					return resource.getBuffer().then((buffer) => {

--- a/packages/ui5-task-zipper/package.json
+++ b/packages/ui5-task-zipper/package.json
@@ -24,6 +24,7 @@
     "timeout": "5m"
   },
   "dependencies": {
+    "minimatch": "^10.2.5",
     "yazl": "^3.3.1"
   },
   "devDependencies": {

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.excludePatternsAlias.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.excludePatternsAlias.yaml
@@ -1,0 +1,22 @@
+specVersion: "3.0"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.148.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateVersionInfo
+      configuration:
+        debug: true
+        archiveName: "excludeAlias"
+        excludePatterns:
+          - "**/*.map"
+          - "**/*-dbg.js"

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.excludes.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.excludes.yaml
@@ -1,0 +1,22 @@
+specVersion: "3.0"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.148.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateVersionInfo
+      configuration:
+        debug: true
+        archiveName: "excludes"
+        excludes:
+          - "**/*.map"
+          - "**/*-dbg.js"

--- a/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.includes.yaml
+++ b/packages/ui5-task-zipper/test/__assets__/ui5-app/ui5.includes.yaml
@@ -1,0 +1,22 @@
+specVersion: "3.0"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.148.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateVersionInfo
+      configuration:
+        debug: true
+        archiveName: "includes"
+        includes:
+          - "Component.js"
+          - "manifest.json"

--- a/packages/ui5-task-zipper/test/zipper.test.js
+++ b/packages/ui5-task-zipper/test/zipper.test.js
@@ -101,6 +101,51 @@ test("archive creation w/ additional files map", async (t) => {
 	t.true(allDepsFound.every((dep) => dep === true));
 });
 
+test("archive excludes .map and -dbg.js files via glob patterns", async (t) => {
+	const ui5 = { yaml: path.resolve("./test/__assets__/ui5-app/ui5.excludes.yaml") };
+	spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+		stdio: "inherit", // > don't include stdout in test output,
+		shell: true,
+		cwd: path.resolve(__dirname, "../../../showcases/ui5-app"),
+	});
+	const targetZip = path.resolve(t.context.tmpDir, "dist", "excludes.zip");
+	t.true(existsSync(targetZip));
+	// excluded artifacts must not be present in the archive
+	t.false(await promisifiedNeedleInHaystack(targetZip, ".js.map"), "source map files should be excluded");
+	t.false(await promisifiedNeedleInHaystack(targetZip, "-dbg.js"), "debug bundle files should be excluded");
+	// regular resources must still be present
+	t.true(await promisifiedNeedleInHaystack(targetZip, "manifest.json"), "manifest.json should still be included");
+});
+
+test("archive excludes files via excludePatterns alias", async (t) => {
+	const ui5 = { yaml: path.resolve("./test/__assets__/ui5-app/ui5.excludePatternsAlias.yaml") };
+	spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+		stdio: "inherit", // > don't include stdout in test output,
+		shell: true,
+		cwd: path.resolve(__dirname, "../../../showcases/ui5-app"),
+	});
+	const targetZip = path.resolve(t.context.tmpDir, "dist", "excludeAlias.zip");
+	t.true(existsSync(targetZip));
+	t.false(await promisifiedNeedleInHaystack(targetZip, ".js.map"), "source map files should be excluded via alias");
+	t.false(await promisifiedNeedleInHaystack(targetZip, "-dbg.js"), "debug bundle files should be excluded via alias");
+});
+
+test("archive includes only allow-listed files via glob patterns", async (t) => {
+	const ui5 = { yaml: path.resolve("./test/__assets__/ui5-app/ui5.includes.yaml") };
+	spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+		stdio: "inherit", // > don't include stdout in test output,
+		shell: true,
+		cwd: path.resolve(__dirname, "../../../showcases/ui5-app"),
+	});
+	const targetZip = path.resolve(t.context.tmpDir, "dist", "includes.zip");
+	t.true(existsSync(targetZip));
+	// allow-listed resources must be present
+	t.true(await promisifiedNeedleInHaystack(targetZip, "Component.js"), "Component.js should be included");
+	t.true(await promisifiedNeedleInHaystack(targetZip, "manifest.json"), "manifest.json should be included");
+	// non-listed resources must be absent
+	t.false(await promisifiedNeedleInHaystack(targetZip, "index.html"), "index.html should not be included");
+});
+
 test("archive creation w/ defaults", async (t) => {
   const ui5 = { yaml: path.resolve("./test/__assets__/ui5-app/ui5.basic.yaml") };
   spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,9 @@ importers:
 
   packages/ui5-task-zipper:
     dependencies:
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
       yazl:
         specifier: ^3.3.1
         version: 3.3.1
@@ -4013,6 +4016,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xn-sakina/rml-darwin-arm64@2.8.0':
     resolution: {integrity: sha512-B8XpWn/t3vALCePi8DnbHQWVQnmKybwPIKbfzL1L75w2V/ELXn0OguFayujf2eZdmCIBPC+Drqxztn6fDV08Ww==}
@@ -7619,10 +7623,6 @@ packages:
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
-  minimatch@7.4.9:
-    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.9:
@@ -17625,7 +17625,7 @@ snapshots:
       lodash: 4.18.1
       log4js: 6.9.1
       mime: 2.6.0
-      minimatch: 7.4.9
+      minimatch: 10.2.5
       mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
@@ -18042,10 +18042,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
-  minimatch@7.4.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -18405,7 +18401,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 6.0.6
       memorystream: 0.3.1
-      minimatch: 7.4.9
+      minimatch: 10.2.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   chromedriver: '>=115'
   minimatch@<3.1.4: '>=3.1.4'
+  karma>minimatch: 7.4.9
   qs@<6.14.1: '>=6.14.1'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
   tmp@>=0.2.0 <0.2.6: '>=0.2.6'
@@ -7623,6 +7624,10 @@ packages:
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@7.4.9:
+    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.9:
@@ -17625,7 +17630,7 @@ snapshots:
       lodash: 4.18.1
       log4js: 6.9.1
       mime: 2.6.0
-      minimatch: 10.2.5
+      minimatch: 7.4.9
       mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
@@ -18039,6 +18044,10 @@ snapshots:
       brace-expansion: 5.0.6
 
   minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimatch@7.4.9:
     dependencies:
       brace-expansion: 2.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,12 @@ overrides:
   # NOT overridden here: the cross-major bump would force-upgrade
   # transitive consumers and is more likely to break than to fix.
   "minimatch@<3.1.4": ">=3.1.4"
+  # karma@6.4.4 calls minimatch as a directly-callable function (mm(path, pattern)
+  # in lib/file-list.js). That callable default export only exists up to minimatch
+  # v7; v9+ moved it to the named `minimatch` export, so deduping karma onto a v9/v10
+  # copy breaks the showcase karma tests with "TypeError: mm is not a function".
+  # Pin karma's transitive minimatch to the last callable line.
+  "karma>minimatch": "7.4.9"
   "qs@<6.14.1": ">=6.14.1"
   "ws@>=8.0.0 <8.20.1": ">=8.20.1"
   "tmp@>=0.2.0 <0.2.6": ">=0.2.6"


### PR DESCRIPTION
## Closes #1426

### Problem

The native `builder.resources.excludes` in `ui5.yaml` only filters **source** files. It cannot remove artifacts that are created **during** the build — most notably source maps (`.map`) and debug bundles (`-dbg.js`). As requested in #1426, there was no way to keep these out of the ZIP produced by `ui5-task-zipper`, so production deployment archives were larger than necessary.

### Solution

Two new configuration options for `ui5-task-zipper`, matched against the archive-relative resource paths via [`minimatch`](https://www.npmjs.com/package/minimatch):

- **`excludes`** — glob patterns for build resources to omit from the archive (e.g. `**/*.map`, `**/*-dbg.js`).
- **`includes`** — glob patterns restricting the archive to an allow-list of resources (e.g. `Component.js`, `manifest.json`, `css/**`).

```yaml
builder:
  customTasks:
    - name: ui5-task-zipper
      afterTask: generateVersionInfo
      configuration:
        archiveName: "my-app-deployment"
        excludes:
          - "**/*.map"
          - "**/*-dbg.js"
        includes:
          - "Component.js"
          - "manifest.json"
          - "css/**"
          - "i18n/**"
```

### Notes on conventions

- Naming follows the modern **ui5-tooling-transpile** convention: primary keys `includes`/`excludes`, with `includePatterns`/`excludePatterns` retained as **backward-compatible aliases**.
- **Glob** matching (via `minimatch`, as used by `ui5-middleware-simpleproxy` and `ui5-tooling-modules`) is used so the `**`-style patterns in the issue work as written.
- `excludes` wins over `includes`.
- `additionalFiles` are **not** affected by these patterns.
- Filtered resources are only skipped from the ZIP; they remain in the build result (`dist`) unless `onlyZip` is set.

### Tests

Added ava tests + fixtures covering: `excludes` (`.map`/`-dbg.js` absent), the `excludePatterns` alias, and the `includes` allow-list (only listed files present). All **13 tests pass**; lint is clean.

A changeset is included (`ui5-task-zipper`: minor).