### PR TITLE
feat: align tasks/middlewares with glob-based includes/excludes syntax

### DIFF
--- a/.changeset/copyright-includes-excludes-globs.md
+++ b/.changeset/copyright-includes-excludes-globs.md
@@ -1,0 +1,11 @@
+---
+"ui5-task-copyright": minor
+---
+
+feat(ui5-task-copyright): add glob-based `includes`/`excludes` options
+
+Adds `includes`/`excludes` configuration options that are matched via `minimatch`
+glob patterns (e.g. `**/thirdparty/**`, `**/*.designtime.js`), aligning the option
+naming and semantics with `ui5-task-zipper`. `excludes` wins over `includes`; when
+`includes` is set, only matching resources get the copyright header. The existing
+`excludePatterns` option keeps its classic substring behavior for backward compatibility.

--- a/.changeset/minify-xml-includes-excludes-globs.md
+++ b/.changeset/minify-xml-includes-excludes-globs.md
@@ -1,0 +1,11 @@
+---
+"ui5-task-minify-xml": minor
+---
+
+feat(ui5-task-minify-xml): add glob-based `includes`/`excludes` options
+
+Adds `includes`/`excludes` configuration options that are matched via `minimatch`
+glob patterns (e.g. `**/thirdparty/**`, `**/*.fragment.xml`), aligning the option
+naming and semantics with `ui5-task-zipper`. `excludes` wins over `includes`; when
+`includes` is set, only matching resources are minified. The existing `excludePatterns`
+option keeps its classic substring behavior for backward compatibility.

--- a/.changeset/simpleproxy-includes-excludes-globs.md
+++ b/.changeset/simpleproxy-includes-excludes-globs.md
@@ -1,0 +1,11 @@
+---
+"ui5-middleware-simpleproxy": minor
+---
+
+feat(ui5-middleware-simpleproxy): add `includes`/`excludes` glob options
+
+Adds `excludes` (a glob-syntax alias of the pre-existing `excludePatterns`) and a new
+`includes` option, both matched via `minimatch`, aligning the option naming with
+`ui5-task-zipper`. When `includes` is set, only matching request paths are proxied;
+`excludes`/`excludePatterns` still take precedence. The behavior of the existing
+`excludePatterns` option is unchanged (it was already glob-based).

--- a/.changeset/transpile-use-glob-patterns.md
+++ b/.changeset/transpile-use-glob-patterns.md
@@ -1,0 +1,13 @@
+---
+"ui5-tooling-transpile": minor
+---
+
+feat(ui5-tooling-transpile): add `useGlobPatterns` flag for glob `includes`/`excludes`
+
+Adds a `useGlobPatterns` boolean option (default `false`). When enabled, the
+`includes`/`excludes` options (and their `includePatterns`/`excludePatterns` aliases)
+are matched as glob patterns via `minimatch` instead of the classic substring matching,
+aligning the syntax with other UI5 tooling extensions (e.g. `ui5-task-zipper`). With the
+flag enabled, patterns must be written as globs (e.g. `**/thirdparty/**`, `**/*.png`) and
+the built-in image default excludes are globbed automatically. The default remains
+substring matching, so existing configurations are unaffected.

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -33,6 +33,10 @@ npm install ui5-middleware-simpleproxy --save-dev
   Query parameters set for the proxied request. Will overwrite the parameters from the request. 
 - `excludePatterns`: `string[]`
   Array of exclude patterns using glob syntax
+- `excludes`: `string[]`
+  Array of exclude patterns using glob syntax (alias of `excludePatterns`, aligned with the `ui5-task-zipper` convention). Requests matching any pattern are not proxied.
+- `includes`: `string[]`
+  Array of include patterns using glob syntax; when set, only requests matching at least one pattern are proxied.
 - `skipCache`: `boolean`
   Remove the cache guid when serving from the FLP launchpad if it matches an excludePattern
 - `enableWebSocket`: `<boolean>`, default: `false` *experimental*

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -9,6 +9,8 @@
  * @property {map|yo<input>} [httpHeaders] Http headers set for the proxied request. Will overwrite the http headers from the request.
  * @property {map|yo<input>} [query] Query parameters set for the proxied request. Will overwrite the parameters from the request.
  * @property {string[]|yo<input>} [excludePatterns] Array of exclude patterns using glob syntax
+ * @property {string[]|yo<input>} [excludes] Array of exclude patterns using glob syntax (alias of excludePatterns, aligned with ui5-task-zipper)
+ * @property {string[]|yo<input>} [includes] Array of include patterns using glob syntax; when set, only matching requests are proxied
  * @property {boolean|yo<confirm>} [skipCache] Remove the cache guid when serving from the FLP launchpad if it matches an excludePattern
  * @property {boolean|yo<confirm>} [debug] see output
  */
@@ -87,6 +89,8 @@ module.exports = async function ({ log, options, middlewareUtil }) {
 		httpHeaders: {},
 		query: null,
 		excludePatterns: [],
+		includes: [],
+		excludes: [],
 		skipCache: false,
 		enableWebSocket: false,
 	};
@@ -95,7 +99,7 @@ module.exports = async function ({ log, options, middlewareUtil }) {
 	Object.assign(effectiveOptions, sanitizeObject(options.configuration), /* env values */ sanitizeObject(env));
 
 	// effective configuration options
-	const { debug, baseUri, strictSSL, removeETag, username, password, httpHeaders, query, excludePatterns, skipCache } = effectiveOptions;
+	const { debug, baseUri, strictSSL, removeETag, username, password, httpHeaders, query, excludePatterns, includes, excludes, skipCache } = effectiveOptions;
 
 	// log the configuration for the proxy in debug mode
 	debug && log.info(`[${baseUri}] Effective configuration:\n${JSON.stringify(effectiveOptions, undefined, 2)}`);
@@ -121,23 +125,25 @@ module.exports = async function ({ log, options, middlewareUtil }) {
 	const { createProxyMiddleware, responseInterceptor } = await import("http-proxy-middleware");
 
 	// check whether the request should be included or not
-	const hasExcludePatterns = excludePatterns && Array.isArray(excludePatterns);
+	// `excludePatterns` is the pre-existing (glob) option; `excludes`/`includes` align with the
+	// ui5-task-zipper convention (also glob). `excludePatterns` and `excludes` are merged as they
+	// share identical glob semantics.
+	const effectiveExcludes = [...(Array.isArray(excludePatterns) ? excludePatterns : []), ...(Array.isArray(excludes) ? excludes : [])];
+	const effectiveIncludes = Array.isArray(includes) ? includes : [];
 	const filter = function (pathname, req) {
-		if (hasExcludePatterns) {
-			const exclude = excludePatterns.some((glob) => minimatch(pathname, glob));
-			if (exclude) {
-				const url = req.url;
-				debug && log.info(`[${baseUri}] Request ${url} is excluded`);
-				const reCBToken = /\/~.*~.\//g;
-				if (skipCache && reCBToken.test(url)) {
-					const newUrl = url.replace(reCBToken, "/");
-					debug && log.info(`[${baseUri}] Removing cachebuster token from ${url}, resolving to ${newUrl}`);
-					req.url = newUrl;
-				}
+		// a request matching any exclude glob is excluded (exclude wins)
+		const exclude = effectiveExcludes.some((glob) => minimatch(pathname, glob)) || (effectiveIncludes.length > 0 && !effectiveIncludes.some((glob) => minimatch(pathname, glob)));
+		if (exclude) {
+			const url = req.url;
+			debug && log.info(`[${baseUri}] Request ${url} is excluded`);
+			const reCBToken = /\/~.*~.\//g;
+			if (skipCache && reCBToken.test(url)) {
+				const newUrl = url.replace(reCBToken, "/");
+				debug && log.info(`[${baseUri}] Removing cachebuster token from ${url}, resolving to ${newUrl}`);
+				req.url = newUrl;
 			}
-			return !exclude;
 		}
-		return true;
+		return !exclude;
 	};
 
 	// run the proxy middleware based on the host configuration

--- a/packages/ui5-middleware-simpleproxy/test/proxy.test.js
+++ b/packages/ui5-middleware-simpleproxy/test/proxy.test.js
@@ -158,6 +158,17 @@ test.before(async (t) => {
 					},
 					{
 						name: "ui5-middleware-simpleproxy",
+						mountPath: "/proxy-glob",
+						afterMiddleware: "compression",
+						configuration: {
+							debug,
+							baseUri: `http://www.example.com`,
+							excludes: ["**/excluded/**"],
+							includes: ["**/*.json"],
+						},
+					},
+					{
+						name: "ui5-middleware-simpleproxy",
 						mountPath: "/ws",
 						afterMiddleware: "compression",
 						configuration: {
@@ -381,6 +392,26 @@ test("excludePatterns option", async (t) => {
 	t.is(res.statusCode, 200, "Correct HTTP status code");
 	t.regex(res.headers["content-type"], /text/, "Correct content type");
 	t.regex(res.text, /Hello World/, "Correct response");
+});
+
+test("excludes/includes glob options", async (t) => {
+	nock("http://www.example.com/")
+		.get("/api/data.json")
+		.reply(200, JSON.stringify({ ok: true }), { "content-type": "application/json" })
+		.get("/excluded/data.json")
+		.reply(200, JSON.stringify({ ok: true }), { "content-type": "application/json" });
+
+	const { request } = t.context;
+	// a .json path (matches includes, not excluded) is proxied
+	const res = await request.get("/proxy-glob/api/data.json");
+	t.is(res.statusCode, 200, "included .json path is proxied");
+	t.regex(res.headers["content-type"], /json/, "Correct content type");
+	// a .json path under /excluded/ is excluded (exclude wins) -> not proxied -> 404 (no local resource)
+	const resExcluded = await request.get("/proxy-glob/excluded/data.json");
+	t.is(resExcluded.statusCode, 404, "excluded path is not proxied");
+	// a non-.json path does not match includes -> not proxied -> 404
+	const resNotIncluded = await request.get("/proxy-glob/api/data.txt");
+	t.is(resNotIncluded.statusCode, 404, "path not matching includes is not proxied");
 });
 
 test("skipCache option", async (t) => {

--- a/packages/ui5-task-copyright/README.md
+++ b/packages/ui5-task-copyright/README.md
@@ -32,7 +32,13 @@ npm install ui5-task-copyright --save-dev
   the value of the currentYear placeholder in the copyright comments
 
 - excludePatterns: `Array<String>`
-  array of paths inside `$yourapp/` to exclude from the minification, e.g. 3-rd party libs in `lib/*`. defaults to an empty array `[]`.
+  array of paths inside `$yourapp/` to exclude from the copyright processing, e.g. 3-rd party libs in `lib/*`. defaults to an empty array `[]`. Uses substring matching (classic behavior).
+
+- includes: `Array<String>`
+  array of glob patterns (matched via [minimatch](https://github.com/isaacs/minimatch)); when set, only resources matching at least one pattern are processed, e.g. `["**/controller/**"]`. defaults to an empty array `[]`.
+
+- excludes: `Array<String>`
+  array of glob patterns (matched via [minimatch](https://github.com/isaacs/minimatch)); resources matching any pattern are excluded from processing, e.g. `["**/thirdparty/**", "**/*.designtime.js"]`. defaults to an empty array `[]`.
 
 ## Usage
 

--- a/packages/ui5-task-copyright/lib/copyright.js
+++ b/packages/ui5-task-copyright/lib/copyright.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 
 const { parse } = require("@typescript-eslint/typescript-estree");
 const { XMLParser } = require("fast-xml-parser");
+const { minimatch } = require("minimatch");
 
 /**
  * Task to append a copyright header for TypeScript, JavaScript and XML files
@@ -64,6 +65,25 @@ module.exports = async ({ log, workspace, options }) => {
 		options.configuration,
 	);
 
+	// glob-based include/exclude patterns (aligned with ui5-task-zipper); the classic
+	// substring-based `excludePatterns` is kept for backward compatibility
+	const includes = options?.configuration?.includes || [];
+	const excludes = options?.configuration?.excludes || [];
+
+	// determine whether a resource should be processed based on the include/exclude globs
+	// eslint-disable-next-line jsdoc/require-jsdoc
+	function shouldProcessResource(resourcePath) {
+		// exclude wins: drop the resource if it matches any exclude glob
+		if (excludes.some((glob) => minimatch(resourcePath, glob))) {
+			return false;
+		}
+		// when includes are given, only keep resources matching at least one include glob
+		if (includes.length > 0) {
+			return includes.some((glob) => minimatch(resourcePath, glob));
+		}
+		return true;
+	}
+
 	// the environment variable ui5_task_copyright__file can be used to specify a file path for the copyright
 	if (process.env.ui5_task_copyright__file) {
 		copyright = process.env.ui5_task_copyright__file;
@@ -92,8 +112,13 @@ module.exports = async ({ log, workspace, options }) => {
 			scriptResources.map(async (resource) => {
 				const resourcePath = resource.getPath();
 
-				// check if the resource should be excluded
+				// check if the resource should be excluded (classic substring behavior)
 				if (excludePatterns && excludePatterns.some((pattern) => resourcePath.includes(pattern))) {
+					return;
+				}
+
+				// check if the resource should be excluded (glob-based includes/excludes)
+				if (!shouldProcessResource(resourcePath)) {
 					return;
 				}
 
@@ -142,8 +167,13 @@ module.exports = async ({ log, workspace, options }) => {
 			xmlResources.map(async (resource) => {
 				const resourcePath = resource.getPath();
 
-				// check if the resource should be excluded
+				// check if the resource should be excluded (classic substring behavior)
 				if (excludePatterns && excludePatterns.some((pattern) => resourcePath.includes(pattern))) {
+					return;
+				}
+
+				// check if the resource should be excluded (glob-based includes/excludes)
+				if (!shouldProcessResource(resourcePath)) {
 					return;
 				}
 

--- a/packages/ui5-task-copyright/package.json
+++ b/packages/ui5-task-copyright/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^8.60.0",
     "fast-xml-parser": "^5.8.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "minimatch": "^10.2.5"
   }
 }

--- a/packages/ui5-task-copyright/test/__assets__/ui5.globExcludes.yaml
+++ b/packages/ui5-task-copyright/test/__assets__/ui5.globExcludes.yaml
@@ -1,0 +1,28 @@
+specVersion: "3.0"
+metadata:
+  name: ui5.ecosystem.demo.tsapp
+type: application
+framework:
+  name: OpenUI5
+  version: "1.148.0"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.unified
+    - name: themelib_sap_horizon
+builder:
+  customTasks:
+    - name: ui5-tooling-transpile-task
+      afterTask: replaceVersion
+      configuration:
+        generateDts: true
+        generateTsInterfaces: true
+        omitTSFromBuildResult: false
+    - name: ui5-task-copyright
+      beforeTask: replaceCopyright
+      configuration:
+        copyright: "Copyright ${currentYear} UI5 Community
+          \nAll rights reserved."
+        excludes:
+          - "**/Main*"
+          - "**/Main.view.xml"

--- a/packages/ui5-task-copyright/test/copyright.test.js
+++ b/packages/ui5-task-copyright/test/copyright.test.js
@@ -37,6 +37,25 @@ function startsWithCopyright(file, copyrightString) {
 	return false;
 }
 
+test("Copyright with glob excludes", async (t) => {
+	const ui5 = { yaml: path.resolve("./test/__assets__/ui5.globExcludes.yaml") };
+	spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {
+		stdio: "inherit", // > don't include stdout in test output,
+		shell: true,
+		cwd: path.resolve(__dirname, "../../../showcases/ui5-tsapp"),
+	});
+
+	const copyright = `Copyright ${new Date().getFullYear()} UI5 Community\nAll rights reserved.`;
+	// files NOT matching the exclude globs are stamped
+	t.true(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "Component.js"), copyright));
+	t.true(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "controller/App.controller.js"), copyright));
+	t.true(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "view/App.view.xml"), copyright));
+	// files matching the exclude globs are skipped (no copyright header)
+	t.false(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "controller/Main.controller.js"), copyright));
+	t.false(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "controller/Main-dbg.controller.js"), copyright));
+	t.false(startsWithCopyright(path.resolve(t.context.tmpDir, "dist", "view/Main.view.xml"), copyright));
+});
+
 test("Inline copyright", async (t) => {
 	const ui5 = { yaml: path.resolve("./test/__assets__/ui5.inline.yaml") };
 	spawnSync(`ui5 build --config ${ui5.yaml} --dest ${t.context.tmpDir}/dist`, {

--- a/packages/ui5-task-minify-xml/README.md
+++ b/packages/ui5-task-minify-xml/README.md
@@ -26,7 +26,13 @@ npm install ui5-task-minify-xml --save-dev
   the file extensions to glob for. defaults to `xml`.
 
 - excludePatterns: `Array<String>` 
-  array of paths inside `$yourapp/` to exclude from the minification, e.g. 3-rd party libs in `lib/*`. defaults to an empty array `[]`.
+  array of paths inside `$yourapp/` to exclude from the minification, e.g. 3-rd party libs in `lib/*`. defaults to an empty array `[]`. Uses substring matching (classic behavior).
+
+- includes: `Array<String>`
+  array of glob patterns (matched via [minimatch](https://github.com/isaacs/minimatch)); when set, only resources matching at least one pattern are minified, e.g. `["**/view/**"]`. defaults to an empty array `[]`.
+
+- excludes: `Array<String>`
+  array of glob patterns (matched via [minimatch](https://github.com/isaacs/minimatch)); resources matching any pattern are excluded from the minification, e.g. `["**/thirdparty/**", "**/*.fragment.xml"]`. defaults to an empty array `[]`.
 
 ## Usage
 

--- a/packages/ui5-task-minify-xml/lib/minifyXml.js
+++ b/packages/ui5-task-minify-xml/lib/minifyXml.js
@@ -1,3 +1,5 @@
+const { minimatch } = require("minimatch");
+
 const defaultMinifyOptions = {
 	collapseWhitespaceInAttributeValues: true,
 };
@@ -13,10 +15,32 @@ const attrValueRegExp = /(?<=<\/?[^\s/>]+\b(?:\s+[^=\s>]+\s*=\s*(?:"[^"]*"|'[^']
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {object} [parameters.options.configuration] Task configuration if given in ui5.yaml
+ * @param {string[]} [parameters.options.configuration.excludePatterns] Substring patterns; matching resources are excluded from minification (classic behavior)
+ * @param {string[]} [parameters.options.configuration.includes] Glob patterns; when set, only resources matching at least one pattern are minified
+ * @param {string[]} [parameters.options.configuration.excludes] Glob patterns; resources matching any pattern are excluded from minification
  * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
  */
 module.exports = async ({ log, workspace, options }) => {
 	const config = options.configuration || {};
+
+	// glob-based include/exclude patterns (aligned with ui5-task-zipper); the classic
+	// substring-based `excludePatterns` is kept for backward compatibility
+	const includes = config.includes || [];
+	const excludes = config.excludes || [];
+
+	// determine whether a resource should be minified based on the include/exclude globs
+	// eslint-disable-next-line jsdoc/require-jsdoc
+	function shouldMinifyResource(resourcePath) {
+		// exclude wins: drop the resource if it matches any exclude glob
+		if (excludes.some((glob) => minimatch(resourcePath, glob))) {
+			return false;
+		}
+		// when includes are given, only keep resources matching at least one include glob
+		if (includes.length > 0) {
+			return includes.some((glob) => minimatch(resourcePath, glob));
+		}
+		return true;
+	}
 
 	const fileExtensions = Array.isArray(config.fileExtensions) ? config.fileExtensions : [config.fileExtensions || "xml"];
 	const xmlResources = await workspace.byGlob(`**/*.+(${fileExtensions.join("|")})`);
@@ -25,8 +49,13 @@ module.exports = async ({ log, workspace, options }) => {
 
 	await Promise.all(
 		xmlResources.map(async (resource) => {
-			// check if the resource should be excluded from minification
+			// check if the resource should be excluded from minification (classic substring behavior)
 			if (config.excludePatterns && config.excludePatterns.some((pattern) => resource.getPath().includes(pattern))) {
+				return;
+			}
+
+			// check if the resource should be excluded from minification (glob-based includes/excludes)
+			if (!shouldMinifyResource(resource.getPath())) {
 				return;
 			}
 

--- a/packages/ui5-task-minify-xml/package.json
+++ b/packages/ui5-task-minify-xml/package.json
@@ -11,9 +11,22 @@
     "directory": "packages/ui5-task-minify-xml"
   },
   "scripts": {
-    "lint": "eslint lib"
+    "lint": "eslint lib",
+    "test": "ava"
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.js"
+    ],
+    "verbose": true,
+    "timeout": "5m"
+  },
+  "devDependencies": {
+    "@ui5/cli": "^3",
+    "ava": "^8.0.1"
   },
   "dependencies": {
-    "minify-xml": "^4.5.2"
+    "minify-xml": "^4.5.2",
+    "minimatch": "^10.2.5"
   }
 }

--- a/packages/ui5-task-minify-xml/test/minifyXml.test.js
+++ b/packages/ui5-task-minify-xml/test/minifyXml.test.js
@@ -1,0 +1,62 @@
+const { default: test } = require("ava");
+
+const minifyXml = require("../lib/minifyXml");
+
+// minimal in-memory resource + workspace mocks mirroring the @ui5/fs API surface used by the task
+// eslint-disable-next-line jsdoc/require-jsdoc
+function createResource(pathName, content) {
+	let str = content;
+	return {
+		getPath: () => pathName,
+		getString: async () => str,
+		setString: (value) => {
+			str = value;
+		},
+		// test helper
+		_get: () => str,
+	};
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function createWorkspace(resources) {
+	return {
+		byGlob: async () => resources,
+		write: async () => {},
+	};
+}
+
+const log = { info() {}, verbose() {}, warn() {}, error() {} };
+
+const UNMINIFIED = `<mvc:View xmlns:mvc="sap.ui.core.mvc">\n\n    <Text   text="hello" />\n\n</mvc:View>`;
+
+test("minifies all XML resources by default", async (t) => {
+	const a = createResource("/resources/app/view/App.view.xml", UNMINIFIED);
+	const b = createResource("/resources/app/view/Main.view.xml", UNMINIFIED);
+	await minifyXml({ log, workspace: createWorkspace([a, b]), options: { configuration: {} } });
+	t.not(a._get(), UNMINIFIED, "App.view.xml should be minified");
+	t.not(b._get(), UNMINIFIED, "Main.view.xml should be minified");
+});
+
+test("excludes via glob excludes patterns", async (t) => {
+	const a = createResource("/resources/app/view/App.view.xml", UNMINIFIED);
+	const b = createResource("/resources/app/view/Main.view.xml", UNMINIFIED);
+	await minifyXml({ log, workspace: createWorkspace([a, b]), options: { configuration: { excludes: ["**/Main.view.xml"] } } });
+	t.not(a._get(), UNMINIFIED, "App.view.xml should be minified");
+	t.is(b._get(), UNMINIFIED, "Main.view.xml should be excluded (unchanged)");
+});
+
+test("restricts to allow-list via glob includes patterns", async (t) => {
+	const a = createResource("/resources/app/view/App.view.xml", UNMINIFIED);
+	const b = createResource("/resources/app/view/Main.view.xml", UNMINIFIED);
+	await minifyXml({ log, workspace: createWorkspace([a, b]), options: { configuration: { includes: ["**/App.view.xml"] } } });
+	t.not(a._get(), UNMINIFIED, "App.view.xml should be minified (included)");
+	t.is(b._get(), UNMINIFIED, "Main.view.xml should be skipped (not in includes)");
+});
+
+test("classic excludePatterns substring behavior is preserved", async (t) => {
+	const a = createResource("/resources/app/view/App.view.xml", UNMINIFIED);
+	const b = createResource("/resources/app/view/Main.view.xml", UNMINIFIED);
+	await minifyXml({ log, workspace: createWorkspace([a, b]), options: { configuration: { excludePatterns: ["Main.view.xml"] } } });
+	t.not(a._get(), UNMINIFIED, "App.view.xml should be minified");
+	t.is(b._get(), UNMINIFIED, "Main.view.xml should be excluded via substring");
+});

--- a/packages/ui5-tooling-transpile/README.md
+++ b/packages/ui5-tooling-transpile/README.md
@@ -36,10 +36,13 @@ npm install ui5-tooling-transpile --save-dev -rte
   path to the babel config file or object to use as configuration for babel instead of the babel configuration from the file system (as described at [Babel config files](https://babeljs.io/docs/en/config-files)), or the default configuration defined in this middleware (just using the `@babel/preset-env`)
 
 - includes: `String<Array>` (old alias: includePatterns)
-  array of paths your application to include in transpilation, e.g. `/modern-stuff/`
+  array of paths your application to include in transpilation, e.g. `/modern-stuff/`. By default matched as substrings; set `useGlobPatterns: true` to match them as glob patterns.
 
 - excludes: `String<Array>` (old alias: excludePatterns)
-  array of paths your application to exclude from transpilation, e.g. 3-rd party libs in `/lib/`
+  array of paths your application to exclude from transpilation, e.g. 3-rd party libs in `/lib/`. By default matched as substrings; set `useGlobPatterns: true` to match them as glob patterns.
+
+- useGlobPatterns: `boolean` (defaults to `false`)
+  when enabled, `includes`/`excludes` (and their `includePatterns`/`excludePatterns` aliases) are matched as glob patterns via [minimatch](https://github.com/isaacs/minimatch) instead of the classic substring matching — aligning the syntax with other UI5 tooling extensions (e.g. `ui5-task-zipper`). With this enabled, patterns must be written as globs, e.g. `**/thirdparty/**` or `**/*.png` (the built-in default excludes for images are globbed automatically). Kept `false` by default to preserve backward compatibility with existing substring configurations.
 
 - filePattern: `String`
   source file pattern for the resources to transpile, defaults to `.js` and will be changed to `.ts` if a `tsconfig.json` file is located in the project or by explicitly setting the configuration option transformTypeScript to `true` (multiple file extensions can be handled by specifying mutliple extensions using the glob syntax, e.g.: `.+(js|jsx)` or `.+(ts|tsx)`)

--- a/packages/ui5-tooling-transpile/lib/middleware.js
+++ b/packages/ui5-tooling-transpile/lib/middleware.js
@@ -103,7 +103,7 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 					const resourcePath = resource.getPath();
 					return (
 						!resourcePath.endsWith(".d.ts") &&
-						shouldHandlePath(resourcePath, config.excludes, config.includes)
+						shouldHandlePath(resourcePath, config.excludes, config.includes, config.useGlobPatterns)
 					);
 				})
 				.map((resource) => {
@@ -147,7 +147,10 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 
 	return async (req, res, next) => {
 		const pathname = req.url?.match("^[^?]*")[0];
-		if (pathname.endsWith(".js") && shouldHandlePath(pathname, config.excludes, config.includes)) {
+		if (
+			pathname.endsWith(".js") &&
+			shouldHandlePath(pathname, config.excludes, config.includes, config.useGlobPatterns)
+		) {
 			const pathWithFilePattern = pathname.replace(".js", config.filePattern);
 			config.debug && log.verbose(`Lookup resource ${pathWithFilePattern}`);
 

--- a/packages/ui5-tooling-transpile/lib/task.js
+++ b/packages/ui5-tooling-transpile/lib/task.js
@@ -26,7 +26,8 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 		createBabelConfig,
 		normalizeLineFeeds,
 		determineResourceFSPath,
-		transformAsync
+		transformAsync,
+		shouldHandlePath
 	} = require("./util")(log);
 	const { OmitFromBuildResult } = taskUtil.STANDARD_TAGS;
 
@@ -112,10 +113,7 @@ module.exports = async function ({ log, workspace /*, dependencies*/, taskUtil, 
 			const resourcePath = resource.getPath();
 
 			// Ignore files that match the excludePatterns configuration
-			if (
-				!config.excludes.some((pattern) => resourcePath.includes(pattern)) ||
-				config.includes.some((pattern) => resourcePath.includes(pattern))
-			) {
+			if (shouldHandlePath(resourcePath, config.excludes, config.includes, config.useGlobPatterns)) {
 				const filePath = resourcePath.replace(new RegExp("\\.[^.]+$"), ".js");
 
 				// read source file

--- a/packages/ui5-tooling-transpile/lib/util.js
+++ b/packages/ui5-tooling-transpile/lib/util.js
@@ -2,6 +2,8 @@ const os = require("os");
 const path = require("path");
 const fs = require("fs");
 
+const { minimatch } = require("minimatch");
+
 // https://babeljs.io/docs/
 const babel = require("@babel/core");
 
@@ -322,9 +324,14 @@ module.exports = function (log) {
 				}
 			}
 
+			// derive whether the includes/excludes should be matched via glob (minimatch)
+			// instead of the classic substring matching (opt-in to stay backward compatible)
+			const useGlobPatterns = config.useGlobPatterns ?? false;
+
 			// derive the includes/excludes from the configuration
 			const includes = config.includes || config.includePatterns || [];
-			const defaultExcludes = [".png", ".jpeg", ".jpg"]; // still needed?
+			// the built-in default excludes must be expressed as globs when glob matching is enabled
+			const defaultExcludes = useGlobPatterns ? ["**/*.png", "**/*.jpeg", "**/*.jpg"] : [".png", ".jpeg", ".jpg"];
 			const excludes = defaultExcludes.concat(config.excludes || config.excludePatterns || []);
 
 			// derive whether JSX/TSX should be transformed or not
@@ -351,6 +358,7 @@ module.exports = function (log) {
 				generateBabelConfig: config.generateBabelConfig,
 				includes,
 				excludes,
+				useGlobPatterns,
 				filePattern,
 				omitTSFromBuildResult: config.omitTSFromBuildResult,
 				omitSourceMaps: config.omitSourceMaps,
@@ -652,13 +660,17 @@ module.exports = function (log) {
 		 * @param {string} pathname the path name
 		 * @param {Array<string>} excludes exclude paths
 		 * @param {Array<string>} includes include paths
+		 * @param {boolean} [useGlob] match patterns via glob (minimatch) instead of substring
 		 * @returns {boolean} true, if the path should be handled
 		 */
-		shouldHandlePath: function shouldHandlePath(pathname, excludes = [], includes = []) {
-			return (
-				!(excludes || []).some((pattern) => pathname.includes(pattern)) ||
-				(includes || []).some((pattern) => pathname.includes(pattern))
-			);
+		shouldHandlePath: function shouldHandlePath(pathname, excludes = [], includes = [], useGlob = false) {
+			// when glob matching is enabled, patterns are matched via minimatch; otherwise the
+			// classic substring matching is used (default, backward compatible)
+			const matches = (patterns) =>
+				(patterns || []).some((pattern) =>
+					useGlob ? minimatch(pathname, pattern) : pathname.includes(pattern)
+				);
+			return !matches(excludes) || matches(includes);
 		},
 
 		/**

--- a/packages/ui5-tooling-transpile/package.json
+++ b/packages/ui5-tooling-transpile/package.json
@@ -19,7 +19,8 @@
     "babel-preset-transform-ui5": "^7.9.0",
     "browserslist": "^4.28.2",
     "comment-json": "^5.0.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "minimatch": "^10.2.5"
   },
   "devDependencies": {
     "ava": "^8.0.1"

--- a/packages/ui5-tooling-transpile/test/util.test.js
+++ b/packages/ui5-tooling-transpile/test/util.test.js
@@ -283,3 +283,39 @@ test("generate babel config file with a name", async (t) => {
 	t.deepEqual(config.presets[2].file.request, "@babel/preset-typescript");
 	fs.rmSync(tmpDir, { recursive: true });
 });
+
+test("shouldHandlePath: classic substring matching (default)", (t) => {
+	const { shouldHandlePath } = t.context.util;
+	// excluded by substring
+	t.false(shouldHandlePath("/my/app/thirdparty/foo.js", ["/thirdparty/"], []));
+	// not excluded
+	t.true(shouldHandlePath("/my/app/foo.js", ["/thirdparty/"], []));
+	// includes override an exclude (existing OR semantics)
+	t.true(shouldHandlePath("/my/app/thirdparty/keep.js", ["/thirdparty/"], ["keep"]));
+	// glob-style pattern is treated literally as a substring (does NOT match) -> path is handled
+	t.true(shouldHandlePath("/my/app/thirdparty/foo.js", ["**/thirdparty/**"], []));
+});
+
+test("shouldHandlePath: glob matching when useGlobPatterns is enabled", (t) => {
+	const { shouldHandlePath } = t.context.util;
+	// a substring pattern no longer matches as a glob -> path is handled
+	t.true(shouldHandlePath("/my/app/thirdparty/foo.js", ["/thirdparty/"], [], true));
+	// a proper glob excludes the path
+	t.false(shouldHandlePath("/my/app/thirdparty/foo.js", ["**/thirdparty/**"], [], true));
+	// includes glob overrides an exclude glob (existing OR semantics)
+	t.true(shouldHandlePath("/my/app/thirdparty/keep.js", ["**/thirdparty/**"], ["**/keep.js"], true));
+	// non-matching exclude glob -> path is handled
+	t.true(shouldHandlePath("/my/app/foo.js", ["**/thirdparty/**"], [], true));
+});
+
+test("createConfiguration: useGlobPatterns default false, globbed default excludes when enabled", async (t) => {
+	const { createConfiguration } = t.context.util;
+	// default: substring-style default excludes, flag false
+	const classic = await createConfiguration({ configuration: {} });
+	t.false(classic.useGlobPatterns);
+	t.deepEqual(classic.excludes, [".png", ".jpeg", ".jpg"]);
+	// with the flag: default excludes are expressed as globs
+	const glob = await createConfiguration({ configuration: { useGlobPatterns: true } });
+	t.true(glob.useGlobPatterns);
+	t.deepEqual(glob.excludes, ["**/*.png", "**/*.jpeg", "**/*.jpg"]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
     devDependencies:
       '@ui5/cli':
         specifier: ^3
@@ -460,6 +463,16 @@ importers:
       minify-xml:
         specifier: ^4.5.2
         version: 4.5.2
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
+    devDependencies:
+      '@ui5/cli':
+        specifier: ^3
+        version: 3.11.13
+      ava:
+        specifier: ^8.0.1
+        version: 8.0.1(encoding@0.1.13)(rollup@4.60.4)
 
   packages/ui5-task-pwa-enabler:
     dependencies:
@@ -630,6 +643,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
     devDependencies:
       ava:
         specifier: ^8.0.1
@@ -4013,6 +4029,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xn-sakina/rml-darwin-arm64@2.8.0':
     resolution: {integrity: sha512-B8XpWn/t3vALCePi8DnbHQWVQnmKybwPIKbfzL1L75w2V/ELXn0OguFayujf2eZdmCIBPC+Drqxztn6fDV08Ww==}
@@ -7619,10 +7636,6 @@ packages:
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
-  minimatch@7.4.9:
-    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.9:
@@ -17625,7 +17638,7 @@ snapshots:
       lodash: 4.18.1
       log4js: 6.9.1
       mime: 2.6.0
-      minimatch: 7.4.9
+      minimatch: 10.2.5
       mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
@@ -18042,10 +18055,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
-  minimatch@7.4.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -18405,7 +18414,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 6.0.6
       memorystream: 0.3.1
-      minimatch: 7.4.9
+      minimatch: 10.2.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   chromedriver: '>=115'
   minimatch@<3.1.4: '>=3.1.4'
+  karma>minimatch: 7.4.9
   qs@<6.14.1: '>=6.14.1'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
   tmp@>=0.2.0 <0.2.6: '>=0.2.6'
@@ -7636,6 +7637,10 @@ packages:
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@7.4.9:
+    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.9:
@@ -17638,7 +17643,7 @@ snapshots:
       lodash: 4.18.1
       log4js: 6.9.1
       mime: 2.6.0
-      minimatch: 10.2.5
+      minimatch: 7.4.9
       mkdirp: 0.5.6
       qjobs: 1.2.0
       range-parser: 1.2.1
@@ -18052,6 +18057,10 @@ snapshots:
       brace-expansion: 5.0.6
 
   minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimatch@7.4.9:
     dependencies:
       brace-expansion: 2.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,12 @@ overrides:
   # NOT overridden here: the cross-major bump would force-upgrade
   # transitive consumers and is more likely to break than to fix.
   "minimatch@<3.1.4": ">=3.1.4"
+  # karma@6.4.4 calls minimatch as a directly-callable function (mm(path, pattern)
+  # in lib/file-list.js). That callable default export only exists up to minimatch
+  # v7; v9+ moved it to the named `minimatch` export, so deduping karma onto a v9/v10
+  # copy breaks the showcase karma tests with "TypeError: mm is not a function".
+  # Pin karma's transitive minimatch to the last callable line.
+  "karma>minimatch": "7.4.9"
   "qs@<6.14.1": ">=6.14.1"
   "ws@>=8.0.0 <8.20.1": ">=8.20.1"
   "tmp@>=0.2.0 <0.2.6": ">=0.2.6"


### PR DESCRIPTION
## Summary

Follow-up to #1429 (which gave `ui5-task-zipper` glob-based `includes`/`excludes`). This PR aligns the other file/path-filtering tasks and middlewares on the same convention — **`includes`/`excludes` matched via [`minimatch`](https://github.com/isaacs/minimatch)** (exclude-wins, then include-if-any) — **without breaking any existing configuration**.

The guiding rule: **new `includes`/`excludes` options use glob**; the **existing `includePatterns`/`excludePatterns` options keep their classic behavior**. The option name selects the semantics, so no config silently changes meaning.

## Changes per package

| Package | What changed | Backward compat |
|---|---|---|
| **ui5-task-minify-xml** | New glob `includes`/`excludes` | `excludePatterns` keeps substring matching. Adds an ava test harness (had none). |
| **ui5-task-copyright** | New glob `includes`/`excludes`, applied to both the JS/TS and XML processing paths | `excludePatterns` keeps substring matching |
| **ui5-middleware-simpleproxy** | New `excludes` (glob alias of `excludePatterns`) + new glob `includes` | `excludePatterns` unchanged (was already glob) |
| **ui5-tooling-transpile** | New `useGlobPatterns` flag (default `false`) | see below |

### ui5-tooling-transpile — why a flag?

`ui5-tooling-transpile` is the one package that *already* ships `includes`/`excludes` as its primary option names, but matched by **substring**. Switching them to glob outright would silently break existing configs (e.g. `excludes: ["/thirdparty/"]`). So the new glob behavior is opt-in via **`useGlobPatterns: true`**, which switches `includes`/`excludes` (and the `includePatterns`/`excludePatterns` aliases) from substring to glob matching. The built-in image default excludes (`.png`/`.jpeg`/`.jpg`) are expressed as globs under the flag. Default stays substring — existing configs are byte-for-byte unaffected.

## Explicitly out of scope (left untouched)

Per discussion, options that are not path include/exclude filters were **not** changed: `additionalDependencies`, `entryPoints`, `skipTransform`, `includeAssets` (ui5-tooling-modules), `files` (ui5-tooling-stringreplace), `exclusions` (ui5-middleware-livereload / -hmr, regex-based), `excludeFromMove` (ui5-task-cachebuster).

## Tests

- **minify-xml**: new ava suite (unit, mock workspace) — default minify, glob `excludes`, glob `includes` allow-list, and classic `excludePatterns` substring still works. ✅ 4/4
- **copyright**: new `ui5.globExcludes.yaml` fixture + integration test (spawns `ui5 build`) asserting glob-excluded files are skipped while others are stamped. ✅ full suite 10/10
- **simpleproxy**: new mount + test asserting `excludes`/`includes` globs filter proxied paths. ✅ full suite 13/13
- **transpile**: unit tests for `shouldHandlePath` in both modes + `createConfiguration` default-excludes globbing under the flag. ✅ full suite 11/11
- Lint clean (0 errors) across all four packages.

A changeset is included per touched package (all `minor`, additive).