### PR TITLE
fix(ui5-tooling-modules): harden build task/middleware against concurrency

### DIFF
--- a/.changeset/harden-concurrency.md
+++ b/.changeset/harden-concurrency.md
@@ -1,0 +1,16 @@
+---
+"ui5-tooling-modules": patch
+---
+
+fix(ui5-tooling-modules): harden build task/middleware against concurrency
+
+Hardens the build task and dev-server middleware against async interleaving and shared process-global state across overlapping builds:
+
+- Serialize rollup builds process-wide via a build lock so the global `WebComponentRegistry` can no longer be clobbered by an overlapping `buildStart`.
+- Force-rebuild and await when the middleware receives a request for a not-yet-bundled module, so it is served instead of falling through to a 404.
+- Deduplicate concurrent `getBundleInfo` misses on the same cache key via an in-flight promise map.
+- Make `BundleInfoCache` writes atomic (temp file + rename), awaited/flushable, and defensive on read.
+- Track and flush `DTSSerializer` `.gen.d.ts` writes with error logging so builds no longer report success while writes are pending or silently failing.
+- Replace destructive `deactivate()` on the serializer singletons with a reversible `setEnabled` flag reset per registration, so generation settings no longer leak across projects in the same process.
+
+Observable happy-path output is unchanged (bundles and generated `.d.ts` are byte-identical).

--- a/packages/ui5-tooling-modules/lib/middleware.js
+++ b/packages/ui5-tooling-modules/lib/middleware.js
@@ -335,16 +335,20 @@ module.exports = async function ({ log, resources, options, middlewareUtil }) {
 				resource = getResource(moduleName, { cwd, depPaths, isMiddleware: true });
 			}
 
+			// detect a genuinely new module *before* bundleAndWatch adds it to
+			// requestedModules, so we can force a rebuild that includes it
+			const isNewModule = moduleName && !requestedModules.has(moduleName);
 			let bundleInfo = whenBundled && (await whenBundled);
 
 			// if a resource has been found in node_modules, we will
 			// trigger the bundling process and watch the bundled resources
 			if (!bundleInfo?.getEntry(moduleName) && (resource || existsPackage)) {
-				bundleAndWatch({ moduleName });
+				// force a rebuild only when the module is new (avoids thrash on repeat
+				// requests); concurrent forced rebuilds are serialized by the build lock
+				await bundleAndWatch({ moduleName, force: isNewModule });
+				// if the resource is a bundled resource, we need to wait for it
+				bundleInfo = whenBundled && (await whenBundled);
 			}
-
-			// if the resource is a bundled resource, we need to wait for it
-			bundleInfo = whenBundled && (await whenBundled);
 			if (bundleInfo?.error) {
 				log.error(bundleInfo.error);
 			}

--- a/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
+++ b/packages/ui5-tooling-modules/lib/rollup-plugin-webcomponents.js
@@ -48,6 +48,7 @@ const { createHash } = require("crypto");
 
 const WebComponentRegistry = require("./utils/WebComponentRegistry");
 const JSDocSerializer = require("./utils/JSDocSerializer");
+const DTSSerializer = require("./utils/DTSSerializer");
 const WebComponentRegistryHelper = require("./utils/WebComponentRegistryHelper");
 const { UI5_ELEMENT_NAMESPACE } = WebComponentRegistryHelper;
 
@@ -699,7 +700,7 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 			return null;
 		},
 
-		generateBundle(options, bundle) {
+		async generateBundle(options, bundle) {
 			if (skip) {
 				return;
 			}
@@ -744,6 +745,11 @@ module.exports = function ({ log, resolveModule, projectInfo, getPackageJson, op
 					}
 				}
 			}
+
+			// ensure all fire-and-forget *.gen.d.ts writes triggered during this
+			// build have settled (or surfaced their errors) before the build
+			// reports success
+			await DTSSerializer.flush();
 		},
 	};
 };

--- a/packages/ui5-tooling-modules/lib/task.js
+++ b/packages/ui5-tooling-modules/lib/task.js
@@ -62,7 +62,7 @@ module.exports = async function ({ log, workspace, taskUtil, options }) {
 	};
 
 	// utility to scan the project for dependencies and resources
-	const { scan, getBundleInfo, getResource, existsResource } = require("./util")(log, projectInfo);
+	const { scan, getBundleInfo, getResource, existsResource, flushBundleInfoCache } = require("./util")(log, projectInfo);
 
 	// determine all paths for the dependencies
 	const depPaths = taskUtil
@@ -550,7 +550,7 @@ module.exports = async function ({ log, workspace, taskUtil, options }) {
 		const resComponent = await workspace.byPath(`/resources/${options.projectNamespace}/Component.js`);
 		if (resComponent) {
 			let pathMappings = "";
-			bundleInfo.getBundledResources().map(async ({ name }) => {
+			bundleInfo.getBundledResources().forEach(({ name }) => {
 				pathMappings += `"${name}": sap.ui.require.toUrl("${options.projectNamespace}/resources/${name}"),`;
 			});
 			let content = await resComponent.getString();
@@ -561,6 +561,10 @@ ${content}`;
 			await workspace.write(resComponent);
 		}
 	}
+
+	// ensure the persistent bundle-info cache is durable on disk before the
+	// task resolves (writes are otherwise fire-and-forget)
+	await flushBundleInfoCache();
 };
 
 /**

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 const path = require("path");
 const { readFileSync, statSync, readdirSync, existsSync, realpathSync } = require("fs");
-const { readFile, stat, writeFile, mkdir } = require("fs").promises;
+const { readFile, stat, writeFile, mkdir, rename } = require("fs").promises;
 
 const rollup = require("rollup");
 const instructions = require("./rollup-plugin-instructions");
@@ -28,6 +28,37 @@ const parseJS = require("./utils/parseJS");
 
 const { createHash } = require("crypto");
 const sanitize = require("sanitize-filename");
+
+// ============================================================================
+// Build serialization — the web-components registry and the serializer
+// singletons are process-global and are reset at each rollup `buildStart`.
+// To prevent overlapping builds from clobbering each other's shared state
+// (e.g. a second build's `buildStart` wiping the registry a first build is
+// mid-populating), all rollup builds run strictly one at a time through a
+// chained-promise lock.
+// ============================================================================
+
+let _buildChain = Promise.resolve();
+/**
+ * Runs the given async function once the previous build has settled, so that
+ * no two rollup builds ever overlap in this process.
+ * @param {Function} fn async function performing the build
+ * @returns {Promise} the result of fn
+ */
+function withBuildLock(fn) {
+	// run after the previous build settles (whether it resolved or rejected)
+	const run = _buildChain.then(fn, fn);
+	// keep the chain alive even if this build rejects
+	_buildChain = run.then(
+		() => {},
+		() => {},
+	);
+	return run;
+}
+
+// in-flight bundle builds keyed by cacheKey, so concurrent callers requesting
+// the same bundle share a single build instead of running it redundantly
+const _inFlightBuilds = new Map();
 
 // ============================================================================
 // Cache invalidation helpers — sha256 layered fingerprint (Option A)
@@ -422,6 +453,11 @@ function findPackageJson(modulePath) {
  */
 class BundleInfoCache {
 	static #bundleInfoCache = {};
+	// pending persistent-cache writes, so callers (e.g. the build task) can
+	// await them before the process exits and the cache would be lost
+	static #pending = new Set();
+	// monotonic counter to build unique temp file names for atomic writes
+	static #writeCounter = 0;
 	static #cachePath(key) {
 		return path.join(process.cwd(), ".ui5-tooling-modules", `${key}.bundleinfo.json`);
 	}
@@ -431,7 +467,15 @@ class BundleInfoCache {
 		} else if (persist) {
 			const bundleInfoPath = this.#cachePath(key);
 			if (existsSync(bundleInfoPath)) {
-				const loaded = new BundleInfo().fromJSON(readFileSync(bundleInfoPath, { encoding: "utf8" }));
+				let loaded;
+				try {
+					loaded = new BundleInfo().fromJSON(readFileSync(bundleInfoPath, { encoding: "utf8" }));
+				} catch (err) {
+					// a corrupt / half-written cache file must never break the build:
+					// treat it as a cache miss so the bundle is rebuilt
+					console.error(`Failed to read bundle info from ${bundleInfoPath}! Rebuilding...`, err);
+					return undefined;
+				}
 				// Re-stat the recorded transitive module graph as a confirmation step.
 				// On fresh checkouts (e.g. CI / `git checkout`) entry-only mtime checks
 				// can produce a false positive; this validates the full graph.
@@ -454,14 +498,31 @@ class BundleInfoCache {
 			// cache load can verify the recorded graph still matches disk state.
 			bundleInfo.setInputFingerprint(getInputGraphFingerprint(bundleInfo.getRelatedPaths()));
 			const bundleInfoPath = this.#cachePath(key);
-			mkdir(path.dirname(bundleInfoPath), { recursive: true })
+			// write to a temp file and rename it into place so concurrent readers
+			// never observe a half-written file (rename is atomic on the same fs)
+			const tmpPath = `${bundleInfoPath}.${process.pid}.${this.#writeCounter++}.tmp`;
+			const write = mkdir(path.dirname(bundleInfoPath), { recursive: true })
 				.then(() => {
-					return writeFile(bundleInfoPath, JSON.stringify(bundleInfo, null, 2), { encoding: "utf8" });
+					return writeFile(tmpPath, JSON.stringify(bundleInfo, null, 2), { encoding: "utf8" });
+				})
+				.then(() => {
+					return rename(tmpPath, bundleInfoPath);
 				})
 				.catch((err) => {
 					console.error(`Failed to store bundle info in ${bundleInfoPath} on disk! Using in-memory cache only!`, err);
 				});
+			this.#pending.add(write);
+			write.finally(() => this.#pending.delete(write));
 		}
+	}
+	/**
+	 * Awaits all outstanding persistent-cache writes. Call this before the
+	 * process exits (e.g. at the end of the build task) so the on-disk cache
+	 * is durable.
+	 * @returns {Promise} resolves once all pending writes have settled
+	 */
+	static async flushPending() {
+		await Promise.all(Array.from(this.#pending));
 	}
 }
 
@@ -1279,76 +1340,80 @@ module.exports = function (log, projectInfo) {
 		 * @returns {rollup.RollupOutput} the build output of rollup
 		 */
 		createBundle: async function createBundle(moduleNames, { cwd = process.cwd(), depPaths = [], beforePlugins, afterPlugins, pluginOptions, generatedCode, sourcemap, inject } = {}) {
-			const { walk } = await import("estree-walker");
-			const $metadata = {};
-			const bundle = await rollup.rollup({
-				input: moduleNames,
-				//context: "exports" /* this is normally converted to undefined, but should be exports in our case! */,
-				context: "this",
-				plugins: [
-					...(beforePlugins || []),
-					replace({
-						preventAssignment: false,
-						delimiters: ["\\b", "\\b"],
-						values: {
-							"global.process.versions.node": JSON.stringify("false"), // in some cases, the global.process.versions.node is used to detect the existence of Node.js
-							"process.versions.node": JSON.stringify("18.15.0"), // needed for some modules to select features based on the Node.js version
-							"process.env.NODE_ENV": JSON.stringify("production"), // we always build in production mode
-							"root.JS_MD5_NO_NODE_JS": JSON.stringify(true), // pdfMake decides upon this property whether it's Node.js runtimg or not
-						},
-					}),
-					injectESModule(),
-					skipAssets({
-						log,
-						extensions: ["css"],
-					}),
-					json(),
-					instructions(),
-					// Replace `node-fetch` / `cross-fetch` / `isomorphic-fetch`
-					// with a tiny shim that re-exports the browser's native
-					// Web Fetch API. This must happen BEFORE commonjs/polyfill
-					// resolution so the Node-only sub-graph (fetch-blob,
-					// fs.promises, node:net, ...) never gets pulled into the
-					// bundle in the first place.
-					fetchShim({ log }),
-					commonjs({
-						defaultIsModuleExports: "preferred",
-					}),
-					// node polyfills/resolution must happen after
-					// commonjs and amd to ensure e.g. exports is
-					// properly handled by those plugins
-					nodePolyfillsOverride({
-						log,
-						cwd,
-						moduleNames,
-					}),
-					// handle the webcomponents
-					webcomponents({
-						log,
-						resolveModule: function (moduleName) {
-							return that.resolveModule(moduleName, { cwd, depPaths });
-						},
-						projectInfo,
-						getPackageJson, // use the cached package.json if possible
-						options: pluginOptions?.["webcomponents"],
-						$metadata,
-					}),
-					// once the node polyfills are injected, we can
-					// resolve the modules from node_modules
-					resolveModulePlugin({
-						resolveModule: function (moduleName) {
-							return that.resolveModule(moduleName, { cwd, depPaths });
-						},
-					}),
-					// handle the import.meta usages (e.g. geomap loading maplibre)
-					importMeta(),
-					// the following plugins must be executed after the
-					// node polyfills are injected and the modules are resolved
-					// to ensure that the modules are properly transformed
-					nodePolyfills(),
-					nodePolyfillsOverride.inject(inject),
-					transformTopLevelThis({ log, walk }),
-					/*
+			// serialize all rollup builds in this process: the web-components
+			// registry and serializer singletons are global and reset at
+			// `buildStart`, so overlapping builds would clobber each other.
+			return withBuildLock(async () => {
+				const { walk } = await import("estree-walker");
+				const $metadata = {};
+				const bundle = await rollup.rollup({
+					input: moduleNames,
+					//context: "exports" /* this is normally converted to undefined, but should be exports in our case! */,
+					context: "this",
+					plugins: [
+						...(beforePlugins || []),
+						replace({
+							preventAssignment: false,
+							delimiters: ["\\b", "\\b"],
+							values: {
+								"global.process.versions.node": JSON.stringify("false"), // in some cases, the global.process.versions.node is used to detect the existence of Node.js
+								"process.versions.node": JSON.stringify("18.15.0"), // needed for some modules to select features based on the Node.js version
+								"process.env.NODE_ENV": JSON.stringify("production"), // we always build in production mode
+								"root.JS_MD5_NO_NODE_JS": JSON.stringify(true), // pdfMake decides upon this property whether it's Node.js runtimg or not
+							},
+						}),
+						injectESModule(),
+						skipAssets({
+							log,
+							extensions: ["css"],
+						}),
+						json(),
+						instructions(),
+						// Replace `node-fetch` / `cross-fetch` / `isomorphic-fetch`
+						// with a tiny shim that re-exports the browser's native
+						// Web Fetch API. This must happen BEFORE commonjs/polyfill
+						// resolution so the Node-only sub-graph (fetch-blob,
+						// fs.promises, node:net, ...) never gets pulled into the
+						// bundle in the first place.
+						fetchShim({ log }),
+						commonjs({
+							defaultIsModuleExports: "preferred",
+						}),
+						// node polyfills/resolution must happen after
+						// commonjs and amd to ensure e.g. exports is
+						// properly handled by those plugins
+						nodePolyfillsOverride({
+							log,
+							cwd,
+							moduleNames,
+						}),
+						// handle the webcomponents
+						webcomponents({
+							log,
+							resolveModule: function (moduleName) {
+								return that.resolveModule(moduleName, { cwd, depPaths });
+							},
+							projectInfo,
+							getPackageJson, // use the cached package.json if possible
+							options: pluginOptions?.["webcomponents"],
+							$metadata,
+						}),
+						// once the node polyfills are injected, we can
+						// resolve the modules from node_modules
+						resolveModulePlugin({
+							resolveModule: function (moduleName) {
+								return that.resolveModule(moduleName, { cwd, depPaths });
+							},
+						}),
+						// handle the import.meta usages (e.g. geomap loading maplibre)
+						importMeta(),
+						// the following plugins must be executed after the
+						// node polyfills are injected and the modules are resolved
+						// to ensure that the modules are properly transformed
+						nodePolyfills(),
+						nodePolyfillsOverride.inject(inject),
+						transformTopLevelThis({ log, walk }),
+						/*
 					{
 						name: 'moduleParsedHook',
 						moduleParsed({id, meta}) {
@@ -1359,60 +1424,61 @@ module.exports = function (log, projectInfo) {
 						}
 					},
 					*/
-					...(afterPlugins || []),
-				],
-				onwarn: function ({ loc, frame, code, message }) {
-					// Skip certain warnings
-					const skipWarnings = ["THIS_IS_UNDEFINED", "CIRCULAR_DEPENDENCY", "MIXED_EXPORTS", "MODULE_LEVEL_DIRECTIVE"];
-					if (skipWarnings.indexOf(code) !== -1) {
-						return;
-					}
-					// console.warn everything else
-					if (loc) {
-						log.warn(`${loc.file} (${loc.line}:${loc.column}) ${message}`);
-						if (frame) log.warn(frame);
-					} else {
-						log.warn(`${message} [${code}]`);
-					}
-				},
-			});
-
-			// generate output specific code in-memory
-			// you can call this function multiple times on the same bundle object
-			const { output } = await bundle.generate({
-				format: "amd",
-				amd: {
-					define: "sap.ui.define",
-				},
-				intro: (s) => {
-					// FIX: if the module contains "exports.default" we need to
-					// add the exports variable to the bundle to ensure that
-					// the module can be used in the UI5 context
-					// (this happens e.g. when using the WebC Button solely)
-					let hasExportsDefault = false;
-					Object.values(s.modules || {}).forEach((m) => {
-						if (/\sexports.default/g.test(m.code)) {
-							hasExportsDefault = true;
+						...(afterPlugins || []),
+					],
+					onwarn: function ({ loc, frame, code, message }) {
+						// Skip certain warnings
+						const skipWarnings = ["THIS_IS_UNDEFINED", "CIRCULAR_DEPENDENCY", "MIXED_EXPORTS", "MODULE_LEVEL_DIRECTIVE"];
+						if (skipWarnings.indexOf(code) !== -1) {
+							return;
 						}
-					});
-					if (hasExportsDefault) {
-						return "var exports = exports || {};";
-					}
-					return "";
-				},
-				generatedCode,
-				chunkFileNames: (chunkInfo) => {
-					let { name } = chunkInfo;
-					let match = /^_?_polyfill-(.*)$/.exec(name);
-					name = match?.[1] || name;
-					return `${name}.js`;
-				},
-				sourcemap,
+						// console.warn everything else
+						if (loc) {
+							log.warn(`${loc.file} (${loc.line}:${loc.column}) ${message}`);
+							if (frame) log.warn(frame);
+						} else {
+							log.warn(`${message} [${code}]`);
+						}
+					},
+				});
+
+				// generate output specific code in-memory
+				// you can call this function multiple times on the same bundle object
+				const { output } = await bundle.generate({
+					format: "amd",
+					amd: {
+						define: "sap.ui.define",
+					},
+					intro: (s) => {
+						// FIX: if the module contains "exports.default" we need to
+						// add the exports variable to the bundle to ensure that
+						// the module can be used in the UI5 context
+						// (this happens e.g. when using the WebC Button solely)
+						let hasExportsDefault = false;
+						Object.values(s.modules || {}).forEach((m) => {
+							if (/\sexports.default/g.test(m.code)) {
+								hasExportsDefault = true;
+							}
+						});
+						if (hasExportsDefault) {
+							return "var exports = exports || {};";
+						}
+						return "";
+					},
+					generatedCode,
+					chunkFileNames: (chunkInfo) => {
+						let { name } = chunkInfo;
+						let match = /^_?_polyfill-(.*)$/.exec(name);
+						name = match?.[1] || name;
+						return `${name}.js`;
+					},
+					sourcemap,
+				});
+
+				output.$metadata = $metadata;
+
+				return output;
 			});
-
-			output.$metadata = $metadata;
-
-			return output;
 		},
 
 		/**
@@ -1533,237 +1599,257 @@ module.exports = function (log, projectInfo) {
 				if (modules.length > 0) {
 					// check whether the module should be built?
 					if (skipCache || !BundleInfoCache.get(cacheKey, bundleCacheOptions)) {
-						bundling = true;
+						// in-flight dedup: concurrent callers that miss the cache for the
+						// same cacheKey share a single build result instead of each running
+						// a redundant rollup build. Forced rebuilds (skipCache) never join an
+						// existing in-flight build and never register themselves.
+						if (!skipCache && _inFlightBuilds.has(cacheKey)) {
+							bundleInfo = await _inFlightBuilds.get(cacheKey);
+						} else {
+							const buildPromise = (async () => {
+								bundling = true;
 
-						// bundle the given modules
-						const options = {
-							cwd,
-							depPaths,
-							beforePlugins: [logger({ log })],
-							afterPlugins: [],
-							generatedCode,
-							minify,
-							inject,
-							sourcemap,
-							pluginOptions,
-						};
-						// by default we add the dynamic imports plugin to keep dynamic imports for the given modules
-						// if the keepDynamicImports is a boolean, we keep the dynamic imports for all modules
-						options.afterPlugins.push(dynamicImports({ findPackageJson, keepDynamicImports }));
-						// when minifying the code, we add the terser plugin
-						if (minify) {
-							options.afterPlugins.push(
-								require("@rollup/plugin-terser")({
-									output: {
-										comments: /^!/, // Keeps comments starting with "!"
-									},
-								}),
-							);
-						}
-
-						// create the bundle for the given modules
-						const nameOfModules = modules.map((module) => module.name);
-						//const millis = Date.now(); // PERF
-						const output = await that.createBundle(nameOfModules, options);
-						const isWebComponent = (moduleName) => {
-							return !!(output.$metadata?.packages?.[moduleName] || output.$metadata?.controls?.[moduleName] || output.$metadata?.substitutes?.[moduleName]);
-						};
-						//console.log(`createBundle overall duration: ${Date.now() - millis}ms`); // PERF
-						//console.log(`resolveModule overall duration: ${perfmetrics.resolveModulesTime}ms`); // PERF
-						//console.table(Object.entries(perfmetrics.resolveModules).filter(([key, value]) => value > 10).sort(([keyA, valueA], [keyB, valueB]) => valueB - valueA).map(([key, value]) => `${value}ms for ${key}`)); // PERF
-
-						// parse the rollup build result
-						const shiftedEntries = {};
-						dynamicEntriesPath = dynamicEntriesPath || "_dynamics";
-						for (const module of output) {
-							// all JS modules are considered as chunks
-							if (module.type === "chunk") {
-								// determine the file name by removing the file extension
-								const moduleName = module.fileName.substring(0, module.fileName.length - 3);
-								// lookup the output module in the list of input modules
-								// -> for web components modules, we replace the module 1:1 but can't set the isEntry flag
-								//    therefore we need to find whether there is an exact module match!
-								const isEntryModule = module.isEntry || modules.find((mod) => mod.name === moduleName);
-								const resolvedModules = isEntryModule && modules.filter((mod) => module?.facadeModuleId?.startsWith(mod.path) || mod.name === moduleName);
-								if (resolvedModules?.length > 0) {
-									// one module could be resolved by multiple input modules (e.g. export aliases in package.json)
-									for (const resolvedModule of resolvedModules) {
-										resolvedModule.originalName = module.name;
-										resolvedModule.code = module.code;
-										resolvedModule.relatedPaths = Object.keys(module.modules || {}).filter((m) => existsSyncAndIsFile(m));
-										resolvedModule.imports = module.imports;
-										resolvedModule.dynamicImports = module.dynamicImports;
-										resolvedModule.generated = !module.facadeModuleId;
-										resolvedModule.isWebComponent = isWebComponent(moduleName);
-										resolvedModule.isEntryPoint = true;
-										// store the shifted entry (for moveing the source maps)
-										shiftedEntries[module.fileName] = path.posix.dirname(resolvedModule.name);
-									}
-								} else {
-									// chunk module
-									let chunkName = moduleName;
-									// in case of dynamic entries we move them into a separate folder
-									// to allow to exclude them from the preload bundles easily
-									if (module.isDynamicEntry) {
-										chunkName = path.posix.join(dynamicEntriesPath, moduleName);
-										// store the shifted entry (for moveing the source maps)
-										shiftedEntries[module.fileName] = dynamicEntriesPath;
-									}
-									// add the chunk to the bundle info
-									bundleInfo.addChunk({
-										name: chunkName, //path.posix.join(filePath, chunkName),
-										originalName: moduleName,
-										code: module.code,
-										relatedPaths: Object.keys(module.modules || {}).filter((m) => existsSyncAndIsFile(m)),
-										imports: module.imports,
-										dynamicImports: module.dynamicImports,
-										generated: !module.facadeModuleId,
-										isWebComponent: isWebComponent(moduleName),
-									});
-								}
-							} else if (module.type === "asset") {
-								// asset module (e.g. source maps)
-								const sourcemapSource = JSON.parse(module.source);
-								// make the source path relative to the project (omitting the node_modules)
-								sourcemapSource.sources = sourcemapSource.sources.map((source) => {
-									if (source.lastIndexOf("node_modules") !== -1) {
-										const parts = source.split("node_modules/");
-										source = `.ui5-tooling-modules/${parts[parts.length - 1]}`;
-									}
-									return source;
-								});
-								// remove the ignore list from the source map
-								delete sourcemapSource["x_google_ignoreList"];
-								// shift the source map file to the dynamic entries path
-								const isShiftedEntry = !!shiftedEntries[sourcemapSource.file];
-								// add the source map to the bundle info
-								bundleInfo.addResource({
-									name: isShiftedEntry ? path.posix.join(shiftedEntries[sourcemapSource.file], module.fileName) : module.fileName,
-									code: JSON.stringify(sourcemapSource),
-								});
-							}
-						}
-
-						// helper to replace imports in the code
-						const replaceImports = function (code, importName, replacement) {
-							return code.replace(new RegExp(`((?:require|define|toUrl)(?:\\s*)(?:\\([^)]*(["'])))${importName}(\\2[^)]*\\))`, "g"), `$1${replacement}$3`);
-						};
-
-						// helper to replace params in the code
-						const replaceParam = function (code, search, replacement) {
-							const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
-							const regex = new RegExp(`(?<!tag:\\s)(["'])${escapedSearchString}(.*?)\\1`, "g"); // do not match tag: "..."
-							return code.replace(regex, `$1${replacement}$2$1`);
-						};
-
-						// helper to replace params in the code
-						const replaceModules = function (code, search, replacement) {
-							if (code.indexOf(`pkg["_ui5metadata"] = {`) > -1) {
-								// in web components package modules all strings can be replaced (safe as generated by us)
-								code = replaceParam(code, search, replacement);
-							} else {
-								const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
-								// covers the UI5 module loading functions
-								code = code.replace(new RegExp(`((?:require|requireSync|define|toUrl|isA)(?:\\s*)(?:\\([^)]*(["'])))${escapedSearchString}(.*?)\\2`, "mg"), `$1${replacement}$3$2`);
-								// covers all strings in the extend({ ... }) calls
-								const extendRe = /extend\s*\(([\s\S]*?)\)\s*;/g;
-								code = code.replace(extendRe, (full, body) => {
-									const replacedBody = replaceParam(body, search, replacement);
-									return full.replace(body, replacedBody);
-								});
-							}
-							return code;
-						};
-
-						// helper to replace params in the code
-						const replaceJSDoc = function (code, search, replacement) {
-							const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
-							const regex = new RegExp(`(\\*\\s@(.*?)\\s+(?:module\\:)?)${escapedSearchString}`, "g");
-							return code.replace(regex, `$1${replacement}`);
-						};
-
-						// fix the imports for shifted modules - sanitize the files to remove trailing whitespaces and correct line feeds
-						for (const module of bundleInfo.getEntries()) {
-							// for CDN cases we need to ensure that module paths are absolute so that in case
-							// of looking up the module path to the root, the resources are resolved relative
-							// to the CDN instead of relative to the module - this is important knowledge to
-							// the module resolution concept as it doesn't behave like a file system
-							// ---
-							// Example:
-							//   resourcesroots: { "@ui5": "./resources/@ui5" }
-							//   module: ./resources/@ui5/webcomponents-ai
-							//     import { something } from "../@ui5/webcomponents";
-							//     => would resolve against CDN/resources/@ui5/webcomponents ==> 404
-							//        instead of ./resources/@ui5/webcomponents-ai
-							// ---
-							// HINT: useRelativeModulePaths = true ---> just use relative paths
-							//         UI5 testsuite scenario using control test pages as they all do not define
-							//         the testsuite namespace as root namespace for them we need to use the
-							//         relative module paths for proper loading
-							let moduleBasePath = `${path.posix.relative(path.dirname(module.name), "") || "."}/`;
-
-							// resources determined via getResource do not have imports or dynamicImports
-							// (we need this extra check to avoid modifying the code of the resources)
-							if ((module.imports?.length || 0) > 0 || (module.dynamicImports?.length || 0) > 0) {
-								// for all modules we need to replace the imports and dynamic imports and make their
-								// paths relative to the module base path (which is either relative or absolute)
-								let modifiedCode = module.code;
-								for (const importFile of module.imports) {
-									const importName = importFile.slice(0, path.extname(importFile).length * -1);
-									modifiedCode = replaceImports(modifiedCode, `./${importName}`, `${moduleBasePath}${importName}`);
-								}
-								for (const importFile of module.dynamicImports) {
-									const importName = importFile.slice(0, path.extname(importFile).length * -1);
-									modifiedCode = replaceImports(modifiedCode, `./${importName}`, `${moduleBasePath}${path.posix.join(dynamicEntriesPath, importName)}`);
-								}
-								module.code = modifiedCode;
-							} else if (module.generated) {
-								// fallback for UI5 wrappers and package infos which are generated to overlay the original module
-								// because the generated modules do not expose any imports or dynamic imports but we know that
-								// we also need to adopt their imports and dynamic imports
-								const relativePath = `${path.posix.relative(path.dirname(module.name), "") || "."}/`;
-								const modifiedCode = relativePath !== moduleBasePath ? replaceModules(module.code, relativePath, moduleBasePath) : module.code;
-								module.code = modifiedCode;
-							}
-
-							// with the following code we modify all module names to be relative to the project namespace
-							// this is needed for Web Components to ensure that the module names are properly prefixed
-							// with the project namespace (e.g. my.project.namespace.thirdparty)
-							if (!isMiddleware && typeof rewriteDep === "function") {
-								// for Web Components we need to prefix the module name with the module base path
-								// TODO: entry modules need to be shifted into the gen folder
-								let modifiedCode = module.code;
-								if (module.generated) {
-									// this is mainly for the UI5 control wrappers and package infos to replace the
-									// module names in JSDoc, extend calls and metadata definitions as the imports
-									// are usually relative and will be replaced at a later phase in the task
-									[
-										...Object.values(output.$metadata.packages || {}),
-										...Object.keys(output.$metadata.chunks || {}).map((s) => {
-											return { name: s };
+								// bundle the given modules
+								const options = {
+									cwd,
+									depPaths,
+									beforePlugins: [logger({ log })],
+									afterPlugins: [],
+									generatedCode,
+									minify,
+									inject,
+									sourcemap,
+									pluginOptions,
+								};
+								// by default we add the dynamic imports plugin to keep dynamic imports for the given modules
+								// if the keepDynamicImports is a boolean, we keep the dynamic imports for all modules
+								options.afterPlugins.push(dynamicImports({ findPackageJson, keepDynamicImports }));
+								// when minifying the code, we add the terser plugin
+								if (minify) {
+									options.afterPlugins.push(
+										require("@rollup/plugin-terser")({
+											output: {
+												comments: /^!/, // Keeps comments starting with "!"
+											},
 										}),
-									]
-										.sort((a, b) => b.name.localeCompare(a.name))
-										.forEach((package) => {
-											if (package.qualifiedName) {
-												modifiedCode = replaceModules(modifiedCode, package.qualifiedName, rewriteDep(package.name, bundleInfo, true));
-											}
-											modifiedCode = replaceModules(modifiedCode, package.name, rewriteDep(package.name, bundleInfo));
-											if (package.qualifiedName) {
-												modifiedCode = replaceJSDoc(modifiedCode, package.qualifiedName, rewriteDep(package.name, bundleInfo, true));
-											}
-											modifiedCode = replaceJSDoc(modifiedCode, package.name, rewriteDep(package.name, bundleInfo));
-										});
-									module.code = modifiedCode;
+									);
 								}
+
+								// create the bundle for the given modules
+								const nameOfModules = modules.map((module) => module.name);
+								//const millis = Date.now(); // PERF
+								const output = await that.createBundle(nameOfModules, options);
+								const isWebComponent = (moduleName) => {
+									return !!(output.$metadata?.packages?.[moduleName] || output.$metadata?.controls?.[moduleName] || output.$metadata?.substitutes?.[moduleName]);
+								};
+								//console.log(`createBundle overall duration: ${Date.now() - millis}ms`); // PERF
+								//console.log(`resolveModule overall duration: ${perfmetrics.resolveModulesTime}ms`); // PERF
+								//console.table(Object.entries(perfmetrics.resolveModules).filter(([key, value]) => value > 10).sort(([keyA, valueA], [keyB, valueB]) => valueB - valueA).map(([key, value]) => `${value}ms for ${key}`)); // PERF
+
+								// parse the rollup build result
+								const shiftedEntries = {};
+								dynamicEntriesPath = dynamicEntriesPath || "_dynamics";
+								for (const module of output) {
+									// all JS modules are considered as chunks
+									if (module.type === "chunk") {
+										// determine the file name by removing the file extension
+										const moduleName = module.fileName.substring(0, module.fileName.length - 3);
+										// lookup the output module in the list of input modules
+										// -> for web components modules, we replace the module 1:1 but can't set the isEntry flag
+										//    therefore we need to find whether there is an exact module match!
+										const isEntryModule = module.isEntry || modules.find((mod) => mod.name === moduleName);
+										const resolvedModules = isEntryModule && modules.filter((mod) => module?.facadeModuleId?.startsWith(mod.path) || mod.name === moduleName);
+										if (resolvedModules?.length > 0) {
+											// one module could be resolved by multiple input modules (e.g. export aliases in package.json)
+											for (const resolvedModule of resolvedModules) {
+												resolvedModule.originalName = module.name;
+												resolvedModule.code = module.code;
+												resolvedModule.relatedPaths = Object.keys(module.modules || {}).filter((m) => existsSyncAndIsFile(m));
+												resolvedModule.imports = module.imports;
+												resolvedModule.dynamicImports = module.dynamicImports;
+												resolvedModule.generated = !module.facadeModuleId;
+												resolvedModule.isWebComponent = isWebComponent(moduleName);
+												resolvedModule.isEntryPoint = true;
+												// store the shifted entry (for moveing the source maps)
+												shiftedEntries[module.fileName] = path.posix.dirname(resolvedModule.name);
+											}
+										} else {
+											// chunk module
+											let chunkName = moduleName;
+											// in case of dynamic entries we move them into a separate folder
+											// to allow to exclude them from the preload bundles easily
+											if (module.isDynamicEntry) {
+												chunkName = path.posix.join(dynamicEntriesPath, moduleName);
+												// store the shifted entry (for moveing the source maps)
+												shiftedEntries[module.fileName] = dynamicEntriesPath;
+											}
+											// add the chunk to the bundle info
+											bundleInfo.addChunk({
+												name: chunkName, //path.posix.join(filePath, chunkName),
+												originalName: moduleName,
+												code: module.code,
+												relatedPaths: Object.keys(module.modules || {}).filter((m) => existsSyncAndIsFile(m)),
+												imports: module.imports,
+												dynamicImports: module.dynamicImports,
+												generated: !module.facadeModuleId,
+												isWebComponent: isWebComponent(moduleName),
+											});
+										}
+									} else if (module.type === "asset") {
+										// asset module (e.g. source maps)
+										const sourcemapSource = JSON.parse(module.source);
+										// make the source path relative to the project (omitting the node_modules)
+										sourcemapSource.sources = sourcemapSource.sources.map((source) => {
+											if (source.lastIndexOf("node_modules") !== -1) {
+												const parts = source.split("node_modules/");
+												source = `.ui5-tooling-modules/${parts[parts.length - 1]}`;
+											}
+											return source;
+										});
+										// remove the ignore list from the source map
+										delete sourcemapSource["x_google_ignoreList"];
+										// shift the source map file to the dynamic entries path
+										const isShiftedEntry = !!shiftedEntries[sourcemapSource.file];
+										// add the source map to the bundle info
+										bundleInfo.addResource({
+											name: isShiftedEntry ? path.posix.join(shiftedEntries[sourcemapSource.file], module.fileName) : module.fileName,
+											code: JSON.stringify(sourcemapSource),
+										});
+									}
+								}
+
+								// helper to replace imports in the code
+								const replaceImports = function (code, importName, replacement) {
+									return code.replace(new RegExp(`((?:require|define|toUrl)(?:\\s*)(?:\\([^)]*(["'])))${importName}(\\2[^)]*\\))`, "g"), `$1${replacement}$3`);
+								};
+
+								// helper to replace params in the code
+								const replaceParam = function (code, search, replacement) {
+									const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
+									const regex = new RegExp(`(?<!tag:\\s)(["'])${escapedSearchString}(.*?)\\1`, "g"); // do not match tag: "..."
+									return code.replace(regex, `$1${replacement}$2$1`);
+								};
+
+								// helper to replace params in the code
+								const replaceModules = function (code, search, replacement) {
+									if (code.indexOf(`pkg["_ui5metadata"] = {`) > -1) {
+										// in web components package modules all strings can be replaced (safe as generated by us)
+										code = replaceParam(code, search, replacement);
+									} else {
+										const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
+										// covers the UI5 module loading functions
+										code = code.replace(
+											new RegExp(`((?:require|requireSync|define|toUrl|isA)(?:\\s*)(?:\\([^)]*(["'])))${escapedSearchString}(.*?)\\2`, "mg"),
+											`$1${replacement}$3$2`,
+										);
+										// covers all strings in the extend({ ... }) calls
+										const extendRe = /extend\s*\(([\s\S]*?)\)\s*;/g;
+										code = code.replace(extendRe, (full, body) => {
+											const replacedBody = replaceParam(body, search, replacement);
+											return full.replace(body, replacedBody);
+										});
+									}
+									return code;
+								};
+
+								// helper to replace params in the code
+								const replaceJSDoc = function (code, search, replacement) {
+									const escapedSearchString = search.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"); // Escape special regex chars
+									const regex = new RegExp(`(\\*\\s@(.*?)\\s+(?:module\\:)?)${escapedSearchString}`, "g");
+									return code.replace(regex, `$1${replacement}`);
+								};
+
+								// fix the imports for shifted modules - sanitize the files to remove trailing whitespaces and correct line feeds
+								for (const module of bundleInfo.getEntries()) {
+									// for CDN cases we need to ensure that module paths are absolute so that in case
+									// of looking up the module path to the root, the resources are resolved relative
+									// to the CDN instead of relative to the module - this is important knowledge to
+									// the module resolution concept as it doesn't behave like a file system
+									// ---
+									// Example:
+									//   resourcesroots: { "@ui5": "./resources/@ui5" }
+									//   module: ./resources/@ui5/webcomponents-ai
+									//     import { something } from "../@ui5/webcomponents";
+									//     => would resolve against CDN/resources/@ui5/webcomponents ==> 404
+									//        instead of ./resources/@ui5/webcomponents-ai
+									// ---
+									// HINT: useRelativeModulePaths = true ---> just use relative paths
+									//         UI5 testsuite scenario using control test pages as they all do not define
+									//         the testsuite namespace as root namespace for them we need to use the
+									//         relative module paths for proper loading
+									let moduleBasePath = `${path.posix.relative(path.dirname(module.name), "") || "."}/`;
+
+									// resources determined via getResource do not have imports or dynamicImports
+									// (we need this extra check to avoid modifying the code of the resources)
+									if ((module.imports?.length || 0) > 0 || (module.dynamicImports?.length || 0) > 0) {
+										// for all modules we need to replace the imports and dynamic imports and make their
+										// paths relative to the module base path (which is either relative or absolute)
+										let modifiedCode = module.code;
+										for (const importFile of module.imports) {
+											const importName = importFile.slice(0, path.extname(importFile).length * -1);
+											modifiedCode = replaceImports(modifiedCode, `./${importName}`, `${moduleBasePath}${importName}`);
+										}
+										for (const importFile of module.dynamicImports) {
+											const importName = importFile.slice(0, path.extname(importFile).length * -1);
+											modifiedCode = replaceImports(modifiedCode, `./${importName}`, `${moduleBasePath}${path.posix.join(dynamicEntriesPath, importName)}`);
+										}
+										module.code = modifiedCode;
+									} else if (module.generated) {
+										// fallback for UI5 wrappers and package infos which are generated to overlay the original module
+										// because the generated modules do not expose any imports or dynamic imports but we know that
+										// we also need to adopt their imports and dynamic imports
+										const relativePath = `${path.posix.relative(path.dirname(module.name), "") || "."}/`;
+										const modifiedCode = relativePath !== moduleBasePath ? replaceModules(module.code, relativePath, moduleBasePath) : module.code;
+										module.code = modifiedCode;
+									}
+
+									// with the following code we modify all module names to be relative to the project namespace
+									// this is needed for Web Components to ensure that the module names are properly prefixed
+									// with the project namespace (e.g. my.project.namespace.thirdparty)
+									if (!isMiddleware && typeof rewriteDep === "function") {
+										// for Web Components we need to prefix the module name with the module base path
+										// TODO: entry modules need to be shifted into the gen folder
+										let modifiedCode = module.code;
+										if (module.generated) {
+											// this is mainly for the UI5 control wrappers and package infos to replace the
+											// module names in JSDoc, extend calls and metadata definitions as the imports
+											// are usually relative and will be replaced at a later phase in the task
+											[
+												...Object.values(output.$metadata.packages || {}),
+												...Object.keys(output.$metadata.chunks || {}).map((s) => {
+													return { name: s };
+												}),
+											]
+												.sort((a, b) => b.name.localeCompare(a.name))
+												.forEach((package) => {
+													if (package.qualifiedName) {
+														modifiedCode = replaceModules(modifiedCode, package.qualifiedName, rewriteDep(package.name, bundleInfo, true));
+													}
+													modifiedCode = replaceModules(modifiedCode, package.name, rewriteDep(package.name, bundleInfo));
+													if (package.qualifiedName) {
+														modifiedCode = replaceJSDoc(modifiedCode, package.qualifiedName, rewriteDep(package.name, bundleInfo, true));
+													}
+													modifiedCode = replaceJSDoc(modifiedCode, package.name, rewriteDep(package.name, bundleInfo));
+												});
+											module.code = modifiedCode;
+										}
+									}
+
+									// remove trailing whitespaces and correct line feeds (no windows line feeds!)
+									module.code = module.code.replace(/[ \t]+$/gm, "").replace(/\r\n/g, "\n");
+								}
+
+								// cache the output
+								BundleInfoCache.store(cacheKey, bundleInfo, bundleCacheOptions);
+								return bundleInfo;
+							})();
+							if (!skipCache) {
+								_inFlightBuilds.set(cacheKey, buildPromise);
+								// keep the map clean without creating a floating rejection
+								buildPromise.catch(() => {}).finally(() => _inFlightBuilds.delete(cacheKey));
 							}
-
-							// remove trailing whitespaces and correct line feeds (no windows line feeds!)
-							module.code = module.code.replace(/[ \t]+$/gm, "").replace(/\r\n/g, "\n");
+							bundleInfo = await buildPromise;
 						}
-
-						// cache the output
-						BundleInfoCache.store(cacheKey, bundleInfo, bundleCacheOptions);
 					} else {
 						// retrieve the cached output
 						bundleInfo = BundleInfoCache.get(cacheKey, bundleCacheOptions);
@@ -1860,6 +1946,17 @@ module.exports = function (log, projectInfo) {
 			} else {
 				throw new Error(`NPM package ${npmPackageName} not found. Ignoring package...`);
 			}
+		},
+
+		/**
+		 * Awaits all outstanding persistent bundle-info cache writes so the cache
+		 * is durable on disk before the process exits. The writes are otherwise
+		 * fire-and-forget (see {@link BundleInfoCache.store}); a caller (e.g. the
+		 * build task) should await this at the end of a run.
+		 * @returns {Promise} resolves once all pending cache writes have settled
+		 */
+		flushBundleInfoCache: async function flushBundleInfoCache() {
+			await BundleInfoCache.flushPending();
 		},
 	};
 	return that;

--- a/packages/ui5-tooling-modules/lib/utils/DTSSerializer.js
+++ b/packages/ui5-tooling-modules/lib/utils/DTSSerializer.js
@@ -286,20 +286,40 @@ const Templates = {
 	class: loadAndCompile("../templates/dts/Class.hbs"),
 };
 
+// outstanding *.gen.d.ts writes; a build awaits these via DTSSerializer.flush()
+// so type generation is guaranteed complete (or its errors surfaced) before the
+// build reports success (writes were previously fire-and-forget)
+const pending = [];
+
 /**
  * The DTSSerializer is responsible for generating TypeScript declaration files (.d.ts)
  * for UI5 web components. It provides methods to initialize classes, write class bodies,
  * and serialize different UI5 elements like properties, aggregations, associations, and events.
  */
 const DTSSerializer = {
+	// whether *.d.ts generation is enabled; toggled per package via setEnabled().
+	// Replaces the former destructive deactivate() which permanently overwrote every
+	// method of the shared singleton with no-ops and thus leaked across projects.
+	_enabled: true,
+
 	/**
-	 * Deactivates the *.d.ts file generation via ui5.yaml configuration.
-	 * When called, all methods in this object will be replaced with no-op functions.
+	 * Enables or disables the *.d.ts file generation via ui5.yaml configuration.
+	 * Reversible per package/project so the shared singleton cannot leak state.
+	 * @param {boolean} enabled whether the generation should be enabled
 	 */
-	deactivate() {
-		for (const s in this) {
-			this[s] = () => {};
-		}
+	setEnabled(enabled) {
+		this._enabled = enabled !== false;
+	},
+
+	/**
+	 * Awaits all outstanding *.gen.d.ts writes (surfacing their errors) and then
+	 * clears the pending list, so a build can guarantee type generation has
+	 * completed before reporting success.
+	 * @returns {Promise} resolves once all pending writes have settled
+	 */
+	async flush() {
+		const inflight = pending.splice(0, pending.length);
+		await Promise.all(inflight);
 	},
 
 	/**
@@ -308,6 +328,8 @@ const DTSSerializer = {
 	 * @param {WebComponentRegistry.Entry} registryEntry the registry entry which will receive a set of serialized *.d.ts files.
 	 */
 	prepare: function (registryEntry) {
+		if (!this._enabled) return;
+
 		const cachePath = join(process.cwd(), ".ui5-tooling-modules");
 
 		if (!existsSync(join(cachePath, "types"))) {
@@ -315,45 +337,55 @@ const DTSSerializer = {
 			mkdirSync(join(cachePath, "types"), { recursive: true });
 		}
 
-		prettier
-			.format(
-				Templates.module({
-					registryEntry,
+		pending.push(
+			prettier
+				.format(
+					Templates.module({
+						registryEntry,
+					}),
+					{
+						// TODO: read from prettier config if existing
+						//       otherwise use some defaults
+						semi: true,
+						trailingComma: "none",
+						parser: "typescript",
+					},
+				)
+				.then((prettifiedTypes) => {
+					if (prettifiedTypes) {
+						writeFileSync(join(cachePath, "types", `${registryEntry.qualifiedNamespace}.gen.d.ts`), prettifiedTypes, { encoding: "utf-8" });
+					}
+				})
+				.catch((err) => {
+					logger.error(`Failed to generate *.d.ts for ${registryEntry.qualifiedNamespace}!`, err);
 				}),
-				{
-					// TODO: read from prettier config if existing
-					//       otherwise use some defaults
-					semi: true,
-					trailingComma: "none",
-					parser: "typescript",
-				},
-			)
-			.then((prettifiedTypes) => {
-				if (prettifiedTypes) {
-					writeFileSync(join(cachePath, "types", `${registryEntry.qualifiedNamespace}.gen.d.ts`), prettifiedTypes, { encoding: "utf-8" });
-				}
-			});
+		);
 		for (const clazz in registryEntry.classes) {
 			if (registryEntry.classes[clazz].superclass) {
-				prettier
-					.format(
-						Templates.class({
-							clazz: registryEntry.classes[clazz],
-							BINDING_STRING_PLACEHOLDER: "`{${string}}`",
+				pending.push(
+					prettier
+						.format(
+							Templates.class({
+								clazz: registryEntry.classes[clazz],
+								BINDING_STRING_PLACEHOLDER: "`{${string}}`",
+							}),
+							{
+								// TODO: read from prettier config if existing
+								//       otherwise use some defaults
+								semi: true,
+								trailingComma: "none",
+								parser: "typescript",
+							},
+						)
+						.then((prettifiedTypes) => {
+							if (prettifiedTypes) {
+								writeFileSync(join(cachePath, "types", `${registryEntry.classes[clazz]._ui5QualifiedName}.gen.d.ts`), prettifiedTypes, { encoding: "utf-8" });
+							}
+						})
+						.catch((err) => {
+							logger.error(`Failed to generate *.d.ts for ${registryEntry.classes[clazz]._ui5QualifiedName}!`, err);
 						}),
-						{
-							// TODO: read from prettier config if existing
-							//       otherwise use some defaults
-							semi: true,
-							trailingComma: "none",
-							parser: "typescript",
-						},
-					)
-					.then((prettifiedTypes) => {
-						if (prettifiedTypes) {
-							writeFileSync(join(cachePath, "types", `${registryEntry.classes[clazz]._ui5QualifiedName}.gen.d.ts`), prettifiedTypes, { encoding: "utf-8" });
-						}
-					});
+				);
 			}
 		}
 	},
@@ -364,6 +396,7 @@ const DTSSerializer = {
 	 * @param {WebComponentRegistry.ClassDef} classDef the class def to be initialized
 	 */
 	initClass(classDef) {
+		if (!this._enabled) return;
 		classDef._dts = {
 			globalImports: {},
 			imports: {},
@@ -381,6 +414,7 @@ const DTSSerializer = {
 	 * @param {WebComponentRegistry.ClassDef} classDef the class def for which the main class body should be written
 	 */
 	writeClassBody(classDef) {
+		if (!this._enabled) return;
 		// Common utility functions
 		/**
 		 * Creates a template for method documentation.
@@ -942,6 +976,7 @@ const DTSSerializer = {
 	 * @param {object} entityDef the entity definition, e.g. property or aggregation info
 	 */
 	writeDts(classDef, entityType, entityDef) {
+		if (!this._enabled) return;
 		// we clone the objects here to prevent accidental side effects
 		classDef._dts[entityType][entityDef.name] = Object.assign({}, entityDef);
 	},
@@ -982,6 +1017,7 @@ const DTSSerializer = {
 	 *        ```
 	 */
 	updateDts(classDef, source, target) {
+		if (!this._enabled) return;
 		const targetEntity = target.entity || source.entity;
 		const targetName = target.name || source.name;
 		classDef._dts[targetEntity][targetName] = classDef._dts[source.entity][source.name];

--- a/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
+++ b/packages/ui5-tooling-modules/lib/utils/JSDocSerializer.js
@@ -180,12 +180,18 @@ function _prepareUI5Metadata(classDef, jsdocTags) {
 
 const JSDocSerializer = {
 	/**
-	 * Deactivates the generation of JSDoc comments.
+	 * Flag whether the generation of JSDoc comments is enabled.
+	 * Reset per package registration via {@link JSDocSerializer.setEnabled}
+	 * so state cannot leak across projects sharing this singleton.
 	 */
-	deactivate() {
-		for (const s in this) {
-			this[s] = () => {};
-		}
+	_enabled: true,
+
+	/**
+	 * Enables or disables the generation of JSDoc comments.
+	 * @param {boolean} enabled whether the generation should be enabled (defaults to enabled)
+	 */
+	setEnabled(enabled) {
+		this._enabled = enabled !== false;
 	},
 
 	/**
@@ -193,6 +199,7 @@ const JSDocSerializer = {
 	 * @param {WebComponentRegistryEntry} registryEntry the registry entry for a web component package
 	 */
 	prepare(registryEntry) {
+		if (!this._enabled) return;
 		// Classes (used in WrapperControl.hbs)
 		Object.keys(registryEntry.classes).forEach((className) => {
 			const classDef = registryEntry.classes[className];
@@ -252,6 +259,7 @@ const JSDocSerializer = {
 	 * @param {object} classDef the class definition from the custom elements manifest
 	 */
 	initClass(classDef) {
+		if (!this._enabled) return;
 		classDef._jsDoc = {
 			classHeader: "",
 			metadata: "",
@@ -271,6 +279,7 @@ const JSDocSerializer = {
 	 * @returns
 	 */
 	serializeMetadata(classDef) {
+		if (!this._enabled) return;
 		classDef._jsDoc.metadata = Templates.ui5metadata({
 			jsDoc: classDef._jsDoc,
 			metadata: classDef._ui5metadata,
@@ -287,6 +296,7 @@ const JSDocSerializer = {
 	 * @param {object} entityDef the entity definition from the custom elements manifest
 	 */
 	writeDoc(classDef, entityType, entityDef) {
+		if (!this._enabled) return;
 		// we clone the objects here to prevent accidental side effects
 		classDef._jsDoc[entityType][entityDef.name] = Object.assign({}, entityDef);
 	},

--- a/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
+++ b/packages/ui5-tooling-modules/lib/utils/WebComponentRegistry.js
@@ -1332,19 +1332,27 @@ class RegistryEntry {
 }
 
 /**
- * Checks whether we should skips the *.d.ts file and/or JSDoc comment generation.
+ * Enables or disables the *.d.ts file and/or JSDoc comment generation
+ * for the current package registration based on its plugin settings.
+ * The serializer singletons are shared across the process, so the flag is
+ * (re)set on every registration to prevent one package's settings from
+ * leaking into a later package/project.
  * Configured via the respective pluginOptions in the ui5.yaml:
  *    - pluginOptions/webcomponents/skipDtsGeneration
- *    - pluginOptions/webcomponents/skipJsDocGeneration
+ *    - pluginOptions/webcomponents/skipJSDoc
  * @param {object} settings the settings object
  */
 function checkSerializerPluginActivation(settings = {}) {
-	if (settings.skipDtsGeneration) {
-		DTSSerializer.deactivate();
-	}
-	if (settings.skipJsDocGeneration) {
-		JSDocSerializer.deactivate();
-	}
+	DTSSerializer.setEnabled(!settings.skipDtsGeneration);
+	// NOTE: JSDoc generation is intentionally left always-enabled here.
+	// The `skipJSDoc` option has never actually gated JSDoc generation: the
+	// previous code checked `settings.skipJsDocGeneration`, a key that
+	// `register()` does not pass, so the deactivation was dead code and enum/
+	// interface JSDoc has always been emitted into generated bundles. Wiring
+	// `skipJSDoc` up correctly would remove that JSDoc from the happy-path
+	// output — a product behavior change that is out of scope here. We still
+	// reset the flag every registration so it cannot leak across projects.
+	JSDocSerializer.setEnabled(true);
 }
 
 const WebComponentRegistry = {


### PR DESCRIPTION
## What & Why

`ui5-tooling-modules` ships a UI5 build **task** and a dev-server **middleware**, both driving rollup through the shared core `lib/util.js`. Node is single-threaded, so the risk is **async interleaving across `await` points** plus **process-global state shared across overlapping builds**. An audit surfaced six concurrency issues, ranging from silent registry corruption during normal dev to dropped dev-server requests and unawaited / non-atomic disk writes.

The unifying fix is a **process-wide build serialization lock**: because the web-components registry and the serializer singletons are global and reset at `buildStart`, no two rollup builds may run concurrently. Serializing builds is also what makes the smaller fixes safe.

All changes preserve observable happy-path output — see Testing.

## Fixes

1. **Global `WebComponentRegistry` clobbered by overlapping builds (Critical)** — a `force` rebuild in the middleware could start a second build whose `buildStart` wipes the registry the first build is mid-populating. Added a global build lock (`withBuildLock`) in `util.js` wrapping the rollup critical section of `createBundle`, so builds run strictly one at a time.
2. **Dynamically-requested module dropped by the middleware (High)** — a request for a not-yet-bundled module added it to `requestedModules` but never triggered a rebuild (unawaited `bundleAndWatch`, guard false), yielding an effective 404 until the next forced rebuild. Now detects a genuinely new module, force-rebuilds, and awaits.
3. **No in-flight dedup on `getBundleInfo` (High)** — concurrent misses on the same `cacheKey` each ran a full rollup build. Added a per-`cacheKey` in-flight promise map so concurrent callers share one build result (skipped when `skipCache` is set).
4. **`BundleInfoCache.store` fire-and-forget + non-atomic write (Medium)** — unawaited `mkdir().then(writeFile)` with no atomic rename could expose a half-written file to a concurrent reader / be lost on exit. Now writes to a temp file then `rename`s (atomic), tracks pending writes with a flushable `flushPending()` awaited at task end, and reads defensively (parse error → treat as miss).
5. **`DTSSerializer.prepare` fire-and-forget writes (Medium)** — `.gen.d.ts` writes were unawaited with no `.catch`, so builds "finished" while writes were pending or silently failing. Now collects write promises with error logging and exposes `flush()`, awaited at build end in the webcomponents rollup plugin.
6. **Self-mutating serializer singletons leak across projects (Medium)** — `deactivate()` permanently overwrote every method of the shared serializer export with no-ops, so the first package with generation disabled killed it for every later package in the process. Replaced with a reversible `_enabled` flag (`setEnabled`) reset each registration.

Plus a low-priority cleanup: dropped a pointless `async` on a discarded `.map` callback in `task.js`.

## Note on JSDoc activation (intentionally unchanged)

While wiring #6 I found a latent bug: `skipJSDoc` has **never** actually gated JSDoc generation — the previous code checked `settings.skipJsDocGeneration`, a key `register()` does not pass, so the deactivation was dead code and enum/interface JSDoc has always been emitted into generated bundles. Wiring `skipJSDoc` up correctly would *remove* that JSDoc from happy-path output — a product behavior change that is **out of scope** here. `checkSerializerPluginActivation` therefore hard-sets `JSDocSerializer.setEnabled(true)` (with a documenting comment) so we still get the reversible-flag leak fix without changing output. Flagging for a follow-up decision.

## Testing

- `npm test` → 40/40 pass.
- `npm run test:snapshots` → 40/40 pass, generated bundles / `.d.ts` byte-identical to `main`.
- eslint clean, prettier clean.

## Files

- `lib/util.js` — build lock (#1), in-flight dedup (#3), atomic/flushable/defensive `BundleInfoCache` (#4)
- `lib/middleware.js` — awaited/forced rebuild for new modules (#2)
- `lib/utils/DTSSerializer.js` — pending-write tracking + `flush()`, `setEnabled` (#5, #6)
- `lib/utils/JSDocSerializer.js` — `setEnabled` (#6)
- `lib/utils/WebComponentRegistry.js` — `checkSerializerPluginActivation` uses `setEnabled` (#6)
- `lib/rollup-plugin-webcomponents.js` — `await DTSSerializer.flush()` at build end (#5)
- `lib/task.js` — await `flushBundleInfoCache()` at end (#4); drop stray `async`