### PR TITLE
fix(ui5-tooling-modules): apply browser mappings to package entries

### DIFF
--- a/.changeset/tidy-browsers-resolve.md
+++ b/.changeset/tidy-browsers-resolve.md
@@ -1,0 +1,5 @@
+---
+"ui5-tooling-modules": patch
+---
+
+Respect object-style `browser` mappings when resolving a package's selected entry module.

--- a/packages/ui5-tooling-modules/lib/util.js
+++ b/packages/ui5-tooling-modules/lib/util.js
@@ -1215,7 +1215,14 @@ module.exports = function (log, projectInfo) {
 							// lookup the entry modules in the package.json root (esnext, module, main, ...)
 							mainExport = pkgJson;
 						}
-						const resolved = resolveTarget(mainExport);
+						let resolved = resolveTarget(mainExport);
+						if (resolved && isMappings(browser)) {
+							const browserSubPath = resolved.startsWith("./") ? resolved : `./${resolved}`;
+							const browserResolved = resolveExports(browser, browserSubPath);
+							if (browserResolved !== browserSubPath) {
+								resolved = browserResolved;
+							}
+						}
 						modulePath = resolved ? path.join(rootPath, resolved) : undefined;
 					} else if (isMappings(exports)) {
 						// if the module is a sub module of the package

--- a/packages/ui5-tooling-modules/test/util.test.js
+++ b/packages/ui5-tooling-modules/test/util.test.js
@@ -235,6 +235,34 @@ test.afterEach.always(async (t) => {
 	process.chdir(cwd);
 });
 
+test("Resolve browser mapping for the selected package entry", (t) => {
+	const packageRoot = path.join(t.context.tmpDir, "node_modules", "browser-entry-test");
+	mkdirSync(path.join(packageRoot, "lib"), { recursive: true });
+	writeFileSync(
+		path.join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "browser-entry-test",
+			module: "./lib/index.es.js",
+			browser: {
+				"./lib/index.es.js": "./lib/index-browser.es.js",
+			},
+		}),
+	);
+	writeFileSync(path.join(packageRoot, "lib/index.es.js"), 'export default "node";\n');
+	writeFileSync(path.join(packageRoot, "lib/index-browser.es.js"), 'export default "browser";\n');
+
+	const projectInfo = {
+		pkgJson: {
+			name: "browser-entry-test-project",
+			dependencies: {},
+		},
+	};
+	const log = { verbose() {} };
+	const util = require("../lib/util")(log, projectInfo);
+
+	t.is(util.resolveModule("browser-entry-test", { cwd, depPaths: [path.join(t.context.tmpDir, "node_modules")] }), path.join(packageRoot, "lib/index-browser.es.js"));
+});
+
 test.serial("Verify generation of @stomp/stompjs", async (t) => {
 	process.chdir(path.resolve(cwd, "../../showcases/ui5-tsapp"));
 	const env = await setupEnv(["@stomp/stompjs"], {


### PR DESCRIPTION
## What does this PR do?

This PR fixes package resolution for NPM packages that define their browser alternative as an object-style `browser` mapping.

When a package exposes an ESM entry via `module`, `ui5-tooling-modules` currently resolves that entry directly without applying the corresponding `browser` mapping.

For example:

```json
{
  "module": "./lib/index.es.js",
  "browser": {
    "./lib/index.es.js": "./lib/index-browser.es.js"
  }
}
```
The resolver incorrectly selects lib/index.es.js instead of lib/index-browser.es.js.

## Why is this needed?
This causes browser builds to include Node-specific implementations. In the original use case, pouchdb-md5 imports Node's crypto module from its ESM entry. The resulting UI5 bundle contains an empty crypto polyfill and fails at runtime when crypto.createHash() is called.

The package already provides a browser implementation using spark-md5; it was simply not selected by the resolver.

## What has changed?
 - Apply object-style browser mappings after resolving a package's selected root entry.
 - Preserve the existing entry selection order (exports, browser, esnext, module, main).
 - Add a regression test covering a package with:
   - an ESM module entry
   - an object-style browser mapping for that entry
 - Add a patch changeset for ui5-tooling-modules.

## Testing
 - The new browser-mapping regression test passes.
 - git diff --check passes.
 - Pre-commit formatting and lint hooks pass.
 - The full ui5-tooling-modules test suite was executed. One existing Web Components fixture test fails independently of this change because the generated superclass is undefined.

## Related package behavior
This fixes packages such as pouchdb-md5 without requiring application-specific aliases or Node crypto polyfills.